### PR TITLE
Add support for HC-SR04 sensor

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -92,6 +92,7 @@ char mqtt_port[6] = "1883";
 //#define ZgatewayRFM69  "RFM69"    //ESP8266, Arduino, ESP32
 //#define ZactuatorONOFF "ONOFF"    //ESP8266, Arduino, ESP32,  Sonoff RF Bridge
 //#define ZsensorINA226  "INA226"   //ESP8266, Arduino, ESP32
+//#define ZsensorHCSR04  "HCSR04"   //ESP8266, Arduino, ESP32
 //#define ZsensorHCSR501 "HCSR501"  //ESP8266, Arduino, ESP32,  Sonoff RF Bridge
 //#define ZsensorADC     "ADC"      //ESP8266, Arduino, ESP32
 //#define ZsensorBH1750  "BH1750"   //ESP8266, Arduino, ESP32

--- a/main/ZsensorHCSR04.ino
+++ b/main/ZsensorHCSR04.ino
@@ -1,0 +1,74 @@
+/*  
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+    HC SR-04 reading Addon
+  
+    Copyright: (c)Florian ROBERT
+    
+    Contributors:
+    - 1technophile
+    - mpember
+  
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "User_config.h"
+
+#ifdef ZsensorHCSR04
+
+unsigned long timeHCSR04 = 0;
+
+void setupHCSR04() {
+  pinMode(HCSR04_TRI_PIN, OUTPUT);    // declare HC SR-04 trigger pin as output
+  pinMode(HCSR04_ECH_PIN, INPUT);     // declare HC SR-04 echo pin as input
+}
+
+void MeasureDistance() {
+  if (millis() > (timeHCSR04 + TimeBetweenReadingHCSR04)) {
+    timeHCSR04 = millis();
+    trc(F("Creating HCSR04 buffer"));
+    StaticJsonBuffer<JSON_MSG_BUFFER> jsonBuffer;
+    JsonObject& HCSR04data = jsonBuffer.createObject();
+    static unsigned int distance = 99999;
+    digitalWrite(HCSR04_TRI_PIN, LOW);
+    delayMicroseconds(2);
+    digitalWrite(HCSR04_TRI_PIN, HIGH);
+    delayMicroseconds(10);
+    digitalWrite(HCSR04_TRI_PIN, LOW);
+    unsigned long duration = pulseIn(HCSR04_ECH_PIN, HIGH);
+    if (isnan(duration)) {
+      trc(F("Failed to read from HC SR04 sensor!"));
+    } else {
+      unsigned int d = duration/58.2;
+      HCSR04data.set("distance", (int)d);
+      if (d > distance) {
+        HCSR04data.set("direction", "away");
+        trc(F("HC SR04 Distance changed"));
+      } else if (d < distance) {
+        HCSR04data.set("direction", "towards");
+        trc(F("HC SR04 Distance changed"));
+      } else if (HCSR04_always) {
+        HCSR04data.set("direction", "static");
+        trc(F("HC SR04 Distance hasn't changed"));
+      }
+      distance = d;
+      if(HCSR04data.size()>0) pub(subjectHCSR04,HCSR04data);
+    }
+  }
+}
+#endif

--- a/main/ZsensorHCSR04.ino
+++ b/main/ZsensorHCSR04.ino
@@ -44,16 +44,16 @@ void MeasureDistance() {
     trc(F("Creating HCSR04 buffer"));
     StaticJsonBuffer<JSON_MSG_BUFFER> jsonBuffer;
     JsonObject& HCSR04data = jsonBuffer.createObject();
-    static unsigned int distance = 99999;
     digitalWrite(HCSR04_TRI_PIN, LOW);
     delayMicroseconds(2);
     digitalWrite(HCSR04_TRI_PIN, HIGH);
     delayMicroseconds(10);
     digitalWrite(HCSR04_TRI_PIN, LOW);
+    unsigned long duration = pulseIn(HCSR04_ECH_PIN, HIGH);
     if (isnan(duration)) {
       trc(F("Failed to read from HC SR04 sensor!"));
     } else {
-      unsigned long duration = pulseIn(HCSR04_ECH_PIN, HIGH);
+      static unsigned int distance = 99999;
       unsigned int d = duration/58.2;
       HCSR04data.set("distance", (int)d);
       if (d > distance) {

--- a/main/ZsensorHCSR04.ino
+++ b/main/ZsensorHCSR04.ino
@@ -50,10 +50,10 @@ void MeasureDistance() {
     digitalWrite(HCSR04_TRI_PIN, HIGH);
     delayMicroseconds(10);
     digitalWrite(HCSR04_TRI_PIN, LOW);
-    unsigned long duration = pulseIn(HCSR04_ECH_PIN, HIGH);
     if (isnan(duration)) {
       trc(F("Failed to read from HC SR04 sensor!"));
     } else {
+      unsigned long duration = pulseIn(HCSR04_ECH_PIN, HIGH);
       unsigned int d = duration/58.2;
       HCSR04data.set("distance", (int)d);
       if (d > distance) {

--- a/main/config_HCSR04.h
+++ b/main/config_HCSR04.h
@@ -1,0 +1,62 @@
+/*  
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+   This files enables to set your parameter for the HCSR04 sensor
+
+    Copyright: (c) mpember
+    
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   Connection Schemata:
+   --------------------
+
+   HC-SR04 ------> Arduino Uno ----------> ESP8266
+   ==============================================
+   Vcc ---------> 5V -------------------> Vu (5V)
+   GND ---------> GND ------------------> GND
+   TRI ---------> Pin D6 ---------------> D6
+   ECH ---------> Pin D7 ---------------> D7
+   
+*/
+#ifndef config_HCSR04_h
+#define config_HCSR04_h
+
+extern void setupHCSR04();
+extern void MeasureDistance();
+
+#define HCSR04_always true // If false, the current value of the parameter is the same as previous one don't send it by MQTT
+#define TimeBetweenReadingHCSR04 5000
+
+/*----------------------------USER PARAMETERS-----------------------------*/
+/*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
+#define subjectHCSR04   Base_Topic Gateway_Name "/DISTtoMQTT/sr04"
+
+/*-------------------PIN DEFINITIONS----------------------*/
+#if defined(ESP8266)
+  #define HCSR04_TRI_PIN D6
+  #define HCSR04_ECH_PIN D7
+#elif defined(ESP32)
+  #define HCSR04_TRI_PIN 16 // NOT TESTED
+  #define HCSR04_ECH_PIN 17 // NOT TESTED
+#else
+  #define HCSR04_TRI_PIN 6 // NOT TESTED
+  #define HCSR04_ECH_PIN 5 // NOT TESTED
+#endif
+
+#endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -84,6 +84,9 @@
 #ifdef ZsensorBME280
   #include "config_BME280.h"
 #endif
+#ifdef ZsensorHCSR04
+  #include "config_HCSR04.h"
+#endif
 #ifdef ZsensorDHT
   #include "config_DHT.h"
 #endif
@@ -605,6 +608,9 @@ void setup()
   #ifdef ZsensorHCSR501
     setupHCSR501();
   #endif
+  #ifdef ZsensorHCSR04
+    setupHCSR04();
+  #endif
   #ifdef ZsensorGPIOInput
     setupGPIOInput();
   #endif
@@ -887,6 +893,9 @@ void loop()
     #ifdef ZsensorBME280
       MeasureTempHumAndPressure(); //Addon to measure Temperature, Humidity, Pressure and Altitude with a Bosch BME280
     #endif
+    #ifdef ZsensorHCSR04
+      MeasureDistance(); //Addon to measure distance with a HC-SR04
+    #endif
     #ifdef ZsensorBH1750
       MeasureLightIntensity(); //Addon to measure Light Intensity with a BH1750
     #endif
@@ -991,6 +1000,9 @@ void stateMeasures(){
       #endif
       #ifdef ZsensorBME280
           modules = modules + ZsensorBME280;
+      #endif
+      #ifdef ZsensorHCSR04
+          modules = modules + ZsensorHCSR04;
       #endif
       #ifdef ZsensorBH1750
           modules = modules + ZsensorBH1750;

--- a/platformio.ini
+++ b/platformio.ini
@@ -254,6 +254,7 @@ build_flags =
   '-DZactuatorFASTLED="FASTLED"'
   '-DZsensorINA226="INA226"'
   '-DZsensorHCSR501="HCSR501"'
+  '-DZsensorHCSR04="HCSR04"'
   '-DZsensorADC="ADC"'
   '-DZsensorBH1750="BH1750"'
   '-DZsensorBME280="BME280"'


### PR DESCRIPTION
Adds support for HC-SR04 Ultrasonic distance sensor.

Note: only tested on a Wemos d1 mini board