### PR TITLE
[CI] Correct wrong json msg buffer size on bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,8 @@ matrix:
       install:
         - pip install -U platformio
         - platformio update
-        - rm /home/travis/build/1technophile/OpenMQTTGateway/main/User_config.h
-        - cp /home/travis/build/1technophile/OpenMQTTGateway/test/Test_config.h /home/travis/build/1technophile/OpenMQTTGateway/main//User_config.h
       script: 
         - sed -i 's/version_tag/'$TRAVIS_TAG'/g' main/User_config.h
-        - sed -i 's/version_tag/'$TRAVIS_TAG'/g' test/Test_config.h
         - platformio run
         - bash scripts/prepare_deploy.sh
       before_deploy: ls -a

--- a/test/Test_config.h
+++ b/test/Test_config.h
@@ -160,7 +160,7 @@ char gateway_name[parameters_size * 2] = Gateway_Name;
 #define eraseCmd            "erase"
 
 // define if we concatenate the values into the topic
-#define valueAsASubject true
+//#define valueAsASubject true
 
 //variables to avoid duplicates
 #define time_avoid_duplicate 3000 // if you want to avoid duplicate mqtt message received set this to > 0, the value is the time in milliseconds during which we don't publish duplicates
@@ -169,7 +169,7 @@ char gateway_name[parameters_size * 2] = Gateway_Name;
   //#define multiCore //uncomment to use multicore function of ESP32 for BLE
 #endif
 #if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
-  #define JSON_MSG_BUFFER 1024 // Json message max buffer size, don't put 1024 or higher it is causing unexpected behaviour on ESP8266
+  #define JSON_MSG_BUFFER 512 // Json message max buffer size, don't put 1024 or higher it is causing unexpected behaviour on ESP8266
   #define ARDUINOJSON_USE_LONG_LONG 1
 #else // boards with smaller memory
   #define JSON_MSG_BUFFER 64 // Json message max buffer size, don't put 1024 or higher it is causing unexpected behaviour on ESP8266


### PR DESCRIPTION
Solve #518 

Currently the json msg buffer size of binaries produced by the CI is to high for certain boards, in particular the sonoff rf bridge.
This is due to a bad value in test config file used for the continuous integration.
This file is not needed anymore with PIO, so I don't use it on the CI.
Nevertheless I keep it in the repo for a future use with an arduino IDE automated build.