### PR TITLE
Added NTP support for ESP platform

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -194,4 +194,9 @@ const byte subnet[] = { 255, 255, 255, 0 }; //ip adress
 /*-------------------ACTIVATE TRACES----------------------*/
 #define TRACE 1  // commented =  trace off, uncommented = trace on
 
+/*-------------------ENABLE NTP---------------------------*/
+#if defined(ESP8266) || defined(ESP32) // simpleDSTadjust library is ESP only
+  #define USE_NTP 1  // commented = NTP off, uncommented = NTP on
+#endif
+
 #endif

--- a/main/config_NTP.h
+++ b/main/config_NTP.h
@@ -1,0 +1,45 @@
+/*  
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+
+  This module enables NTP support in OpenMQTTGateway
+
+*/
+#ifndef config_NTP_h
+#define config_NTP_h
+
+#include <Ticker.h>
+#include <simpleDSTadjust.h>
+
+// Settings for Central European Time
+//#define UTC_OFFSET +1
+//struct dstRule StartRule = {"CEST", Last, Sun, Mar, 2, 3600}; // Central European Summer Time = UTC/GMT +2 hours
+//struct dstRule EndRule = {"CET", Last, Sun, Oct, 2, 0};       // Central European Time = UTC/GMT +1 hour
+
+// Settings for Central Standard Time (North America)
+#define UTC_OFFSET -6
+struct dstRule StartRule = {"CDT", Second, Sun, Mar, 2, 3600}; // Central Daylight time = UTC/GMT -5 hours
+struct dstRule EndRule = {"CST", First, Sun, Nov, 1, 0};       // Central Standard time = UTC/GMT -6 hour
+
+// change for different NTP (time servers)
+//#define NTP_SERVERS "0.ch.pool.ntp.org", "1.ch.pool.ntp.org", "2.ch.pool.ntp.org"
+#define NTP_SERVERS "0.us.pool.ntp.org", "1.us.pool.ntp.org", "2.us.pool.ntp.org"
+
+// August 1st, 2018
+#define NTP_MIN_VALID_EPOCH 1533081600
+
+// Update time from NTP server every 5 hours
+#define NTP_UPDATE_INTERVAL_SEC 5*3600
+
+// Initialize a few things
+void updateTime();
+void printTime(time_t offset);
+void secTicker();
+time_t dstOffset = 0;
+Ticker ticker1;
+int32_t tick;
+bool updateNTP = false;
+
+// Define our DST rules
+simpleDSTadjust dstAdjusted(StartRule, EndRule);
+
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -74,6 +74,7 @@ ethernet = Ethernet
 esp8266_mdns = esp8266_mdns
 wire = Wire
 fastled = FastLED
+simpledstadjust = simpleDSTadjust
 
 [env]
 framework = arduino
@@ -95,6 +96,7 @@ atmelavr_platform = atmelavr@1.13.0
 lib_deps =
   ${env.lib_deps}
   ${libraries.wifimanager}
+  ${libraries.simpledstadjust}
 build_flags =
   ${env.build_flags}
   -DMQTT_MAX_PACKET_SIZE=1024


### PR DESCRIPTION
This patch (hopefully) fixes WiFi connection issues for the ESP platform.  OMG was getting disconnected from my Apple router every 15-20 minutes, or so.

I had a similar issue with a Linux laptop that wouldn't connect to WiFi until the time was corrected in the system BIOS.

As an experiment, I added NTP support to OMG to see if would make a difference. It seems to have fixed the problem for me.  Nearly 3 days uptime without a single disconnect.

The patch adds [simpleDSTadjust](https://github.com/neptune2/simpleDSTadjust) library by neptune2.