### PR TITLE
Add support for presenting status with 3 LEDs

### DIFF
--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -182,7 +182,7 @@ void setup()
     Serial.begin(SERIAL_BAUD);
     //Begining ethernet connection in case of Arduino + W5100
     setup_ethernet();
-    //setup LED status, turn all ON for short ammount then leave only the RED one ON
+    //setup LED status, turn all ON for short amount then leave only the RED LED ON
     pinMode(ledG, OUTPUT);
     pinMode(ledY, OUTPUT);
     pinMode(ledR, OUTPUT);

--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -81,9 +81,9 @@ PubSubClient client(mqtt_server, mqtt_port, callback, eClient);
 unsigned long lastReconnectAttempt = 0;
 
 //timers for LED indicators
-unsigned long timerG = 0;
-unsigned long timerY = 0;
-unsigned long timerR = 0;
+unsigned long timer_led_receive = 0;
+unsigned long timer_led_send = 0;
+unsigned long timer_led_error = 0;
 
 boolean reconnect() {
   // Loop until we're reconnected
@@ -183,15 +183,15 @@ void setup()
     //Begining ethernet connection in case of Arduino + W5100
     setup_ethernet();
     //setup LED status, turn all ON for short amount then leave only the RED LED ON
-    pinMode(ledG, OUTPUT);
-    pinMode(ledY, OUTPUT);
-    pinMode(ledR, OUTPUT);
-    digitalWrite(ledG, LOW);
-    digitalWrite(ledY, LOW);
-    digitalWrite(ledR, LOW);
+    pinMode(led_receive, OUTPUT);
+    pinMode(led_send, OUTPUT);
+    pinMode(led_error, OUTPUT);
+    digitalWrite(led_receive, LOW);
+    digitalWrite(led_send, LOW);
+    digitalWrite(led_error, LOW);
     delay(500);
-    digitalWrite(ledG, HIGH);
-    digitalWrite(ledY, HIGH);
+    digitalWrite(led_receive, HIGH);
+    digitalWrite(led_send, HIGH);
   #endif
 
   delay(1500);
@@ -270,7 +270,7 @@ void loop()
   //MQTT client connexion management
   if (!client.connected()) { // not connected
     //RED ON
-    digitalWrite(ledR, LOW);
+    digitalWrite(led_error, LOW);
 
     if (now - lastReconnectAttempt > 5000) {
       lastReconnectAttempt = now;
@@ -282,11 +282,11 @@ void loop()
   } else { //connected
     // MQTT loop
     //RED OFF
-    if (now - timerG > 300) {
-      timerG = now;
-      digitalWrite(ledG, HIGH);
+    if (now - timer_led_receive > 300) {
+      timer_led_receive = now;
+      digitalWrite(led_receive, HIGH);
     }
-    digitalWrite(ledR, HIGH);
+    digitalWrite(led_error, HIGH);
     
     client.loop();
 
@@ -317,15 +317,15 @@ void loop()
       if(RFtoMQTT()){
       trc(F("RFtoMQTT OK"));
       //GREEN ON
-      digitalWrite(ledG, LOW);
-      timerG = millis();
+      digitalWrite(led_receive, LOW);
+      timer_led_receive = millis();
       }
     #endif
     #ifdef ZgatewayRF2
       if(RF2toMQTT()){
       trc(F("RF2toMQTT OK"));
-      digitalWrite(ledG, LOW);
-      timerG = millis();
+      digitalWrite(led_receive, LOW);
+      timer_led_receive = millis();
       }
     #endif
     #ifdef ZgatewaySRFB
@@ -335,8 +335,8 @@ void loop()
     #ifdef ZgatewayIR
       if(IRtoMQTT())      {
       trc(F("IRtoMQTT OK"));
-      digitalWrite(ledG, LOW);
-      timerG = millis();
+      digitalWrite(led_receive, LOW);
+      timer_led_receive = millis();
       delay(100);
       }
     #endif
@@ -408,7 +408,7 @@ void receivingMQTT(char * topicOri, char * datacallback) {
       trc(F("Data stored"));
    }
 //YELLOW ON
-digitalWrite(ledY, LOW);
+digitalWrite(led_send, LOW);
 #ifdef ZgatewayRF
   MQTTtoRF(topicOri, datacallback);
 #endif
@@ -425,7 +425,7 @@ digitalWrite(ledY, LOW);
   MQTTtoRFM69(topicOri, datacallback);
 #endif
 //YELLOW OFF
-digitalWrite(ledY, HIGH);
+digitalWrite(led_send, HIGH);
 }
 
 void extract_char(char * token_char, char * subset, int start ,int l, boolean reverse, boolean isNumber){

--- a/User_config.h
+++ b/User_config.h
@@ -64,6 +64,16 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
 #define ota_password "OTAPASSWORD"
 #define ota_port 8266
 
+/*-------------DEFINE PINs FOR STATUS LEDs----------------*/
+#define ledG 40
+#define ledY 42
+#define ledR 44
+
+
+// 
+//      VCC   ------------D|-----------/\/\/\/\ -----------------  Arduino PIN
+//                            LED       Resistor 270-510R
+
 /*-------------DEFINE THE MODULES YOU WANT BELOW----------------*/
 //Addons and module management, comment the Z line and the config file if you don't use
 #ifdef ESP8266 // for nodemcu, weemos and esp8266

--- a/User_config.h
+++ b/User_config.h
@@ -65,9 +65,9 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
 #define ota_port 8266
 
 /*-------------DEFINE PINs FOR STATUS LEDs----------------*/
-#define ledG 40
-#define ledY 42
-#define ledR 44
+#define led_receive 40
+#define led_send 42
+#define led_error 44
 
 //      VCC   ------------D|-----------/\/\/\/\ -----------------  Arduino PIN
 //                        LED       Resistor 270-510R

--- a/User_config.h
+++ b/User_config.h
@@ -69,10 +69,8 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
 #define ledY 42
 #define ledR 44
 
-
-// 
 //      VCC   ------------D|-----------/\/\/\/\ -----------------  Arduino PIN
-//                            LED       Resistor 270-510R
+//                        LED       Resistor 270-510R
 
 /*-------------DEFINE THE MODULES YOU WANT BELOW----------------*/
 //Addons and module management, comment the Z line and the config file if you don't use

--- a/tests/Test_config.h
+++ b/tests/Test_config.h
@@ -63,6 +63,13 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
 #define ota_hostname "OTAHOSTNAME"
 #define ota_password "OTAPASSWORD"
 #define ota_port 8266
+/*-------------DEFINE PINs FOR STATUS LEDs----------------*/
+#define led_receive 40
+#define led_send 42
+#define led_error 44
+
+//      VCC   ------------D|-----------/\/\/\/\ -----------------  Arduino PIN
+//                        LED       Resistor 270-510R
 
 /*-------------DEFINE THE MODULES YOU WANT BELOW----------------*/
 //Addons and module management, comment the Z line and the config file if you don't use


### PR DESCRIPTION
The idea is taken from https://www.mysensors.org/build/advanced_gateway

It is working for RF433 and IR module. Probably can be added to the other modules. RED will stay ON until MQTT connection is ready.