### PR TITLE
Add support for TSL2561 based light intensity measurement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - git clone https://github.com/mrdunk/esp8266_mdns.git /usr/local/share/arduino/libraries/ESP8266mDNS
   - git clone https://github.com/adafruit/DHT-sensor-library /usr/local/share/arduino/libraries/DHT_sensor_library
   - git clone https://github.com/adafruit/Adafruit_Sensor /usr/local/share/arduino/libraries/Adafruit_Sensor
+  - git clone https://github.com/adafruit/Adafruit_TSL2561.git /usr/local/share/arduino/libraries/Adafruit_TSL2561
   - git clone https://github.com/sparkfun/SparkFun_BME280_Arduino_Library /usr/local/share/arduino/libraries/SparkFun_BME280
   - git clone https://github.com/LowPowerLab/RFM69 /usr/local/share/arduino/libraries/RFM69
   - rm /usr/local/share/arduino/libraries/RFM69/RFM69_OTA.h

--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -279,7 +279,7 @@ void loop()
       MeasureLightIntensity(); //Addon to measure Light Intensity with a BH1750
     #endif
     #ifdef ZsensorTSL2561
-      MeasureLightIntensity(); // Addon to measure Light Intensity with a TSL2561
+      MeasureLightIntensityTSL2561(); // Addon to measure Light Intensity with a TSL2561
     #endif
     #ifdef ZsensorDHT
       MeasureTempAndHum(); //Addon to measure the temperature with a DHT

--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -189,6 +189,9 @@ void setup()
   #ifdef ZsensorBH1750
     setupZsensorBH1750();
   #endif
+  #ifdef ZsensorTSL2561
+    setupZsensorTSL2561();
+  #endif
   #ifdef ZgatewayIR
     setupIR();
   #endif
@@ -274,6 +277,9 @@ void loop()
     #endif
     #ifdef ZsensorBH1750
       MeasureLightIntensity(); //Addon to measure Light Intensity with a BH1750
+    #endif
+    #ifdef ZsensorTSL2561
+      MeasureLightIntensity(); // Addon to measure Light Intensity with a TSL2561
     #endif
     #ifdef ZsensorDHT
       MeasureTempAndHum(); //Addon to measure the temperature with a DHT

--- a/User_config.h
+++ b/User_config.h
@@ -84,6 +84,8 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
   //#include "config_ADC.h"
   //#define ZsensorBH1750
   //#include "config_BH1750.h"
+  //#define ZsensorTSL2561
+  //#include "config_TSL2561.h"
   //#define ZsensorBME280
   //#include "config_BME280.h"
   //#define ZsensorDHT // If you uncomment this you can't use I2C due to the fact that I2C use also D1
@@ -106,6 +108,8 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
   //#include "config_DHT.h"
   //#define ZsensorBH1750
   //#include "config_BH1750.h"
+  //#define ZsensorTSL2561
+  //#include "config_TSL2561.h"
   //#define ZsensorBME280
   //#include "config_BME280.h"
   //#define ZsensorHCSR501

--- a/ZsensorTSL2561.ino
+++ b/ZsensorTSL2561.ino
@@ -85,11 +85,10 @@ void setupZsensorTSL2561()
   displaySensorDetails();  
 }
 
-void MeasureLightIntensity()
+void MeasureLightIntensityTSL2561()
 {
-  static uint32_t persisted_lux = 0;
-  
   if (millis() > (timetsl2561 + TimeBetweenReadingtsl2561)) {
+    static uint32_t persisted_lux;
     timetsl2561 = millis();
     
     sensors_event_t event;
@@ -106,7 +105,7 @@ void MeasureLightIntensity()
 	  sprintf(ftcd, "%s", String(event.light/10.764).c_str());
 	  sprintf(wattsm2, "%s", String(event.light/683.0).c_str());
 	  	  
-	  trc("Sending Light Intensity in Lux to MQTT " + (event.light) + " lux");
+	  trc("Sending Light Intensity in Lux to MQTT " + String(event.light) + " lux");
 	  client.publish(LUX, lux);
 	  client.publish(FTCD, ftcd);
 	  client.publish(WATTSM2, wattsm2);

--- a/ZsensorTSL2561.ino
+++ b/ZsensorTSL2561.ino
@@ -1,0 +1,126 @@
+  /*  
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+   This is the Light Meter Addon based on modules with a TSL2561:
+   - Measures ambient Light Intensity in Lux (lx), Foot Candela (ftcd) and Watt/m^2 (wattsm2)
+   - Required Hardware Module: TSL2561 (for instance Banggood.com product ID 1129550)
+   - Dependencies: Adafruit_TSL2561 and Adafruit_Sensor
+
+   Connection Scheme:
+   --------------------
+
+   TSL2561------> Arduino Uno ----------> ESP8266
+   ==============================================
+   Vcc ---------> 3.3V -----------------> 3.3V
+   GND ---------> GND ------------------> GND
+   SCL ---------> Pin A5 ---------------> D1
+   SDA ---------> Pin A4 ---------------> D2
+   ADD ---------> N/C (Not Connected) --> N/C (Not Connected)
+ 
+    Copyright: (c) Chris Broekema
+  
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef ZsensorTSL2561
+#include "math.h"
+#include "Wire.h"
+#include <Adafruit_Sensor.h>
+#include <Adafruit_TSL2561_U.h>
+
+Adafruit_TSL2561_Unified tsl = Adafruit_TSL2561_Unified(TSL2561_ADDR_FLOAT, 12345);
+
+
+void displaySensorDetails(void)
+{
+  sensor_t sensor;
+  tsl.getSensor(&sensor);
+  Serial.println("------------------------------------");
+  Serial.print  ("Sensor:       "); Serial.println(sensor.name);
+  Serial.print  ("Driver Ver:   "); Serial.println(sensor.version);
+  Serial.print  ("Unique ID:    "); Serial.println(sensor.sensor_id);
+  Serial.print  ("Max Value:    "); Serial.print(sensor.max_value); Serial.println(" lux");
+  Serial.print  ("Min Value:    "); Serial.print(sensor.min_value); Serial.println(" lux");
+  Serial.print  ("Resolution:   "); Serial.print(sensor.resolution); Serial.println(" lux");  
+  Serial.println("------------------------------------");
+  Serial.println("");
+  delay(500);
+}
+
+void setupZsensorTSL2561()
+{
+  Wire.begin();
+  Wire.beginTransmission(TSL2561_i2c_addr);
+
+  if (!tsl.begin())
+  {
+    Serial.println("No TSL2561 detected\n");
+  }
+  
+  // enable auto ranging
+  // tsl.setGain(TSL2561_GAIN_1X);      /* No gain ... use in bright light to avoid sensor saturation */
+  // tsl.setGain(TSL2561_GAIN_16X);     /* 16x gain ... use in low light to boost sensitivity */
+  tsl.enableAutoRange(true);            /* Auto-gain ... switches automatically between 1x and 16x */
+  // since we're slowly sampling, enable high resolution but slow mode TSL2561
+  // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_13MS);      /* fast but low resolution */
+  // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_101MS);  /* medium resolution and speed   */
+  tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_402MS);
+
+  Serial.println("TSL2561 Initialized. Printing detials now.");
+  displaySensorDetails();  
+}
+
+void MeasureLightIntensity()
+{
+  static uint32_t persisted_lux = 0;
+  
+  if (millis() > (timetsl2561 + TimeBetweenReadingtsl2561)) {
+    timetsl2561 = millis();
+    
+    sensors_event_t event;
+    tsl.getEvent(&event);
+    if (event.light)
+      // if event.light == 0 the sensor is clipping, do not send
+      {
+	if (persisted_lux != event.light || tsl2561_always ) {
+	  persisted_lux = event.light;
+	  char lux[7];
+	  char ftcd[7];
+	  char wattsm2[7];
+	  sprintf(lux, "%s", String(event.light).c_str());
+	  sprintf(ftcd, "%s", String(event.light/10.764).c_str());
+	  sprintf(wattsm2, "%s", String(event.light/683.0).c_str());
+	  	  
+	  trc(F("Sending Lux to MQTT"));
+	  trc(String(event.light));
+	  client.publish(LUX, lux);
+	  client.publish(FTCD, ftcd);
+	  client.publish(WATTSM2, wattsm2);
+	} else {
+	  trc(F("Same lux value, do not send"));
+	}
+      } else {
+        trc(F("Failed to read from TSL2561"));
+      }
+  }
+}
+
+
+
+#endif 

--- a/ZsensorTSL2561.ino
+++ b/ZsensorTSL2561.ino
@@ -46,31 +46,30 @@
 
 Adafruit_TSL2561_Unified tsl = Adafruit_TSL2561_Unified(TSL2561_ADDR_FLOAT, 12345);
 
-
 void displaySensorDetails(void)
 {
   sensor_t sensor;
   tsl.getSensor(&sensor);
-  Serial.println("------------------------------------");
-  Serial.print  ("Sensor:       "); Serial.println(sensor.name);
-  Serial.print  ("Driver Ver:   "); Serial.println(sensor.version);
-  Serial.print  ("Unique ID:    "); Serial.println(sensor.sensor_id);
-  Serial.print  ("Max Value:    "); Serial.print(sensor.max_value); Serial.println(" lux");
-  Serial.print  ("Min Value:    "); Serial.print(sensor.min_value); Serial.println(" lux");
-  Serial.print  ("Resolution:   "); Serial.print(sensor.resolution); Serial.println(" lux");  
-  Serial.println("------------------------------------");
-  Serial.println("");
+  trc("------------------------------------");
+  trc("Sensor:       " + String(sensor.name));
+  trc("Driver Ver:   " + String(sensor.version));
+  trc("Unique ID:    " + String(sensor.sensor_id));
+  trc("Max Value:    " + String(sensor.max_value) + " lux");
+  trc("Min Value:    " + String(sensor.min_value) + " lux");
+  trc("Resolution:   " + String(sensor.resolution) + " lux");
+  trc("------------------------------------");
+  trc("");
   delay(500);
 }
 
 void setupZsensorTSL2561()
 {
   Wire.begin();
-  Wire.beginTransmission(TSL2561_i2c_addr);
+  Wire.beginTransmission(TSL2561_ADDR_FLOAT);
 
   if (!tsl.begin())
   {
-    Serial.println("No TSL2561 detected\n");
+    trc("No TSL2561 detected");
   }
   
   // enable auto ranging
@@ -82,7 +81,7 @@ void setupZsensorTSL2561()
   // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_101MS);  /* medium resolution and speed   */
   tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_402MS);
 
-  Serial.println("TSL2561 Initialized. Printing detials now.");
+  trc("TSL2561 Initialized. Printing detials now.");
   displaySensorDetails();  
 }
 
@@ -107,20 +106,17 @@ void MeasureLightIntensity()
 	  sprintf(ftcd, "%s", String(event.light/10.764).c_str());
 	  sprintf(wattsm2, "%s", String(event.light/683.0).c_str());
 	  	  
-	  trc(F("Sending Lux to MQTT"));
-	  trc(String(event.light));
+	  trc("Sending Light Intensity in Lux to MQTT " + (event.light) + " lux");
 	  client.publish(LUX, lux);
 	  client.publish(FTCD, ftcd);
 	  client.publish(WATTSM2, wattsm2);
 	} else {
-	  trc(F("Same lux value, do not send"));
+	  trc("Same lux value, do not send");
 	}
       } else {
-        trc(F("Failed to read from TSL2561"));
-      }
+      trc("Failed to read from TSL2561");
+    }
   }
 }
+#endif
 
-
-
-#endif 

--- a/config_TSL2561.h
+++ b/config_TSL2561.h
@@ -1,0 +1,49 @@
+/*  
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+   This files exposes light level measured by a TSL2651 module
+   Heavily inspired by the driver for the BH1750 light sensor
+
+   Copyright: (c) Chris Broekema
+    
+   This file is part of OpenMQTTGateway.
+   
+   OpenMQTTGateway is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   
+   OpenMQTTGateway is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+   
+   Connection Schemata:
+   --------------------
+
+   TSL2561 ------> Arduino Uno ----------> ESP8266
+   ==============================================
+   Vcc ---------> 3.3V -----------------> Vu (3.3V)
+   GND ---------> GND ------------------> GND
+   SCL ---------> Pin A5 ---------------> D1
+   SDA ---------> Pin A4 ---------------> D2
+   ADD ---------> N/C (Not Connected) --> N/C (Not Connected)
+
+*/
+#define tsl2561_always true              // if false only send current value if it has changed 
+#define TimeBetweenReadingtsl2561 30000  
+/*----------------------------USER PARAMETERS-----------------------------*/
+/*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
+#define LUX      "home/LIGHTtoMQTT/lux"
+#define FTCD     "home/LIGHTtoMQTT/ftcd"
+#define WATTSM2  "home/LIGHTtoMQTT/wattsm2"
+
+//Time used to wait for an interval before resending measured values
+unsigned long timetsl2561 = 0;
+//int TSL2561_i2c_addr = 0x37; // Light Sensor I2C Address (Set in Adafruit library)

--- a/tests/Test_config.h
+++ b/tests/Test_config.h
@@ -85,6 +85,8 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
   #define ZsensorBH1750
   #include "config_BH1750.h"
   #define ZsensorBME280
+  #include "config_TSL2561.h"
+  #define ZsensorTSL2561
   #include "config_BME280.h"
   #define ZsensorDHT // If you uncomment this you can't use I2C due to the fact that I2C use also D1
   #include "config_DHT.h"


### PR DESCRIPTION
I added light intensity measurement based on TSL2561 based modules, such as these from banggood: https://www.banggood.com/GY-2561-TSL2561-Luminosity-Sensor-Breakout-Infrared-Light-Sensor-Module-Integrating-Sensor-AL-p-1129550.html

Dependencies are on Adafruit_TSL2561 and Adafruit_Sensor, as stated in header.
