### PR TITLE
[CI] Use travis tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
         - rm /home/travis/build/1technophile/OpenMQTTGateway/main/User_config.h
         - cp /home/travis/build/1technophile/OpenMQTTGateway/test/Test_config.h /home/travis/build/1technophile/OpenMQTTGateway/main//User_config.h
       script: 
+        - sed -i 's/version_tag/'$TRAVIS_TAG'/g' main/User_config.h
+        - sed -i 's/version_tag/'$TRAVIS_TAG'/g' test/Test_config.h
         - platformio run
         - bash scripts/prepare_deploy.sh
       before_deploy: ls -a

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -28,7 +28,7 @@
 #ifndef user_config_h
 #define user_config_h
 /*-------------------VERSION----------------------*/
-#define OMG_VERSION "0.9.3beta"
+#define OMG_VERSION "version_tag"
 
 /*-------------CONFIGURE WIFIMANAGER-------------(only ESP8266 & SONOFF RFBridge)*/
 /*

--- a/test/Test_config.h
+++ b/test/Test_config.h
@@ -31,7 +31,7 @@
 #ifndef user_config_h
 #define user_config_h
 /*-------------------VERSION----------------------*/
-#define OMG_VERSION "0.9.3beta"
+#define OMG_VERSION "version_tag"
 
 /*-------------CONFIGURE WIFIMANAGER-------------*/
 /*


### PR DESCRIPTION
instead of using harcoded version name use the TRAVIS_TAG environment variable, it recovers the tag name from github.
