### PR TITLE
fix 'LoadProhibited' in dumpdevice

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -110,9 +110,9 @@ void dumpDevices()
   for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
   {
     Log.trace(F("macAdr %s" CR),p->macAdr);
-    Log.trace(F("isDisc %s" CR),p->isDisc);
-    Log.trace(F("isWhtL %s" CR),p->isWhtL);
-    Log.trace(F("isBlkL %s" CR),p->isBlkL);
+    Log.trace(F("isDisc %d" CR),p->isDisc);
+    Log.trace(F("isWhtL %d" CR),p->isWhtL);
+    Log.trace(F("isBlkL %d" CR),p->isBlkL);
   }
 }
 


### PR DESCRIPTION
This patch fixes a fix 'LoadProhibited' in dumpdevice function on my ESP32.

Reason: booleans can not be interpreted as null-terminated strings

I think the source of the problem is that booleans are internally represented as byte and printf (with is called behind Log.trace) try to interpret this byte as a char array with length of 1. But this char array has no null-terminator if the value of the boolean is set to true (with is represented as  1). If the value of the boolean is set to false (0), an empty string will be printed, whats confirms my belief because 0 is also the null-terminator.

Example:
```
BLEDevice device;
device.isDisc = false;
//....
Log.trace(F("isDisc: %d" CR), device->isDisc);

> isDisc:

device.isDisc = true;
//...
Log.trace(F("isDisc: %d" CR), device->isDisc);

> isDisc: Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
> Core 1 register dump:
> PC      : 0x400014dc  PS      : 0x00060430  A0      : 0x800debe8  A1      : 0x3ffcfe80  
> A2      : 0x00000001  A3      : 0xfffffffd  A4      : 0x000000ff  A5      : 0x0000ff00
> A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x8008e070  A9      : 0x3ffcfe30  
> A10     : 0x00000000  A11     : 0x00000000  A12     : 0x00000000  A13     : 0x00000001
> A14     : 0x00060420  A15     : 0x00000000  SAR     : 0x00000018  EXCCAUSE: 0x0000001c  
> EXCVADDR: 0x00000001  LBEG    : 0x400014fd  LEND    : 0x4000150d  LCOUNT  : 0xffffffff
> 
> Backtrace: 0x400014dc:0x3ffcfe80 0x400debe5:0x3ffcfe90 0x400decbd:0x3ffcfeb0 0x400d8082:0x3ffcfed0 0x400d80e5:0x3ffcfef0 0x400d1f36:0x3ffcff20 0x400d20a5:0x3ffcff70 0x400d2e65:0x3ffcff90 0x400d59d8:0x3ffcffd0 0x400d5a5f:0x3ffd0220 0x401f275f:0x3ffd0240 0x400d7d16:0x3ffd0260 0x400d5ee0:0x3ffd02b0 0x400e0475:0x3ffd02d0 0x4008e689:0x3ffd02f0
```
As you see EXCVADDR is close to zero with means: 

> If this address is close to zero, it usually means that application attempted to access member of a structure, but the pointer to the structure was NULL.