### PR TITLE
Decrease program size if traces off

### DIFF
--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -190,13 +190,13 @@ boolean reconnect() {
       //Subscribing to topic
       if (client.subscribe(subjectMQTTtoX)) {
         #ifdef ZgatewayRF
-          client.subscribe(subjectMultiGTWRF);
+          client.subscribe(subjectMultiGTWRF); // subject on which other OMG will publish, this OMG will store these msg and by the way don't republish them if they have been already published
         #endif
         #ifdef ZgatewayRF315
-          client.subscribe(subjectMultiGTWRF315);
+          client.subscribe(subjectMultiGTWRF315);// subject on which other OMG will publish, this OMG will store these msg and by the way don't republish them if they have been already published
         #endif
         #ifdef ZgatewayIR
-          client.subscribe(subjectMultiGTWIR);
+          client.subscribe(subjectMultiGTWIR);// subject on which other OMG will publish, this OMG will store these msg and by the way don't republish them if they have been already published
         #endif
         trc(F("Subscription OK to the subjects"));
       }
@@ -247,7 +247,7 @@ void setup()
   #if defined(ESP8266) || defined(ESP32)
     #ifdef ESP8266
       Serial.end();
-      Serial.begin(SERIAL_BAUD, SERIAL_8N1, SERIAL_TX_ONLY);
+      Serial.begin(SERIAL_BAUD, SERIAL_8N1, SERIAL_TX_ONLY);// enable on ESP8266 to free some pin
     #endif
     #if defined(ESP8266) && !defined(ESPWifiManualSetup)
       setup_wifimanager();
@@ -289,7 +289,7 @@ void setup()
     });
     ArduinoOTA.begin();
 
-  #else // In case of arduino
+  #else // In case of arduino platform
 
     //Launch serial for debugging purposes
     Serial.begin(SERIAL_BAUD);

--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -110,13 +110,14 @@
   #include "config_GPIOInput.h"
 #endif
 // array to store previous received RFs, IRs codes and their timestamps
-#if defined(ESP8266) || defined(ESP32)
-#define MQTT_MAX_PACKET_SIZE 1024
-#define array_size 12
-unsigned long ReceivedSignal[array_size][2] ={{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}};
-#else
-#define array_size 4
-unsigned long ReceivedSignal[array_size][2] ={{0,0},{0,0},{0,0},{0,0}};
+#if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
+  #define MQTT_MAX_PACKET_SIZE 1024
+  #define array_size 12
+  unsigned long ReceivedSignal[array_size][2] ={{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}};
+#else // boards with smaller memory
+  #define MQTT_MAX_PACKET_SIZE 256
+  #define array_size 4
+  unsigned long ReceivedSignal[array_size][2] ={{0,0},{0,0},{0,0},{0,0}};
 #endif
 /*------------------------------------------------------------------------*/
 

--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -887,43 +887,43 @@ bool to_bool(String const& s) { // thanks Chris Jester-Young from stackoverflow
 
 //trace
 void trc(String msg){
-  if (TRACE) {
+  #ifdef TRACE
   Serial.println(msg);
-  }
+  #endif
 }
 
 void trc(int msg){
-  if (TRACE) {
+  #ifdef TRACE
   Serial.println(msg);
-  }
+  #endif
 }
 
 void trc(unsigned int msg){
-  if (TRACE) {
+  #ifdef TRACE
   Serial.println(msg);
-  }
+  #endif
 }
 
 void trc(long msg){
-  if (TRACE) {
+  #ifdef TRACE
   Serial.println(msg);
-  }
+  #endif
 }
 
 void trc(unsigned long msg){
-  if (TRACE) {
+  #ifdef TRACE
   Serial.println(msg);
-  }
+  #endif
 }
 
 void trc(double msg){
-  if (TRACE) {
+  #ifdef TRACE
   Serial.println(msg);
-  }
+  #endif
 }
 
 void trc(float msg){
-  if (TRACE) {
+  #ifdef TRACE
   Serial.println(msg);
-  }
+  #endif
 }

--- a/User_config.h
+++ b/User_config.h
@@ -130,4 +130,4 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
 #define subjectSYStoMQTT  Base_Topic Gateway_Name "/SYStoMQTT"
 
 /*-------------------ACTIVATE TRACES----------------------*/
-#define TRACE 1  // 0= trace off 1 = trace on
+#define TRACE 1  // commented =  trace off, uncommented = trace on


### PR DESCRIPTION
use #define to remove trace function at build time so as to decrease program size for small memory boards