### PR TITLE
Introduced safeDelayMicroseconds() function to avoid wdt resets

### DIFF
--- a/lib/rc-switch/RCSwitch.cpp
+++ b/lib/rc-switch/RCSwitch.cpp
@@ -504,6 +504,21 @@ void RCSwitch::sendTriState(const char* sCodeWord) {
 }
 
 /**
+ * @param duration   no. of microseconds to delay
+ */
+static inline void safeDelayMicroseconds(unsigned long duration) {
+#if defined(ESP8266) || defined(ESP32)
+  // uses yield() to avoid wdt reset
+  unsigned long start = micros();
+  while ((micros() - start) < duration) {
+    yield();
+  }
+#else
+  delayMicroseconds(duration);
+#endif
+}
+
+/**
  * @param sCodeWord   a binary code word consisting of the letter 0, 1
  */
 void RCSwitch::send(const char* sCodeWord) {
@@ -569,7 +584,7 @@ void RCSwitch::send(unsigned long long code, unsigned int length) {
     // выдерживаем Защитное время (Guard Time)
     if (protocol.Guard > 0) {
       digitalWrite(this->nTransmitterPin, LOW);
-      delayMicroseconds(this->protocol.pulseLength * protocol.Guard);
+      safeDelayMicroseconds(this->protocol.pulseLength * protocol.Guard);
     }
   }
 
@@ -593,11 +608,11 @@ void RCSwitch::transmit(HighLow pulses) {
   
   if (pulses.high > 0) {
     digitalWrite(this->nTransmitterPin, firstLogicLevel);
-    delayMicroseconds( this->protocol.pulseLength * pulses.high);
+    safeDelayMicroseconds( this->protocol.pulseLength * pulses.high);
   }
   if (pulses.low > 0) {
     digitalWrite(this->nTransmitterPin, secondLogicLevel);
-    delayMicroseconds( this->protocol.pulseLength * pulses.low);
+    safeDelayMicroseconds( this->protocol.pulseLength * pulses.low);
   }
 }
 

--- a/lib/rc-switch/RCSwitch.cpp
+++ b/lib/rc-switch/RCSwitch.cpp
@@ -508,10 +508,15 @@ void RCSwitch::sendTriState(const char* sCodeWord) {
  */
 static inline void safeDelayMicroseconds(unsigned long duration) {
 #if defined(ESP8266) || defined(ESP32)
-  // uses yield() to avoid wdt reset
-  unsigned long start = micros();
-  while ((micros() - start) < duration) {
-    yield();
+  if (duration > 10000) {
+    // if delay > 10 milliseconds, use yield() to avoid wdt reset
+    unsigned long start = micros();
+    while ((micros() - start) < duration) {
+      yield();
+    }
+  }
+  else {
+    delayMicroseconds(duration);
   }
 #else
   delayMicroseconds(duration);
@@ -608,11 +613,11 @@ void RCSwitch::transmit(HighLow pulses) {
   
   if (pulses.high > 0) {
     digitalWrite(this->nTransmitterPin, firstLogicLevel);
-    safeDelayMicroseconds( this->protocol.pulseLength * pulses.high);
+    delayMicroseconds( this->protocol.pulseLength * pulses.high);
   }
   if (pulses.low > 0) {
     digitalWrite(this->nTransmitterPin, secondLogicLevel);
-    safeDelayMicroseconds( this->protocol.pulseLength * pulses.low);
+    delayMicroseconds( this->protocol.pulseLength * pulses.low);
   }
 }
 


### PR DESCRIPTION
In the rc-switch library, protocol 31 (Mertik Maxitrol G6R-H4T1) includes a guard time of 17,000 microseconds. The ON command needs to be transmitted over 80 times for the fireplace to actually switch on. These lengthy delays were causing frequent crashes of the ESP8266 (wdt reset). A new function safeDelayMicroseconds() has been added to replace the usage of the standard delayMicroseconds() function. This new function uses yield() within the delay loop, allowing the ESP to 'breathe' during these delays. After implementing this function and changing 3 lines of code to make use of this new function, no more crashes (wdt reset) occur. I have even tested using a repeat count of 200, and the transmission went fine.

Below is an example of how I am using this protocol within Home Assistant. As you can see, the ON command has a repeat count of 100, and is successfully able to switch on my Heat & Glo fireplace.

```
switch:
  - platform: mqtt
    name: Fireplace
    command_topic: "home/OpenMQTTGateway/commands/MQTTto433"
    payload_on: '{ "protocol": 31, "delay": 400, "length": 12, "repeat": 100, "value": 1267 }'
    payload_off: '{ "protocol": 31, "delay": 400, "length": 12, "repeat": 10, "value": 1271 }'
    optimistic: false
    retain: false
```