### PR TITLE
Check bool value of simplePublishing

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -295,7 +295,7 @@ void pub(char * topicori, JsonObject& data){
       pub(topic, JSONmessageBuffer);
     #endif
 
-    #ifdef simplePublishing
+    #if(simplePublishing == true)
       trc(F("Pub data per topic"));
       // Loop through all the key-value pairs in obj 
       for (JsonPair& p : data) {


### PR DESCRIPTION
Hey @1technophile,
lots of respect for creating OMG! I just tried to switch over to the JSON formatted MQTT messages for my BLE devices and found out a strange issue. Even if simplePublishing was commented in the user_config, I was able to see the simple data my mqtt broker (mosquitto) and was able to confirm this via the serial monitor.

Instead of creating an issue and creating efforts on your side, I *tried* to write a fix.
Downside of this would be, that simplePublishing has to be defined as true or false in the user config.
But, to be honest, i'm not that deep in C-development. I learned C# years ago and you might have a better solution for this. So don't hesitate and decline my PR ;-) 
My test using my ESP32-devkit C is running fine.
Again, thank your for all your efforts!
Best regards
Jan-Hendrik