### PR TITLE
Add Unit of Measurement for MiFlora Fertility and Fix MiJia BT battery to percentage

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -139,7 +139,7 @@ void MiJiaDiscovery(char * mac){
   #define MiJiaparametersCount 3
   trc(F("MiJiaDiscovery"));
   char * MiJiasensor[MiJiaparametersCount][8] = {
-     {"sensor", "MiJia-batt", mac, "battery","{{ value_json.batt | is_defined }}","", "", "V"} ,
+     {"sensor", "MiJia-batt", mac, "battery","{{ value_json.batt | is_defined }}","", "", "%"} ,
      {"sensor", "MiJia-tem", mac,"temperature","{{ value_json.tem | is_defined }}","", "", "°C"} ,
      {"sensor", "MiJia-hum", mac,"humidity","{{ value_json.hum | is_defined }}","", "", "%"}
      //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -111,7 +111,7 @@ void MiFloraDiscovery(char * mac){
   char * MiFlorasensor[MiFloraparametersCount][8] = {
      {"sensor", "MiFlora-lux", mac, "illuminance","{{ value_json.lux | is_defined }}","", "", "lu"} ,
      {"sensor", "MiFlora-tem", mac,"temperature","{{ value_json.tem | is_defined }}","", "", "°C"} ,
-     {"sensor", "MiFlora-fer", mac,"","{{ value_json.fer | is_defined }}","", "", ""} ,
+     {"sensor", "MiFlora-fer", mac,"","{{ value_json.fer | is_defined }}","", "", "µS/cm"} ,
      {"sensor", "MiFlora-moi", mac,"","{{ value_json.moi | is_defined }}","", "", "%"}
      //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };


### PR DESCRIPTION
Home assistant requires unit of measurement for data to display correctly in graphs.
Added unit "µS/cm" for MiFlora Fertility.

Also after fixing single byte issue (PR #465) noticed that MiJia Bluetooth sensor battery unit must be % instead of V. Esphome also uses % as MiJiaBT unit.

I don't have any Xiaomi LYWSD02 or ClearGrass sensor available so not able to check which battery value they are reporting.