### PR TITLE
Fix compile error

### DIFF
--- a/lib/rc-switch/RCSwitch.cpp
+++ b/lib/rc-switch/RCSwitch.cpp
@@ -832,7 +832,7 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
   }
 
   // заносим в массив длительность очередного принятого импульса
-  if (changeCount > 0 & duration < 100) { // игнорируем шумовые всплески менее 100 мкс
+  if (changeCount > 0 && duration < 100) { // игнорируем шумовые всплески менее 100 мкс
     RCSwitch::timings[changeCount-1] += duration;   
   } else {
     RCSwitch::timings[changeCount++] = duration;


### PR DESCRIPTION
Introduced with https://github.com/1technophile/OpenMQTTGateway/pull/313

```
/home/johno/Workspaces/rf-tx/main/RCSwitch.cpp: In static member function 'static void RCSwitch::handleInterrupt()':
/home/johno/Workspaces/rf-tx/main/RCSwitch.cpp:835:19: error: suggest parentheses around comparison in operand of '&' [-Werror=parentheses]
   if (changeCount > 0 & duration < 100) { // игнорируем шумовые всплески менее 100 мкс
                   ^
cc1plus: some warnings being treated as errors
```