### PR TITLE
Better sensors

### DIFF
--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -240,6 +240,9 @@ void setup()
   #ifdef ZsensorBH1750
     setupZsensorBH1750();
   #endif
+  #ifdef ZsensorTSL2561
+    setupZsensorTSL2561();
+  #endif
   #ifdef ZgatewayIR
     setupIR();
   #endif
@@ -371,6 +374,9 @@ void loop()
     #endif
     #ifdef ZsensorBH1750
       MeasureLightIntensity(); //Addon to measure Light Intensity with a BH1750
+    #endif
+    #ifdef ZsensorTSL2561
+      MeasureLightIntensityTSL2561();
     #endif
     #ifdef ZsensorDHT
       MeasureTempAndHum(); //Addon to measure the temperature with a DHT

--- a/ZsensorADC.ino
+++ b/ZsensorADC.ino
@@ -28,7 +28,7 @@
 */
 #ifdef ZsensorADC
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266)
   ADC_MODE(ADC_TOUT);
 #endif
 
@@ -47,11 +47,9 @@ void MeasureADC(){
       trc(F("Failed to read from ADC !"));
     }else{
       if(val  >= persistedadc + ThresholdReadingADC || val  <= persistedadc - ThresholdReadingADC){
-        char value[4];
-        sprintf(value, "%d", val);
         trc(F("Sending analog value to MQTT"));
         trc(String(val));
-        client.publish(ADC,value);
+        client.publish(ADC,String(val).c_str());
         persistedadc = val;
        }
     }

--- a/ZsensorBH1750.ino
+++ b/ZsensorBH1750.ino
@@ -104,7 +104,7 @@ void MeasureLightIntensity()
       // Generate FtCd
       if(FtCd != persistedlf || bh1750_always){
         trc(F("Sending FtCd to MQTT"));
-        trc(String(ftcd));
+        trc(String(FtCd));
         client.publish(FTCD,String(FtCd).c_str());
       }else{
         trc(F("Same ftcd don't send it"));

--- a/ZsensorBH1750.ino
+++ b/ZsensorBH1750.ino
@@ -94,33 +94,27 @@ void MeasureLightIntensity()
 
       // Generate Lux
       if(Lux != persistedll || bh1750_always){
-        char lux[7];
-        sprintf(lux,"%u",Lux);
         trc(F("Sending Lux to MQTT"));
-        trc(String(lux));
-        client.publish(LUX,lux);
+        trc(String(Lux));
+        client.publish(LUX,String(Lux).c_str());
        }else{
         trc(F("Same lux don't send it"));
        }
 
       // Generate FtCd
       if(FtCd != persistedlf || bh1750_always){
-        char ftcd[7];
-        dtostrf(FtCd,4,2,ftcd);
         trc(F("Sending FtCd to MQTT"));
         trc(String(ftcd));
-        client.publish(FTCD,ftcd);
+        client.publish(FTCD,String(FtCd).c_str());
       }else{
         trc(F("Same ftcd don't send it"));
       }
 
       // Generate Watts/m2
       if(Wattsm2 != persistedlw || bh1750_always){
-        char wattsm2[7];
-        dtostrf(Wattsm2,6,4,wattsm2);
         trc(F("Sending Wattsm2 to MQTT"));
-        trc(String(wattsm2));
-        client.publish(WATTSM2,wattsm2);
+        trc(String(Wattsm2));
+        client.publish(WATTSM2,String(Wattsm2).c_str());
       }else{
         trc(F("Same wattsm2 don't send it"));
       }    

--- a/ZsensorBME280.ino
+++ b/ZsensorBME280.ino
@@ -70,7 +70,7 @@ void setupZsensorBME280()
   //  5, 1000ms
   //  6, 10ms
   //  7, 20ms
-  mySensor.settings.tStandby = 0;
+  mySensor.settings.tStandby = 1;
   
   // Filter can be off or number of FIR coefficients - Values:
   // ---------------------------------------------------------
@@ -79,7 +79,7 @@ void setupZsensorBME280()
   //  2, coefficients = 4
   //  3, coefficients = 8
   //  4, coefficients = 16
-  mySensor.settings.filter = 0;
+  mySensor.settings.filter = 4;
   
   // tempOverSample - Values:
   // ------------------------
@@ -129,66 +129,54 @@ void MeasureTempHumAndPressure()
     }else{
       // Generate Temperature in degrees C
       if(BmeTempC != persisted_bme_tempc || bme280_always){
-        char bmetempc[7];
-        dtostrf(BmeTempC,4,2,bmetempc);
         trc(F("Sending Degrees C to MQTT"));
-        trc(String(bmetempc));
-        client.publish(TEMPBMEC,bmetempc);
+        trc(String(BmeTempC));
+        client.publish(TEMPBMEC, String(BmeTempC).c_str());
       }else{
         trc(F("Same Degrees C don't send it"));
       }
       
       // Generate Temperature in degrees F
       if(BmeTempF != persisted_bme_tempf || bme280_always){
-        char bmetempf[7];
-        dtostrf(BmeTempF,4,2,bmetempf);
         trc(F("Sending Degrees F to MQTT"));
-        trc(String(bmetempf));
-        client.publish(TEMPBMEF,bmetempf);
+        trc(String(BmeTempF));
+        client.publish(TEMPBMEF,String(BmeTempF).c_str());
       }else{
         trc(F("Same Degrees F don't send it"));
       }
       
       // Generate Humidity in percent
       if(BmeHum != persisted_bme_hum || bme280_always){
-        char bmehum[7];
-        dtostrf(BmeHum,4,2,bmehum);
         trc(F("Sending Humidity to MQTT"));
-        trc(String(bmehum));
-        client.publish(HUMBME,bmehum);
+        trc(String(BmeHum));
+        client.publish(HUMBME, String(BmeHum).c_str());
       }else{
         trc(F("Same Humidity don't send it"));
       }
 
       // Generate Pressure in Pa
       if(BmePa != persisted_bme_pa || bme280_always){
-        char bmepa[7];
-        dtostrf(BmePa,4,2,bmepa);
         trc(F("Sending Pressure to MQTT"));
-        trc(String(bmepa));
-        client.publish(PRESSBME,bmepa);
+        trc(String(BmePa));
+        client.publish(PRESSBME, String(BmePa).c_str());
       }else{
         trc(F("Same Pressure don't send it"));
       }
 
       // Generate Altitude in Meter
       if(BmeAltiM != persisted_bme_altim || bme280_always){
-        char bmealtim[7];
-        dtostrf(BmeAltiM,4,2,bmealtim);
         trc(F("Sending Altitude Meter to MQTT"));
-        trc(String(bmealtim));
-        client.publish(ALTIBMEM,bmealtim);
+        trc(String(BmeAltiM));
+        client.publish(ALTIBMEM, String(BmeAltiM).c_str());
       }else{
         trc(F("Same Altitude Meter don't send it"));
       }
 
       // Generate Altitude in Feet
       if(BmeAltiFt != persisted_bme_altift || bme280_always){
-        char bmealtift[7];
-        dtostrf(BmeAltiFt,4,2,bmealtift);
         trc(F("Sending Altitude Feet to MQTT"));
-        trc(String(bmealtift));
-        client.publish(ALTIBMEFT,bmealtift);
+        trc(String(BmeAltiFt));
+        client.publish(ALTIBMEFT, String(BmeAltiFt).c_str());
       }else{
         trc(F("Same Altitude Feet don't send it"));
       }

--- a/ZsensorDHT.ino
+++ b/ZsensorDHT.ino
@@ -49,20 +49,16 @@ void MeasureTempAndHum(){
       trc(F("Failed to read from DHT sensor!"));
     }else{
       if(h != persistedh || dht_always){
-        char hum[6];
-        dtostrf(h,4,2,hum);
         trc(F("Sending Hum to MQTT"));
-        trc(String(hum));
-        client.publish(HUM1,hum);
+        trc(String(h));
+        client.publish(HUM1,String(h).c_str());
        }else{
         trc(F("Same hum don't send it"));
        }
       if(t != persistedt || dht_always){
-        char temp[6];
-        dtostrf(t,4,2,temp);
         trc(F("Sending Temp to MQTT"));
-        trc(String(temp));
-        client.publish(TEMP1,temp);
+        trc(String(t));
+        client.publish(TEMP1, String(t).c_str());
       }else{
         trc(F("Same temp don't send it"));
       }

--- a/ZsensorTSL2561.ino
+++ b/ZsensorTSL2561.ino
@@ -98,17 +98,11 @@ void MeasureLightIntensityTSL2561()
       {
 	if (persisted_lux != event.light || tsl2561_always ) {
 	  persisted_lux = event.light;
-	  char lux[7];
-	  char ftcd[7];
-	  char wattsm2[7];
-	  sprintf(lux, "%s", String(event.light).c_str());
-	  sprintf(ftcd, "%s", String(event.light/10.764).c_str());
-	  sprintf(wattsm2, "%s", String(event.light/683.0).c_str());
 	  	  
 	  trc("Sending Light Intensity in Lux to MQTT " + String(event.light) + " lux");
-	  client.publish(LUX, lux);
-	  client.publish(FTCD, ftcd);
-	  client.publish(WATTSM2, wattsm2);
+	  client.publish(LUX, String(event.light).c_str());
+	  client.publish(FTCD, String((event.light)/10.764).c_str());
+	  client.publish(WATTSM2, String((event.light)/683.0).c_str());
 	} else {
 	  trc("Same lux value, do not send");
 	}


### PR DESCRIPTION
This branch has two goals and one bugfix:
- I noticed in on ESP32 that BME280 sensor readings quite often contained tailing garbage. This is due to several issues with buffer length in the various sensor code files. While incorrect on all platforms, this showed up on ESP32, probably due to a more modern base compiler. This is a classic C-style issue, which I've solved by moving to C++-style dynamically allocated strings. This may use more memory, so perhaps less suitable for arduino boards.
- There were also occasional spikes in the BME280 data. I've attempted to mitigate these by tweaking some of the sensor internal parameters (turned on the filter and significantly increase tStandby). At first glance the results are better.
- Finally, ZsensorADC did not compile on ESP32 for me on line 31. I believe this is ESP8266 specific, but I could be wrong.