### PR TITLE
removes duplicate code in main\ZgatewayBT.ino

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -62,26 +62,18 @@ bool updateWorB(JsonObject &BTdata, bool isWhite){
   {
     const char *mac = BTdata[jsonKey][i];
     Log.trace(F("%s set: %s" CR), jsonKey, mac);
-
-    foundMac = false;
-    for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
-    {
-      if ((strcmp(p->macAdr, mac) == 0))
-      {
-        p->isWhtL = isWhite;
-        p->isBlkL = !isWhite;
-        foundMac = true;
-      }
+    
+    BLEdevice *device = getDeviceByMac(mac);
+    if(device == &NO_DEVICE_FOUND){
+      //new device
+      device = new BLEdevice();
+      strcpy(device->macAdr, mac);
+      device->isDisc = false;
+      devices.push_back(*device);
     }
-    if (!foundMac)
-    {
-      BLEdevice device;
-      strcpy(device.macAdr, mac);
-      device.isDisc = false;
-      device.isWhtL = isWhite;
-      device.isBlkL = !isWhite;
-      devices.push_back(device);
-    }
+    
+    device->isWhtL = isWhite;
+    device->isBlkL = !isWhite;
   }
   
   return true;

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -36,6 +36,20 @@ Thanks to wolass https://github.com/wolass for suggesting me HM 10 and dinosd ht
 using namespace std;
 vector<BLEdevice> devices;
 
+static BLEdevice NO_DEVICE_FOUND = { NULL, false, false, false };
+
+BLEdevice * getDeviceByMac(const char *mac)
+{
+  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
+  {
+    if ((strcmp(p->macAdr, mac) == 0))
+    {
+      return &(*p);
+    }
+  }
+  return &NO_DEVICE_FOUND;
+}
+
 bool updateWorB(JsonObject &BTdata, bool isWhite){
   const char* jsonKey = isWhite ? "white-list" : "black-list";
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -89,17 +89,7 @@ bool oneWhite()
   return false;
 }
 
-bool isWhite(char *mac)
-{
-  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
-  {
-    if ((strcmp(p->macAdr, mac) == 0))
-    {
-      return p->isWhtL;
-    }
-  }
-  return false;
-}
+#define isWhite(mac) getDeviceByMac(mac)->isWhtL
 
 bool isBlack(char *mac)
 {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -90,18 +90,7 @@ bool oneWhite()
 }
 
 #define isWhite(mac) getDeviceByMac(mac)->isWhtL
-
-bool isBlack(char *mac)
-{
-  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
-  {
-    if ((strcmp(p->macAdr, mac) == 0))
-    {
-      return p->isBlkL;
-    }
-  }
-  return false;
-}
+#define isBlack(mac) getDeviceByMac(mac)->isBlkL
 
 bool isDiscovered(char *mac)
 {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -36,7 +36,7 @@ Thanks to wolass https://github.com/wolass for suggesting me HM 10 and dinosd ht
 using namespace std;
 vector<BLEdevice> devices;
 
-bool setWorBMac(JsonObject &BTdata, bool isWhite){
+bool updateWorB(JsonObject &BTdata, bool isWhite){
   const char* jsonKey = isWhite ? "white-list" : "black-list";
 
   int size = BTdata[jsonKey].size();
@@ -1209,11 +1209,11 @@ void MQTTtoBT(char *topicOri, JsonObject &BTdata)
     Log.trace(F("MQTTtoBT json set" CR));
 
     // Black list & white list set
-    bool WLorBLupdated;
-    WLorBLupdated |= setWorBMac(BTdata, true);
-    WLorBLupdated |= setWorBMac(BTdata, false);
+    bool WorBupdated;
+    WorBupdated |= updateWorB(BTdata, true);
+    WorBupdated |= updateWorB(BTdata, false);
 
-    if (WLorBLupdated)
+    if (WorBupdated)
       dumpDevices();
 
     // Scan interval set

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -91,18 +91,7 @@ bool oneWhite()
 
 #define isWhite(mac) getDeviceByMac(mac)->isWhtL
 #define isBlack(mac) getDeviceByMac(mac)->isBlkL
-
-bool isDiscovered(char *mac)
-{
-  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
-  {
-    if ((strcmp(p->macAdr, mac) == 0))
-    {
-      return p->isDisc;
-    }
-  }
-  return false;
-}
+#define isDiscovered(mac) getDeviceByMac(mac)->isDisc
 
 void dumpDevices()
 {


### PR DESCRIPTION
this patch series merges duplicate code when processing the white-list and black-list into the existing setWorBMac function and rename it to updadeWorB. 

it introduces a new helper 'getDeviceByMac' and removes duplicate code from isWhite, isBlack and isDiscovered.

this improves readability and maintainability. As a little bonus, this saves memory and reduces the file size.