### PR TITLE
Add "repeat" field to RF JSON messages.

### DIFF
--- a/ZgatewayRF.ino
+++ b/ZgatewayRF.ino
@@ -162,10 +162,13 @@ void MQTTtoRF(char * topicOri, char * datacallback) {
         int valuePRT =  RFdata["protocol"]|1;
         int valuePLSL = RFdata["delay"]|350;
         int valueBITS = RFdata["length"]|24;
+        int valueRPT = RFdata["repeat"]|RF_EMITTER_REPEAT;
+        mySwitch.setRepeatTransmit(valueRPT);
         mySwitch.setProtocol(valuePRT,valuePLSL);
         mySwitch.send(data, valueBITS);
         trc(F("MQTTtoRF OK"));
         pub(subjectGTWRFtoMQTT, RFdata);// we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+        mySwitch.setRepeatTransmit(RF_EMITTER_REPEAT); // Restore the default value
       }else{
         trc(F("MQTTtoRF Fail json"));
       }

--- a/config_RF.h
+++ b/config_RF.h
@@ -45,7 +45,7 @@ RF supported protocols
 #define RFpulselengthKey "PLSL_" // pulselength will be defined if a subject contains RFprotocolKey followed by a value of 3 digits
 // subject monitored to listen traffic processed by other gateways to store data and avoid ntuple
 #define subjectMultiGTWRF "+/+/433toMQTT"
-//RF number of signal repetition
+//RF number of signal repetition - Can be overridden by specifying "repeat" in a JSON message.
 #define RF_EMITTER_REPEAT 20
 
 /*-------------------RF2 topics & parameters----------------------*/


### PR DESCRIPTION
Currently the MQTTto433 messages do not support a "repeat" key/value pair. This PR adds support for optionally specifying the number of times an RF message should be transmitted. The default RF_EMITTER_REPEAT remains in effect if "repeat" is not specified in the JSON message.

My use case is a ceiling light which toggles its state upon receipt of the RF signal.