### PR TITLE
Add Livolo 433Mhz switch support

### DIFF
--- a/main/ZgatewayLivolo.ino
+++ b/main/ZgatewayLivolo.ino
@@ -33,27 +33,30 @@
 
 bool livoloIsHigh;
 
-void setupLivolo(){
+void setupLivolo()
+{
   trc(F("LIVOLO_EMITTER_PIN "));
   trc(String(LIVOLO_EMITTER_PIN));
   trc(F("ZgatewayLivolo setup done "));
 }
 
 
-void MQTTtoLivolo(char * topicOri, JsonObject& data) {
-
-  int result = 0;
-  
-  if (strcmp(topicOri,subjectMQTTtoLivolo) == 0){
+void MQTTtoLivolo(char * topicOri, JsonObject& data) 
+{
+  if (strcmp(topicOri,subjectMQTTtoLivolo) == 0) 
+  { 
     trc(F("MQTTtoLivolo json data analysis"));
     const char * remoteIdChar = data["remoteId"];
     const char * keyCodeChar = data["keyCode"];
     uint16_t remoteId = 0;
     uint8_t keyCode = 0;    
-    if (_livolo_str_to_uint16(remoteIdChar, &remoteId) && _livolo_str_to_uint8(keyCodeChar, &keyCode)) {
+    if (_livolo_str_to_uint16(remoteIdChar, &remoteId) && _livolo_str_to_uint8(keyCodeChar, &keyCode)) 
+    {
       _livolo_sendButton(remoteId, keyCode);
       trc(F("MQTTtoLivolo sent"));
-    } else {
+    } 
+    else 
+    {
       trc(F("MQTTtoLivolo Fail json"));
     }
   }

--- a/main/ZgatewayLivolo.ino
+++ b/main/ZgatewayLivolo.ino
@@ -1,0 +1,152 @@
+/*  
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+  This gateway enables to:
+ - receive MQTT data from a topic and send RF 433Mhz signal corresponding to the received MQTT data to Livolo switch
+
+    Copyright: (c) Robert Csakany
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+     OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+     You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "User_config.h"
+
+#ifdef ZgatewayLivolo
+
+#define LIVOLO_PREAMBLE_DURATION 550
+#define LIVOLO_ZERO_DURATION 110
+#define LIVOLO_ONE_DURATION 303
+#define LIVOLO_NUM_REPEATS 150
+
+bool livoloIsHigh;
+
+void setupLivolo(){
+  trc(F("LIVOLO_EMITTER_PIN "));
+  trc(String(LIVOLO_EMITTER_PIN));
+  trc(F("ZgatewayLivolo setup done "));
+}
+
+
+void MQTTtoLivolo(char * topicOri, JsonObject& data) {
+
+  int result = 0;
+  
+  if (strcmp(topicOri,subjectMQTTtoLivolo) == 0){
+    trc(F("MQTTtoLivolo json data analysis"));
+    const char * remoteIdChar = data["remoteId"];
+    const char * keyCodeChar = data["keyCode"];
+    uint16_t remoteId = 0;
+    uint8_t keyCode = 0;    
+    if (_livolo_str_to_uint16(remoteIdChar, &remoteId) && _livolo_str_to_uint8(keyCodeChar, &keyCode)) {
+      _livolo_sendButton(remoteId, keyCode);
+      trc(F("MQTTtoLivolo sent"));
+    } else {
+      trc(F("MQTTtoLivolo Fail json"));
+    }
+  }
+}
+
+void _livolo_sendButton(uint16_t remoteId, uint8_t keyId)
+{
+  trc(F("RemoteID:"));
+  trc(remoteId);
+  trc(F("KeyID:"));
+  trc(keyId);
+
+  // 7 bit Key Id and 16 bit Remote Id
+  uint32_t command = ((uint32_t)keyId & 0x7F) | (remoteId << 7);
+  _livolo_sendCommand(command, 23);
+}
+
+
+void _livolo_sendCommand(uint32_t command, uint8_t numBits)
+{
+  for (uint8_t repeat = 0; repeat < LIVOLO_NUM_REPEATS; ++repeat)
+  {
+    uint32_t mask = (1 << (numBits - 1));
+    _livolo_sendPreamble();
+    for (uint8_t i = numBits; i > 0; --i)
+    {
+      if ((command & mask) > 0)
+      {
+        _livolo_sendOne();
+      }
+      else
+      {
+        _livolo_sendZero();
+      }
+      mask >>= 1;
+    }
+  }
+  _livolo_tx(false);
+}
+
+void _livolo_sendOne()
+{
+  delayMicroseconds(LIVOLO_ONE_DURATION);
+  livoloIsHigh = !livoloIsHigh;
+  _livolo_tx(livoloIsHigh);
+}
+
+void _livolo_sendZero()
+{
+  delayMicroseconds(LIVOLO_ZERO_DURATION);
+  _livolo_tx(!livoloIsHigh);
+  delayMicroseconds(LIVOLO_ZERO_DURATION);
+  _livolo_tx(livoloIsHigh);
+}
+
+void _livolo_sendPreamble()
+{
+  _livolo_tx(true);
+  delayMicroseconds(LIVOLO_PREAMBLE_DURATION);
+  _livolo_tx(false);
+  livoloIsHigh = false;
+}
+
+void _livolo_tx(bool value)
+{
+  digitalWrite(LIVOLO_EMITTER_PIN, value ? HIGH : LOW);
+}
+
+
+bool _livolo_str_to_uint8(const char *str, uint8_t *res) 
+{
+    char *end;
+    errno = 0;
+    long val = strtol(str, &end, 10);
+    if (errno || end == str || *end != '\0' || val < 0 || val >= 0x100) 
+    {
+        return false;
+    }
+    *res = (uint8_t)val;
+    return true;
+}
+
+bool _livolo_str_to_uint16(const char *str, uint16_t *res) 
+{
+    char *end;
+    errno = 0;
+    long val = strtol(str, &end, 10);
+    if (errno || end == str || *end != '\0' || val < 0 || val >= 0x10000) 
+    {
+        return false;
+    }
+    *res = (uint16_t)val;
+    return true;
+}
+
+#endif

--- a/main/config_Livolo.h
+++ b/main/config_Livolo.h
@@ -1,0 +1,31 @@
+#ifndef config_Livolo_h
+#define config_Livolo_h
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+
+#ifdef ZgatewayLivolo
+extern void setupLivolo();
+extern void MQTTtoLivolo(char * topicOri, char * datacallback);
+extern void MQTTtoLivolo(char * topicOri, JsonObject& RFdata);
+
+/*-------------------Livolo topics & parameters----------------------*/
+//433Mhz Livolo MQTT Subjects and keys
+#define subjectMQTTtoLivolo  Base_Topic Gateway_Name "/commands/MQTTtoLivolo"
+
+#ifndef LIVOLO_EMITTER_PIN
+    #ifdef ESP8266
+        #define LIVOLO_EMITTER_PIN 3 // RX on nodemcu if it doesn't work with 3, try with 4 (D2) // put 5 with rf bridge direct mod
+    #elif ESP32
+        #define LIVOLO_EMITTER_PIN 12 // D12 on DOIT ESP32
+    #elif __AVR_ATmega2560__
+        #define LIVOLO_EMITTER_PIN 4
+    #else
+        //IMPORTANT NOTE: On arduino UNO connect IR emitter pin to D9 , comment #define IR_USE_TIMER2 and uncomment #define IR_USE_TIMER1 on library <library>IRremote/boarddefs.h so as to free pin D3 for RF RECEIVER PIN
+        //RF PIN definition
+        #define LIVOLO_EMITTER_PIN 4 //4 = D4 on arduino
+    #endif
+#endif
+
+#endif
+#endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -63,6 +63,9 @@
 #ifdef Zgateway2G
   #include "config_2G.h"
 #endif
+#ifdef ZgatewayLivolo
+  #include "config_Livolo.h"
+#endif
 #ifdef ZactuatorONOFF
   #include "config_ONOFF.h"
 #endif
@@ -597,6 +600,9 @@ void setup()
   #ifdef ZgatewayRF2
     setupRF2();
   #endif
+  #ifdef ZgatewayLivolo
+    setupLivolo();
+  #endif
   #ifdef ZgatewayPilight
     setupPilight();
   #endif
@@ -746,7 +752,7 @@ void setup_wifimanager(bool reset_settings){
     WiFiManagerParameter custom_mqtt_server("server", "mqtt server", mqtt_server, 40);
     WiFiManagerParameter custom_mqtt_port("port", "mqtt port", mqtt_port, 6);
     WiFiManagerParameter custom_mqtt_user("user", "mqtt user", mqtt_user, 20);
-    WiFiManagerParameter custom_mqtt_pass("pass", "mqtt pass", mqtt_pass, 30);
+    WiFiManagerParameter custom_mqtt_pass("pass", "mqtt pass", mqtt_pass, 40);
   
    //WiFiManager
     //Local intialization. Once its business is done, there is no need to keep it around
@@ -1189,6 +1195,9 @@ void receivingMQTT(char * topicOri, char * datacallback) {
   if (jsondata.success()) { // json object ok -> json decoding
    #ifdef ZgatewayPilight // ZgatewayPilight is only defined with json publishing
      MQTTtoPilight(topicOri, jsondata);
+   #endif
+   #ifdef ZgatewayLivolo // ZgatewayLivolo is only defined with json publishing
+     MQTTtoLivolo(topicOri, jsondata);
    #endif
    #ifdef jsonReceiving
     #ifdef ZgatewayLORA

--- a/main/main.ino
+++ b/main/main.ino
@@ -752,7 +752,7 @@ void setup_wifimanager(bool reset_settings){
     WiFiManagerParameter custom_mqtt_server("server", "mqtt server", mqtt_server, 40);
     WiFiManagerParameter custom_mqtt_port("port", "mqtt port", mqtt_port, 6);
     WiFiManagerParameter custom_mqtt_user("user", "mqtt user", mqtt_user, 20);
-    WiFiManagerParameter custom_mqtt_pass("pass", "mqtt pass", mqtt_pass, 40);
+    WiFiManagerParameter custom_mqtt_pass("pass", "mqtt pass", mqtt_pass, 30);
   
    //WiFiManager
     //Local intialization. Once its business is done, there is no need to keep it around


### PR DESCRIPTION
There is the initial version of Livolo switch support. Tested with Livolo clone Welaik variant with an ESP32 WROOM.

 mosquitto_pub -h mqtt.local -t 'home/Gw1/commands/MQTTtoLivolo' -m "{\"remoteId\" : \"13770\", \"keyCode\" : \"16\" }"