### PR TITLE
multi gpio input module

### DIFF
--- a/OpenMQTTGateway.ino
+++ b/OpenMQTTGateway.ino
@@ -109,6 +109,9 @@
 #ifdef ZsensorGPIOInput
   #include "config_GPIOInput.h"
 #endif
+#ifdef ZsensorGPIOKeyCode
+  #include "config_GPIOKeyCode.h"
+#endif
 // array to store previous received RFs, IRs codes and their timestamps
 #if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
   #define MQTT_MAX_PACKET_SIZE 1024
@@ -378,7 +381,9 @@ void setup()
   #ifdef ZsensorGPIOInput
     setupGPIOInput();
   #endif
-  
+  #ifdef ZsensorGPIOKeyCode
+   setupGPIOKeyCode();
+  #endif  
   trc(F("MQTT_MAX_PACKET_SIZE"));
   trc(MQTT_MAX_PACKET_SIZE);
   trc(F("Setup OpenMQTTGateway end"));
@@ -627,6 +632,9 @@ void loop()
     #ifdef ZsensorGPIOInput
       MeasureGPIOInput();
     #endif
+    #ifdef ZsensorGPIOKeyCode
+      MeasureGPIOKeyCode();
+    #endif
     #ifdef ZsensorADC
       MeasureADC(); //Addon to measure the analog value of analog pin
     #endif
@@ -756,6 +764,9 @@ void stateMeasures(){
       #endif
       #ifdef ZsensorGPIOInput
           modules = modules  + ZsensorGPIOInput;
+      #endif
+      #ifdef ZsensorGPIOKeyCode
+          modules = modules  + ZsensorGPIOKeyCode;
       #endif
       SYSdata["modules"] = modules;
       trc(modules);

--- a/ZsensorGPIOKeyCode.ino
+++ b/ZsensorGPIOKeyCode.ino
@@ -5,7 +5,8 @@
  
     GPIO KeyCode derived from  GPIO Input
 
-    This reads a high (open) or low (closed) through a circuit (switch, float sensor, etc.) connected to ground.
+    This reads up to 4 gpio with latch signal (gpio line) and combines the bits as KeyKode - can be connected
+    to EV1527 receiver.
 
     Copyright: (c)Grzegorz Rajtar
     

--- a/ZsensorGPIOKeyCode.ino
+++ b/ZsensorGPIOKeyCode.ino
@@ -1,0 +1,82 @@
+/*  
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+    GPIO KeyCode derived from  GPIO Input
+
+    This reads a high (open) or low (closed) through a circuit (switch, float sensor, etc.) connected to ground.
+
+    Copyright: (c)Grzegorz Rajtar
+    
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef ZsensorGPIOKeyCode
+
+unsigned long lastDebounceTime = 0;
+int InputState = 0x0f;             // Set to 3 so that it reads on startup
+int lastInputState = 0x0f; 
+int lastLatchState = 0;
+
+
+void setupGPIOKeyCode() {
+  pinMode(GPIOKeyCode_LATCH_PIN, INPUT_PULLUP);  //
+  pinMode(GPIOKeyCode_D0_PIN, INPUT_PULLUP);     //
+  pinMode(GPIOKeyCode_D1_PIN, INPUT_PULLUP);     //
+  pinMode(GPIOKeyCode_D2_PIN, INPUT_PULLUP);     //
+  //pinMode(GPIOKeyCode_D3_PIN, INPUT_PULLUP);     //  
+}
+
+void MeasureGPIOKeyCode(){
+  char hex[3];
+  int latch = digitalRead(GPIOKeyCode_LATCH_PIN);
+  
+  // check to see if you just pressed the button
+  // (i.e. the input went from LOW to HIGH), and you've waited long enough
+  // since the last press to ignore any noise:
+
+  {
+    // whatever the reading is at, it's been there for longer than the debounce
+    // delay, so take it as the actual current state:
+  #if defined(ESP8266) || defined(ESP32) 
+    yield();
+  #endif
+    // if the Input state has changed:
+    if (latch > 0 && lastLatchState != latch) {
+
+      int reading = digitalRead(GPIOKeyCode_D0_PIN)
+            | (digitalRead(GPIOKeyCode_D1_PIN) << 1) 
+            | (digitalRead(GPIOKeyCode_D2_PIN) << 2);
+            //| digitalRead(GPIOKeyCode_D3_PIN) << 3;
+      
+      InputState = reading;
+	  	sprintf(hex, "%02x", InputState);
+	   	hex[2] = 0;            
+        Serial.printf("GPIOKeyCode %s\n", hex);
+        client.publish(subjectGPIOKeyCodetoMQTT,hex);
+        lastLatchState = latch;
+    }
+   
+    if (latch != lastLatchState) {
+      lastLatchState = latch;
+       Serial.printf("GPIOKeyCode latch %d\n", latch);
+      if (latch == 0)
+          client.publish(subjectGPIOKeyCodeStatetoMQTT, "done");
+    }
+
+  // save the reading. Next time through the loop, it'll be the lastInputState:
+  lastInputState = InputState;
+  }
+}
+#endif

--- a/ZsensorGPIOKeyCode.ino
+++ b/ZsensorGPIOKeyCode.ino
@@ -40,9 +40,9 @@ void setupGPIOKeyCode() {
 }
 
 void MeasureGPIOKeyCode(){
-  char hex[3];
+
   int latch = digitalRead(GPIOKeyCode_LATCH_PIN);
-  
+
   // check to see if you just pressed the button
   // (i.e. the input went from LOW to HIGH), and you've waited long enough
   // since the last press to ignore any noise:
@@ -60,13 +60,15 @@ void MeasureGPIOKeyCode(){
             | (digitalRead(GPIOKeyCode_D1_PIN) << 1) 
             | (digitalRead(GPIOKeyCode_D2_PIN) << 2);
             //| digitalRead(GPIOKeyCode_D3_PIN) << 3;
-      
+
+      char hex[3];
+
       InputState = reading;
-	  	sprintf(hex, "%02x", InputState);
-	   	hex[2] = 0;            
-        Serial.printf("GPIOKeyCode %s\n", hex);
-        client.publish(subjectGPIOKeyCodetoMQTT,hex);
-        lastLatchState = latch;
+      sprintf(hex, "%02x", InputState);
+      hex[2] = 0;
+      Serial.printf("GPIOKeyCode %s\n", hex);
+      client.publish(subjectGPIOKeyCodetoMQTT,hex);
+      lastLatchState = latch;
     }
    
     if (latch != lastLatchState) {

--- a/config_GPIOKeyCode.h
+++ b/config_GPIOKeyCode.h
@@ -1,0 +1,54 @@
+/*  
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+   This files enables to set your parameter for the GPIOKeyCode multi input
+  
+    Copyright: (c)Grzegorz Rajtar
+  
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------USER PARAMETERS-----------------------------*/
+/*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
+#define subjectGPIOKeyCodetoMQTT    Base_Topic Gateway_Name "/keycode"
+#define subjectGPIOKeyCodeStatetoMQTT subjectGPIOKeyCodetoMQTT "/status"
+#define GPIOKeyCodeDebounceDelay 60 //debounce time, increase if there are issues
+
+/*-------------------PIN DEFINITIONS----------------------*/
+#if defined(ESP8266) || defined(ESP32)
+
+#ifndef GPIOKeyCode_LATCH_PIN
+  #define GPIOKeyCode_LATCH_PIN 12 //D6
+#endif  
+#ifndef GPIOKeyCode_D0_PIN
+  #define GPIOKeyCode_D0_PIN 14 //D5
+#endif  
+#ifndef GPIOKeyCode_D1_PIN
+  #define GPIOKeyCode_D1_PIN 5 //D1
+#endif  
+#ifndef GPIOKeyCode_D2_PIN
+  #define GPIOKeyCode_D2_PIN 13 //D7
+#endif  
+#ifndef GPIOKeyCode_D3_PIN
+  #define GPIOKeyCode_D3_PIN XX //??
+#endif  
+#else
+// must define !!!  
+#endif
+


### PR DESCRIPTION
This module uses up to 4 gpio pins and creates keycode from bits combination, there is 5th gpio pin used as latch signal - for example it can be used with ev1527 code receiver.

My OpenMQTTGateway in 3d printed case:

https://photos.app.goo.gl/unCdrHzDNx1J68cm6