### PR TITLE
remove duplicate code in main\ZgatewayBT.ino

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -97,18 +97,7 @@ bool oneWhite()
 }
 
 #define isWhite(mac) getDeviceByMac(mac)->isWhtL
-
-bool isBlack(char *mac)
-{
-  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
-  {
-    if ((strcmp(p->macAdr, mac) == 0))
-    {
-      return p->isBlkL;
-    }
-  }
-  return false;
-}
+#define isBlack(mac) getDeviceByMac(mac)->isBlkL
 
 bool isDiscovered(char *mac)
 {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -98,18 +98,7 @@ bool oneWhite()
 
 #define isWhite(mac) getDeviceByMac(mac)->isWhtL
 #define isBlack(mac) getDeviceByMac(mac)->isBlkL
-
-bool isDiscovered(char *mac)
-{
-  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
-  {
-    if ((strcmp(p->macAdr, mac) == 0))
-    {
-      return p->isDisc;
-    }
-  }
-  return false;
-}
+#define isDiscovered(mac) getDeviceByMac(mac)->isDisc
 
 void dumpDevices()
 {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -36,6 +36,20 @@ Thanks to wolass https://github.com/wolass for suggesting me HM 10 and dinosd ht
 using namespace std;
 vector<BLEdevice> devices;
 
+static BLEdevice NO_DEVICE_FOUND = { {0,0,0,0,0,0,0,0,0,0,0,0}, false, false, false };
+
+BLEdevice * getDeviceByMac(const char *mac)
+{
+  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
+  {
+    if ((strcmp(p->macAdr, mac) == 0))
+    {
+      return &(*p);
+    }
+  }
+  return &NO_DEVICE_FOUND;
+}
+
 bool updateWorB(JsonObject &BTdata, bool isWhite){
   const char* jsonKey = isWhite ? "white-list" : "black-list";
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -69,13 +69,13 @@ bool updateWorB(JsonObject &BTdata, bool isWhite)
   {
     const char *mac = BTdata[jsonKey][i];
 
-    createOrUpdateDevice(mac, NULL /*isDisc*/, isWhite /*isWhite*/);
+    createOrUpdateDevice(mac, (isWhite ? device_flags::isWhiteL : device_flags::isBlackL));
   }
   
   return true;
 }
 
-void createOrUpdateDevice(const char *mac, bool isDisc, bool isWhite)
+void createOrUpdateDevice(const char *mac, device_flags flags)
 {
 #if ESP32
   bool rc = false;
@@ -93,30 +93,29 @@ void createOrUpdateDevice(const char *mac, bool isDisc, bool isWhite)
     //new device
     device = new BLEdevice();
     strcpy(device->macAdr, mac);
-    device->isDisc = isDisc != NULL && isDisc;
-    device->isWhtL = isWhite != NULL && isWhite;
-    device->isBlkL = isWhite != NULL && !isWhite;
+    device->isDisc = flags & device_flags::isDisc;
+    device->isWhtL = flags & device_flags::isWhiteL;
+    device->isBlkL = flags & device_flags::isBlackL;
     devices.push_back(*device);
   }
   else
   {
     Log.trace(F("update %s" CR), mac);
     
-    if(isDisc != NULL)
+    if(flags & device_flags::isDisc)
     {
-      device->isDisc = isDisc;
+      device->isDisc = true;
     }
 
-    if(isWhite != NULL)
+    if(flags & device_flags::isWhiteL || flags & device_flags::isBlackL)
     {
-      device->isWhtL = isWhite;
-      device->isBlkL = !isWhite;
+      device->isWhtL = flags & device_flags::isWhiteL;
+      device->isBlkL = flags & device_flags::isBlackL;
     }
   }
 
   // update oneWhite flag
-  if(isWhite != NULL)
-    oneWhite = oneWhite || isWhite;
+  oneWhite = oneWhite || device->isWhtL;
 
 #if ESP32
   xSemaphoreGive(semaphoreCreateOrUpdateDevice);
@@ -169,7 +168,7 @@ void MiFloraDiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void VegTrugDiscovery(char *mac)
@@ -196,7 +195,7 @@ void VegTrugDiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void MiJiaDiscovery(char *mac)
@@ -222,7 +221,7 @@ void MiJiaDiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void LYWSD02Discovery(char *mac)
@@ -248,7 +247,7 @@ void LYWSD02Discovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void CLEARGRASSTRHDiscovery(char *mac)
@@ -274,7 +273,7 @@ void CLEARGRASSTRHDiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void CLEARGRASSCGD1Discovery(char *mac)
@@ -300,7 +299,7 @@ void CLEARGRASSCGD1Discovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void CLEARGRASSTRHKPADiscovery(char *mac)
@@ -326,7 +325,7 @@ void CLEARGRASSTRHKPADiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void MiScaleDiscovery(char *mac)
@@ -350,7 +349,7 @@ void MiScaleDiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void MiLampDiscovery(char *mac)
@@ -374,7 +373,7 @@ void MiLampDiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 void MiBandDiscovery(char *mac)
@@ -398,7 +397,7 @@ void MiBandDiscovery(char *mac)
                     0, "", "", false, "");
   }
 
-  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
+  createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
 #endif

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -50,7 +50,8 @@ BLEdevice * getDeviceByMac(const char *mac)
   return &NO_DEVICE_FOUND;
 }
 
-bool updateWorB(JsonObject &BTdata, bool isWhite){
+bool updateWorB(JsonObject &BTdata, bool isWhite)
+{
   const char* jsonKey = isWhite ? "white-list" : "black-list";
 
   int size = BTdata[jsonKey].size();
@@ -61,26 +62,24 @@ bool updateWorB(JsonObject &BTdata, bool isWhite){
   for (int i = 0; i < size; i++)
   {
     const char *mac = BTdata[jsonKey][i];
-    Log.trace(F("%s set: %s" CR), jsonKey, mac);
 
-    foundMac = false;
-    for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
+    BLEdevice *device = getDeviceByMac(mac);
+    if(device == &NO_DEVICE_FOUND)
     {
-      if ((strcmp(p->macAdr, mac) == 0))
-      {
-        p->isWhtL = isWhite;
-        p->isBlkL = !isWhite;
-        foundMac = true;
-      }
+      Log.trace(F("add %s from %s" CR), mac, jsonKey);
+      //new device
+      device = new BLEdevice();
+      strcpy(device->macAdr, mac);
+      device->isDisc = false;
+      device->isWhtL = isWhite;
+      device->isBlkL = !isWhite;
+      devices.push_back(*device);
     }
-    if (!foundMac)
+    else
     {
-      BLEdevice device;
-      strcpy(device.macAdr, mac);
-      device.isDisc = false;
-      device.isWhtL = isWhite;
-      device.isBlkL = !isWhite;
-      devices.push_back(device);
+      Log.trace(F("update %s from %s" CR), mac, jsonKey);
+      device->isWhtL = isWhite;
+      device->isBlkL = !isWhite;
     }
   }
   

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -152,18 +152,7 @@ void MiFloraDiscovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < MiFloraparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),MiFlorasensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + MiFlorasensor[i][1];
-    createDiscovery(MiFlorasensor[i][0],
-                    (char *)discovery_topic.c_str(), MiFlorasensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, MiFlorasensor[i][3], MiFlorasensor[i][4],
-                    MiFlorasensor[i][5], MiFlorasensor[i][6], MiFlorasensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, MiFlorasensor, MiFloraparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -178,19 +167,8 @@ void VegTrugDiscovery(char *mac)
       {"sensor", "VegTrug-moi", mac, "", "{{ value_json.moi | is_defined }}", "", "", "%"}
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
-
-  for (int i = 0; i < VegTrugparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),VegTrugsensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + VegTrugsensor[i][1];
-    createDiscovery(VegTrugsensor[i][0],
-                    (char *)discovery_topic.c_str(), VegTrugsensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, VegTrugsensor[i][3], VegTrugsensor[i][4],
-                    VegTrugsensor[i][5], VegTrugsensor[i][6], VegTrugsensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  
+  createDiscoveryFromList(mac, VegTrugsensor, VegTrugparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -204,19 +182,8 @@ void MiJiaDiscovery(char *mac)
       {"sensor", "MiJia-hum", mac, "humidity", "{{ value_json.hum | is_defined }}", "", "", "%"}
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
-
-  for (int i = 0; i < MiJiaparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),MiJiasensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + MiJiasensor[i][1];
-    createDiscovery(MiJiasensor[i][0],
-                    (char *)discovery_topic.c_str(), MiJiasensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, MiJiasensor[i][3], MiJiasensor[i][4],
-                    MiJiasensor[i][5], MiJiasensor[i][6], MiJiasensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  
+  createDiscoveryFromList(mac, MiJiasensor, MiJiaparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -231,18 +198,7 @@ void LYWSD02Discovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < LYWSD02parametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),LYWSD02sensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + LYWSD02sensor[i][1];
-    createDiscovery(LYWSD02sensor[i][0],
-                    (char *)discovery_topic.c_str(), LYWSD02sensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, LYWSD02sensor[i][3], LYWSD02sensor[i][4],
-                    LYWSD02sensor[i][5], LYWSD02sensor[i][6], LYWSD02sensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, LYWSD02sensor, LYWSD02parametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -257,18 +213,7 @@ void CLEARGRASSTRHDiscovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < CLEARGRASSTRHparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),CLEARGRASSTRHsensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + CLEARGRASSTRHsensor[i][1];
-    createDiscovery(CLEARGRASSTRHsensor[i][0],
-                    (char *)discovery_topic.c_str(), CLEARGRASSTRHsensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, CLEARGRASSTRHsensor[i][3], CLEARGRASSTRHsensor[i][4],
-                    CLEARGRASSTRHsensor[i][5], CLEARGRASSTRHsensor[i][6], CLEARGRASSTRHsensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, CLEARGRASSTRHsensor, CLEARGRASSTRHparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -283,18 +228,7 @@ void CLEARGRASSCGD1Discovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < CLEARGRASSCGD1parametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),CLEARGRASSCGD1sensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + CLEARGRASSCGD1sensor[i][1];
-    createDiscovery(CLEARGRASSCGD1sensor[i][0],
-                    (char *)discovery_topic.c_str(), CLEARGRASSCGD1sensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, CLEARGRASSCGD1sensor[i][3], CLEARGRASSCGD1sensor[i][4],
-                    CLEARGRASSCGD1sensor[i][5], CLEARGRASSCGD1sensor[i][6], CLEARGRASSCGD1sensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, CLEARGRASSCGD1sensor, CLEARGRASSCGD1parametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -309,18 +243,7 @@ void CLEARGRASSTRHKPADiscovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < CLEARGRASSTRHKPAparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),CLEARGRASSTRHKPAsensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + CLEARGRASSTRHKPAsensor[i][1];
-    createDiscovery(CLEARGRASSTRHKPAsensor[i][0],
-                    (char *)discovery_topic.c_str(), CLEARGRASSTRHKPAsensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, CLEARGRASSTRHKPAsensor[i][3], CLEARGRASSTRHKPAsensor[i][4],
-                    CLEARGRASSTRHKPAsensor[i][5], CLEARGRASSTRHKPAsensor[i][6], CLEARGRASSTRHKPAsensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, CLEARGRASSTRHKPAsensor, CLEARGRASSTRHKPAparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -333,18 +256,7 @@ void MiScaleDiscovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < MiScaleparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),MiScalesensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + MiScalesensor[i][1];
-    createDiscovery(MiScalesensor[i][0],
-                    (char *)discovery_topic.c_str(), MiScalesensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, MiScalesensor[i][3], MiScalesensor[i][4],
-                    MiScalesensor[i][5], MiScalesensor[i][6], MiScalesensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, MiScalesensor, MiScaleparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -357,18 +269,7 @@ void MiLampDiscovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < MiLampparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),MiLampsensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + MiLampsensor[i][1];
-    createDiscovery(MiLampsensor[i][0],
-                    (char *)discovery_topic.c_str(), MiLampsensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, MiLampsensor[i][3], MiLampsensor[i][4],
-                    MiLampsensor[i][5], MiLampsensor[i][6], MiLampsensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, MiLampsensor, MiLampparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 
@@ -381,18 +282,7 @@ void MiBandDiscovery(char *mac)
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  for (int i = 0; i < MiBandparametersCount; i++)
-  {
-    Log.trace(F("CreateDiscoverySensor %s" CR),MiBandsensor[i][1]);
-    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
-    String unique_id = String(mac) + "-" + MiBandsensor[i][1];
-    createDiscovery(MiBandsensor[i][0],
-                    (char *)discovery_topic.c_str(), MiBandsensor[i][1], (char *)unique_id.c_str(),
-                    will_Topic, MiBandsensor[i][3], MiBandsensor[i][4],
-                    MiBandsensor[i][5], MiBandsensor[i][6], MiBandsensor[i][7],
-                    0, "", "", false, "");
-  }
-
+  createDiscoveryFromList(mac, MiBandsensor, MiBandparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -285,7 +285,17 @@ void MiBandDiscovery(char *mac)
   createDiscoveryFromList(mac, MiBandsensor, MiBandparametersCount);
   createOrUpdateDevice(mac, device_flags::isDisc);
 }
-
+#else
+void MiFloraDiscovery(char *mac){}
+void VegTrugDiscovery(char *mac){}
+void MiJiaDiscovery(char *mac){}
+void LYWSD02Discovery(char *mac){}
+void CLEARGRASSTRHDiscovery(char *mac){}
+void CLEARGRASSCGD1Discovery(char *mac){}
+void CLEARGRASSTRHKPADiscovery(char *mac){}
+void MiScaleDiscovery(char *mac){}
+void MiLampDiscovery(char *mac){}
+void MiBandDiscovery(char *mac){}
 #endif
 
 #ifdef ESP32
@@ -375,10 +385,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               {
                 Log.trace(F("mi flora data reading" CR));
                 //example "servicedata":"71209800bc63b6658d7cc40d0910023200"
-                #ifdef ZmqttDiscovery
+                
                 if (!isDiscovered(device))
                   MiFloraDiscovery(mac);
-                #endif
+
                 process_sensors(pos - 24, service_data, mac);
               }
               pos = -1;
@@ -387,10 +397,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               {
                 Log.trace(F("vegtrug data reading" CR));
                 //example "servicedata":"7120bc0399c309688d7cc40d0910020000"
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   VegTrugDiscovery(mac);
-                #endif
+
                 process_sensors(pos - 24, service_data, mac);
               }
               pos = -1;
@@ -398,10 +408,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               if (pos != -1)
               {
                 Log.trace(F("mi jia data reading" CR));
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   MiJiaDiscovery(mac);
-                #endif
+
                 process_sensors(pos - 26, service_data, mac);
               }
               pos = -1;
@@ -410,10 +420,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               {
                 Log.trace(F("LYWSD02 data reading" CR));
                 //example "servicedata":"70205b04b96ab883c8593f09041002e000"
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   LYWSD02Discovery(mac);
-                #endif
+
                 process_sensors(pos - 24, service_data, mac);
               }
               pos = -1;
@@ -422,10 +432,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               {
                 Log.trace(F("ClearGrass T RH data reading method 1" CR));
                 //example "servicedata":"5030470340743e10342d58041002d6000a100164"
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   CLEARGRASSTRHDiscovery(mac);
-                #endif
+
                 process_sensors(pos - 26, service_data, mac);
               }
               pos = -1;
@@ -434,10 +444,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               {
                 Log.trace(F("Mi Lamp data reading" CR));
                 //example "servicedata":4030DD031D0300010100
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   MiLampDiscovery(mac);
-                #endif
+
                 process_milamp(service_data, mac);
               }
             }
@@ -445,40 +455,40 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
             { // Mi Scale V1
               Log.trace(F("Mi Scale V1 data reading" CR));
               //example "servicedata":"a2ac2be307060207122b" /"a28039e3070602070e28"
-              #ifdef ZmqttDiscovery
+
               if (!isDiscovered(device))
                 MiScaleDiscovery(mac);
-              #endif
+
               process_scale_v1(service_data, mac);
             }
             if (strstr(BLEdata["servicedatauuid"].as<char *>(), "181b") != NULL)
             { // Mi Scale V2
               Log.trace(F("Mi Scale V2 data reading" CR));
               //example "servicedata":02c4e1070b1e13050c00002607 / 02a6e20705150a251df401443e /02a6e20705180c0d04d701943e
-              #ifdef ZmqttDiscovery
+
               if (!isDiscovered(device))
                 MiScaleDiscovery(mac);
-              #endif
+
               process_scale_v2(service_data, mac);
             }
             if (strstr(BLEdata["servicedatauuid"].as<char *>(), "fee0") != NULL)
             { // Mi Band //0000fee0-0000-1000-8000-00805f9b34fb // ESP32 only
               Log.trace(F("Mi Band data reading" CR));
               //example "servicedata":a21e0000
-              #ifdef ZmqttDiscovery
+
               if (!isDiscovered(device))
                 MiBandDiscovery(mac);
-              #endif
+
               process_miband(service_data, mac);
             }
             if (strstr(BLEdata["servicedata"].as<char *>(), "08094c") != NULL)
             { // Clear grass with air pressure//08094c0140342d580104d8000c020702612702015a
               Log.trace(F("Clear grass data with air pressure reading" CR));
               //example "servicedata":08094c0140342d580104 c400 2402 0702 5d27 02015a
-              #ifdef ZmqttDiscovery
+
               if (!isDiscovered(device))
                 CLEARGRASSTRHKPADiscovery(mac);
-              #endif
+
               process_cleargrass_air(service_data, mac);
             }
             if (strstr(BLEdata["servicedata"].as<char *>(), "080774") != NULL)
@@ -492,10 +502,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
             { // Clear grass CGD1 080caffd50342d580104c900a102
               Log.trace(F("Clear grass CGD1 data reading" CR));
               //example "servicedata":080caffd50342d580104 c900 a102
-              #ifdef ZmqttDiscovery
+
               if (!isDiscovered(device))
                 CLEARGRASSCGD1Discovery(mac);
-              #endif
+
               process_cleargrass(service_data, mac);
             }
           }
@@ -706,10 +716,10 @@ bool BTtoMQTT()
               if (pos != -1)
               {
                 Log.trace(F("mi flora data reading" CR));
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   MiFloraDiscovery(d[0].extract);
-                #endif
+
                 bool result = process_sensors(pos - 38, (char *)service_data.c_str(), d[0].extract);
               }
               pos = -1;
@@ -718,10 +728,10 @@ bool BTtoMQTT()
               if (pos != -1)
               {
                 Log.trace(F("mi jia data reading" CR));
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   MiJiaDiscovery(d[0].extract);
-                #endif
+
                 bool result = process_sensors(pos - 40, (char *)service_data.c_str(), d[0].extract);
               }
               pos = -1;
@@ -730,10 +740,10 @@ bool BTtoMQTT()
               if (pos != -1)
               {
                 Log.trace(F("LYWSD02 data reading" CR));
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   LYWSD02Discovery(d[0].extract);
-                #endif
+
                 bool result = process_sensors(pos - 38, (char *)service_data.c_str(), d[0].extract);
               }
               pos = -1;
@@ -741,10 +751,10 @@ bool BTtoMQTT()
               if (pos != -1)
               {
                 Log.trace(F("CLEARGRASSTRH data reading method 1" CR));
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   CLEARGRASSTRHDiscovery(d[0].extract);
-                #endif
+
                 bool result = process_sensors(pos - 40, (char *)service_data.c_str(), d[0].extract);
               }
               pos = -1;
@@ -753,10 +763,10 @@ bool BTtoMQTT()
               {
                 Log.trace(F("Mi Scale data reading" CR));
                 //example "servicedata":"a2ac2be307060207122b" /"a28039e3070602070e28"
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   MiScaleDiscovery(d[0].extract);
-                #endif
+
                 bool result = process_scale_v1((char *)service_data.c_str(), d[0].extract);
               }
               pos = -1;
@@ -765,10 +775,10 @@ bool BTtoMQTT()
               {
                 Log.trace(F("Mi Lamp data reading" CR));
                 //example "servicedata":4030dd31d0300010100
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   MiLampDiscovery(d[0].extract);
-                #endif
+
                 process_milamp((char *)service_data.c_str(), d[0].extract);
               }
               pos = -1;
@@ -777,10 +787,10 @@ bool BTtoMQTT()
               {
                 Log.trace(F("Clear grass data with air pressure reading" CR));
                 //example "servicedata":08094c0140342d580104 c400 2402 0702 5d27 02015a
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   CLEARGRASSTRHKPADiscovery(d[0].extract);
-                #endif
+
                 process_cleargrass_air((char *)service_data.c_str(), d[0].extract);
               }
               pos = -1;
@@ -797,10 +807,10 @@ bool BTtoMQTT()
               {
                 Log.trace(F("Clear grass data CGD1" CR));
                 //example "servicedata":080caffd50342d580104 c900 a102
-                #ifdef ZmqttDiscovery
+
                 if (!isDiscovered(device))
                   CLEARGRASSCGD1Discovery(d[0].extract);
-                #endif
+
                 process_cleargrass((char *)service_data.c_str(), d[0].extract);
               }
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -57,33 +57,45 @@ bool updateWorB(JsonObject &BTdata, bool isWhite)
   int size = BTdata[jsonKey].size();
   if (size == 0) 
     return false;
-  
-  bool foundMac;
+
   for (int i = 0; i < size; i++)
   {
     const char *mac = BTdata[jsonKey][i];
 
-    BLEdevice *device = getDeviceByMac(mac);
-    if(device == &NO_DEVICE_FOUND)
+    createOrUpdateDevice(mac, NULL /*isDisc*/, isWhite /*isWhite*/);
+  }
+  
+  return true;
+}
+
+void createOrUpdateDevice(const char *mac, bool isDisc, bool isWhite)
+{
+  BLEdevice *device = getDeviceByMac(mac);
+  if(device == &NO_DEVICE_FOUND){
+    Log.trace(F("add %s" CR), mac);
+    //new device
+    device = new BLEdevice();
+    strcpy(device->macAdr, mac);
+    device->isDisc = isDisc != NULL && isDisc;
+    device->isWhtL = isWhite != NULL && isWhite;
+    device->isBlkL = isWhite != NULL && !isWhite;
+    devices.push_back(*device);
+  }
+  else
+  {
+    Log.trace(F("update %s" CR), mac);
+    
+    if(isDisc != NULL)
     {
-      Log.trace(F("add %s from %s" CR), mac, jsonKey);
-      //new device
-      device = new BLEdevice();
-      strcpy(device->macAdr, mac);
-      device->isDisc = false;
-      device->isWhtL = isWhite;
-      device->isBlkL = !isWhite;
-      devices.push_back(*device);
+      device->isDisc = isDisc;
     }
-    else
+
+    if(isWhite != NULL)
     {
-      Log.trace(F("update %s from %s" CR), mac, jsonKey);
       device->isWhtL = isWhite;
       device->isBlkL = !isWhite;
     }
   }
-  
-  return true;
 }
 
 bool oneWhite()
@@ -141,12 +153,8 @@ void MiFloraDiscovery(char *mac)
                     MiFlorasensor[i][5], MiFlorasensor[i][6], MiFlorasensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void VegTrugDiscovery(char *mac)
@@ -172,12 +180,8 @@ void VegTrugDiscovery(char *mac)
                     VegTrugsensor[i][5], VegTrugsensor[i][6], VegTrugsensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void MiJiaDiscovery(char *mac)
@@ -202,12 +206,8 @@ void MiJiaDiscovery(char *mac)
                     MiJiasensor[i][5], MiJiasensor[i][6], MiJiasensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void LYWSD02Discovery(char *mac)
@@ -232,12 +232,8 @@ void LYWSD02Discovery(char *mac)
                     LYWSD02sensor[i][5], LYWSD02sensor[i][6], LYWSD02sensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void CLEARGRASSTRHDiscovery(char *mac)
@@ -262,12 +258,8 @@ void CLEARGRASSTRHDiscovery(char *mac)
                     CLEARGRASSTRHsensor[i][5], CLEARGRASSTRHsensor[i][6], CLEARGRASSTRHsensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void CLEARGRASSCGD1Discovery(char *mac)
@@ -292,12 +284,8 @@ void CLEARGRASSCGD1Discovery(char *mac)
                     CLEARGRASSCGD1sensor[i][5], CLEARGRASSCGD1sensor[i][6], CLEARGRASSCGD1sensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void CLEARGRASSTRHKPADiscovery(char *mac)
@@ -322,12 +310,8 @@ void CLEARGRASSTRHKPADiscovery(char *mac)
                     CLEARGRASSTRHKPAsensor[i][5], CLEARGRASSTRHKPAsensor[i][6], CLEARGRASSTRHKPAsensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void MiScaleDiscovery(char *mac)
@@ -350,12 +334,8 @@ void MiScaleDiscovery(char *mac)
                     MiScalesensor[i][5], MiScalesensor[i][6], MiScalesensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void MiLampDiscovery(char *mac)
@@ -378,12 +358,8 @@ void MiLampDiscovery(char *mac)
                     MiLampsensor[i][5], MiLampsensor[i][6], MiLampsensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 void MiBandDiscovery(char *mac)
@@ -406,12 +382,8 @@ void MiBandDiscovery(char *mac)
                     MiBandsensor[i][5], MiBandsensor[i][6], MiBandsensor[i][7],
                     0, "", "", false, "");
   }
-  BLEdevice device;
-  strcpy(device.macAdr, mac);
-  device.isDisc = true;
-  device.isWhtL = false;
-  device.isBlkL = false;
-  devices.push_back(device);
+
+  createOrUpdateDevice(mac, true /*isDisc*/, NULL /*isWhite*/);
 }
 
 #endif

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -108,9 +108,9 @@ bool oneWhite()
   return false;
 }
 
-#define isWhite(mac) getDeviceByMac(mac)->isWhtL
-#define isBlack(mac) getDeviceByMac(mac)->isBlkL
-#define isDiscovered(mac) getDeviceByMac(mac)->isDisc
+#define isWhite(device) device->isWhtL
+#define isBlack(device) device->isBlkL
+#define isDiscovered(device) device->isDisc
 
 void dumpDevices()
 {
@@ -420,7 +420,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
     char mac[mac_adress.length() + 1];
     mac_adress.toCharArray(mac, mac_adress.length() + 1);
     Log.notice(F("Device detected: %s" CR),mac);
-    if ((!oneWhite() || isWhite(mac)) && !isBlack(mac))
+
+    BLEdevice *device = getDeviceByMac(mac);
+
+    if ((!oneWhite() || isWhite(device)) && !isBlack(device))
     { //if not black listed mac we go AND if we have no white mac or this mac is  white we go out
       if (advertisedDevice.haveName())
         BLEdata.set("name", (char *)advertisedDevice.getName().c_str());
@@ -473,7 +476,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
                 Log.trace(F("mi flora data reading" CR));
                 //example "servicedata":"71209800bc63b6658d7cc40d0910023200"
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(mac))
+                if (!isDiscovered(device))
                   MiFloraDiscovery(mac);
                 #endif
                 process_sensors(pos - 24, service_data, mac);
@@ -485,7 +488,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
                 Log.trace(F("vegtrug data reading" CR));
                 //example "servicedata":"7120bc0399c309688d7cc40d0910020000"
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(mac))
+                if (!isDiscovered(device))
                   VegTrugDiscovery(mac);
                 #endif
                 process_sensors(pos - 24, service_data, mac);
@@ -496,7 +499,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               {
                 Log.trace(F("mi jia data reading" CR));
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(mac))
+                if (!isDiscovered(device))
                   MiJiaDiscovery(mac);
                 #endif
                 process_sensors(pos - 26, service_data, mac);
@@ -508,7 +511,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
                 Log.trace(F("LYWSD02 data reading" CR));
                 //example "servicedata":"70205b04b96ab883c8593f09041002e000"
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(mac))
+                if (!isDiscovered(device))
                   LYWSD02Discovery(mac);
                 #endif
                 process_sensors(pos - 24, service_data, mac);
@@ -520,7 +523,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
                 Log.trace(F("ClearGrass T RH data reading method 1" CR));
                 //example "servicedata":"5030470340743e10342d58041002d6000a100164"
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(mac))
+                if (!isDiscovered(device))
                   CLEARGRASSTRHDiscovery(mac);
                 #endif
                 process_sensors(pos - 26, service_data, mac);
@@ -532,7 +535,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
                 Log.trace(F("Mi Lamp data reading" CR));
                 //example "servicedata":4030DD031D0300010100
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(mac))
+                if (!isDiscovered(device))
                   MiLampDiscovery(mac);
                 #endif
                 process_milamp(service_data, mac);
@@ -543,7 +546,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               Log.trace(F("Mi Scale V1 data reading" CR));
               //example "servicedata":"a2ac2be307060207122b" /"a28039e3070602070e28"
               #ifdef ZmqttDiscovery
-              if (!isDiscovered(mac))
+              if (!isDiscovered(device))
                 MiScaleDiscovery(mac);
               #endif
               process_scale_v1(service_data, mac);
@@ -553,7 +556,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               Log.trace(F("Mi Scale V2 data reading" CR));
               //example "servicedata":02c4e1070b1e13050c00002607 / 02a6e20705150a251df401443e /02a6e20705180c0d04d701943e
               #ifdef ZmqttDiscovery
-              if (!isDiscovered(mac))
+              if (!isDiscovered(device))
                 MiScaleDiscovery(mac);
               #endif
               process_scale_v2(service_data, mac);
@@ -563,7 +566,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               Log.trace(F("Mi Band data reading" CR));
               //example "servicedata":a21e0000
               #ifdef ZmqttDiscovery
-              if (!isDiscovered(mac))
+              if (!isDiscovered(device))
                 MiBandDiscovery(mac);
               #endif
               process_miband(service_data, mac);
@@ -573,7 +576,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               Log.trace(F("Clear grass data with air pressure reading" CR));
               //example "servicedata":08094c0140342d580104 c400 2402 0702 5d27 02015a
               #ifdef ZmqttDiscovery
-              if (!isDiscovered(mac))
+              if (!isDiscovered(device))
                 CLEARGRASSTRHKPADiscovery(mac);
               #endif
               process_cleargrass_air(service_data, mac);
@@ -590,7 +593,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
               Log.trace(F("Clear grass CGD1 data reading" CR));
               //example "servicedata":080caffd50342d580104 c900 a102
               #ifdef ZmqttDiscovery
-              if (!isDiscovered(mac))
+              if (!isDiscovered(device))
                 CLEARGRASSCGD1Discovery(mac);
               #endif
               process_cleargrass(service_data, mac);
@@ -765,9 +768,12 @@ bool BTtoMQTT()
             StaticJsonBuffer<JSON_MSG_BUFFER> jsonBuffer;
             JsonObject &BLEdata = jsonBuffer.createObject();
             strupp(d[0].extract);
-            if (isBlack(d[0].extract))
+
+            BLEdevice *device = getDeviceByMac(d[0].extract);
+
+            if (isBlack(device))
               return false; //if black listed mac we go out
-            if (oneWhite() && !isWhite(d[0].extract))
+            if (oneWhite() && !isWhite(device))
               return false; //if we have at least one white mac and this mac is not white we go out
             #ifdef subjectHomePresence
             String HomePresenceId;
@@ -801,7 +807,7 @@ bool BTtoMQTT()
               {
                 Log.trace(F("mi flora data reading" CR));
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   MiFloraDiscovery(d[0].extract);
                 #endif
                 bool result = process_sensors(pos - 38, (char *)service_data.c_str(), d[0].extract);
@@ -813,7 +819,7 @@ bool BTtoMQTT()
               {
                 Log.trace(F("mi jia data reading" CR));
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   MiJiaDiscovery(d[0].extract);
                 #endif
                 bool result = process_sensors(pos - 40, (char *)service_data.c_str(), d[0].extract);
@@ -825,7 +831,7 @@ bool BTtoMQTT()
               {
                 Log.trace(F("LYWSD02 data reading" CR));
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   LYWSD02Discovery(d[0].extract);
                 #endif
                 bool result = process_sensors(pos - 38, (char *)service_data.c_str(), d[0].extract);
@@ -836,7 +842,7 @@ bool BTtoMQTT()
               {
                 Log.trace(F("CLEARGRASSTRH data reading method 1" CR));
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   CLEARGRASSTRHDiscovery(d[0].extract);
                 #endif
                 bool result = process_sensors(pos - 40, (char *)service_data.c_str(), d[0].extract);
@@ -848,7 +854,7 @@ bool BTtoMQTT()
                 Log.trace(F("Mi Scale data reading" CR));
                 //example "servicedata":"a2ac2be307060207122b" /"a28039e3070602070e28"
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   MiScaleDiscovery(d[0].extract);
                 #endif
                 bool result = process_scale_v1((char *)service_data.c_str(), d[0].extract);
@@ -860,7 +866,7 @@ bool BTtoMQTT()
                 Log.trace(F("Mi Lamp data reading" CR));
                 //example "servicedata":4030dd31d0300010100
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   MiLampDiscovery(d[0].extract);
                 #endif
                 process_milamp((char *)service_data.c_str(), d[0].extract);
@@ -872,7 +878,7 @@ bool BTtoMQTT()
                 Log.trace(F("Clear grass data with air pressure reading" CR));
                 //example "servicedata":08094c0140342d580104 c400 2402 0702 5d27 02015a
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   CLEARGRASSTRHKPADiscovery(d[0].extract);
                 #endif
                 process_cleargrass_air((char *)service_data.c_str(), d[0].extract);
@@ -892,7 +898,7 @@ bool BTtoMQTT()
                 Log.trace(F("Clear grass data CGD1" CR));
                 //example "servicedata":080caffd50342d580104 c900 a102
                 #ifdef ZmqttDiscovery
-                if (!isDiscovered(d[0].extract))
+                if (!isDiscovered(device))
                   CLEARGRASSCGD1Discovery(d[0].extract);
                 #endif
                 process_cleargrass((char *)service_data.c_str(), d[0].extract);

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -69,13 +69,13 @@ bool updateWorB(JsonObject &BTdata, bool isWhite)
   {
     const char *mac = BTdata[jsonKey][i];
 
-    createOrUpdateDevice(mac, (isWhite ? device_flags::isWhiteL : device_flags::isBlackL));
+    createOrUpdateDevice(mac, (isWhite ? device_flags_isWhiteL : device_flags_isBlackL));
   }
   
   return true;
 }
 
-void createOrUpdateDevice(const char *mac, device_flags flags)
+void createOrUpdateDevice(const char *mac, uint8_t flags)
 {
 #ifdef ESP32
   if (!semaphoreCreateOrUpdateDevice.take(30000, "createOrUpdateDevice"))
@@ -89,24 +89,24 @@ void createOrUpdateDevice(const char *mac, device_flags flags)
     //new device
     device = new BLEdevice();
     strcpy(device->macAdr, mac);
-    device->isDisc = flags & device_flags::isDisc;
-    device->isWhtL = flags & device_flags::isWhiteL;
-    device->isBlkL = flags & device_flags::isBlackL;
+    device->isDisc = flags & device_flags_isDisc;
+    device->isWhtL = flags & device_flags_isWhiteL;
+    device->isBlkL = flags & device_flags_isBlackL;
     devices.push_back(*device);
   }
   else
   {
     Log.trace(F("update %s" CR), mac);
     
-    if(flags & device_flags::isDisc)
+    if(flags & device_flags_isDisc)
     {
       device->isDisc = true;
     }
 
-    if(flags & device_flags::isWhiteL || flags & device_flags::isBlackL)
+    if(flags & device_flags_isWhiteL || flags & device_flags_isBlackL)
     {
-      device->isWhtL = flags & device_flags::isWhiteL;
-      device->isBlkL = flags & device_flags::isBlackL;
+      device->isWhtL = flags & device_flags_isWhiteL;
+      device->isBlkL = flags & device_flags_isBlackL;
     }
   }
 
@@ -153,7 +153,7 @@ void MiFloraDiscovery(char *mac)
   };
 
   createDiscoveryFromList(mac, MiFlorasensor, MiFloraparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void VegTrugDiscovery(char *mac)
@@ -169,7 +169,7 @@ void VegTrugDiscovery(char *mac)
   };
   
   createDiscoveryFromList(mac, VegTrugsensor, VegTrugparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void MiJiaDiscovery(char *mac)
@@ -184,7 +184,7 @@ void MiJiaDiscovery(char *mac)
   };
   
   createDiscoveryFromList(mac, MiJiasensor, MiJiaparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void LYWSD02Discovery(char *mac)
@@ -199,7 +199,7 @@ void LYWSD02Discovery(char *mac)
   };
 
   createDiscoveryFromList(mac, LYWSD02sensor, LYWSD02parametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void CLEARGRASSTRHDiscovery(char *mac)
@@ -214,7 +214,7 @@ void CLEARGRASSTRHDiscovery(char *mac)
   };
 
   createDiscoveryFromList(mac, CLEARGRASSTRHsensor, CLEARGRASSTRHparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void CLEARGRASSCGD1Discovery(char *mac)
@@ -229,7 +229,7 @@ void CLEARGRASSCGD1Discovery(char *mac)
   };
 
   createDiscoveryFromList(mac, CLEARGRASSCGD1sensor, CLEARGRASSCGD1parametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void CLEARGRASSTRHKPADiscovery(char *mac)
@@ -244,7 +244,7 @@ void CLEARGRASSTRHKPADiscovery(char *mac)
   };
 
   createDiscoveryFromList(mac, CLEARGRASSTRHKPAsensor, CLEARGRASSTRHKPAparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void MiScaleDiscovery(char *mac)
@@ -257,7 +257,7 @@ void MiScaleDiscovery(char *mac)
   };
 
   createDiscoveryFromList(mac, MiScalesensor, MiScaleparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void MiLampDiscovery(char *mac)
@@ -270,7 +270,7 @@ void MiLampDiscovery(char *mac)
   };
 
   createDiscoveryFromList(mac, MiLampsensor, MiLampparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 
 void MiBandDiscovery(char *mac)
@@ -283,7 +283,7 @@ void MiBandDiscovery(char *mac)
   };
 
   createDiscoveryFromList(mac, MiBandsensor, MiBandparametersCount);
-  createOrUpdateDevice(mac, device_flags::isDisc);
+  createOrUpdateDevice(mac, device_flags_isDisc);
 }
 #else
 void MiFloraDiscovery(char *mac){}

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -36,7 +36,7 @@ Thanks to wolass https://github.com/wolass for suggesting me HM 10 and dinosd ht
 using namespace std;
 vector<BLEdevice> devices;
 
-bool setWorBMac(JsonObject &BTdata, bool isWhite){
+bool updateWorB(JsonObject &BTdata, bool isWhite){
   const char* jsonKey = isWhite ? "white-list" : "black-list";
 
   int size = BTdata[jsonKey].size();
@@ -1209,11 +1209,11 @@ void MQTTtoBT(char *topicOri, JsonObject &BTdata)
     Log.trace(F("MQTTtoBT json set" CR));
 
     // Black list & white list set
-    bool WLorBLupdated;
-    WLorBLupdated |= setWorBMac(BTdata, true);
-    WLorBLupdated |= setWorBMac(BTdata, false);
+    bool WorBupdated;
+    WorBupdated |= updateWorB(BTdata, true);
+    WorBupdated |= updateWorB(BTdata, false);
 
-    if (WLorBLupdated)
+    if (WorBupdated)
       dumpDevices();
 
     // Scan interval set

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -96,17 +96,7 @@ bool oneWhite()
   return false;
 }
 
-bool isWhite(char *mac)
-{
-  for (vector<BLEdevice>::iterator p = devices.begin(); p != devices.end(); ++p)
-  {
-    if ((strcmp(p->macAdr, mac) == 0))
-    {
-      return p->isWhtL;
-    }
-  }
-  return false;
-}
+#define isWhite(mac) getDeviceByMac(mac)->isWhtL
 
 bool isBlack(char *mac)
 {

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -49,6 +49,7 @@ String getUniqueId(String name, String sufix)
   return String(uniqueId);
 }
 
+#ifdef ZgatewayBT
 void createDiscoveryFromList(char *mac, char *sensorList[][8], int sensorCount)
 {
   for (int i = 0; i < sensorCount; i++)
@@ -63,6 +64,7 @@ void createDiscoveryFromList(char *mac, char *sensorList[][8], int sensorCount)
                     0, "", "", false, "");
   }
 }
+#endif
 
 void createDiscovery(char *sensor_type,
                      char *st_topic, char *s_name, char *unique_id,

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -49,6 +49,21 @@ String getUniqueId(String name, String sufix)
   return String(uniqueId);
 }
 
+void createDiscoveryFromList(char *mac, char *sensorList[][8], int sensorCount)
+{
+  for (int i = 0; i < sensorCount; i++)
+  {
+    Log.trace(F("CreateDiscoverySensor %s" CR),sensorList[i][1]);
+    String discovery_topic = String(subjectBTtoMQTT) + "/" + String(mac);
+    String unique_id = String(mac) + "-" + sensorList[i][1];
+    createDiscovery(sensorList[i][0],
+                    (char *)discovery_topic.c_str(), sensorList[i][1], (char *)unique_id.c_str(),
+                    will_Topic, sensorList[i][3], sensorList[i][4],
+                    sensorList[i][5], sensorList[i][6], sensorList[i][7],
+                    0, "", "", false, "");
+  }
+}
+
 void createDiscovery(char *sensor_type,
                      char *st_topic, char *s_name, char *unique_id,
                      char *availability_topic, char *device_class, char *value_template,

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -55,6 +55,13 @@ struct BLEdevice{
   bool isBlkL;
 };
 
+enum device_flags {
+  unknown = 0,
+  isDisc = 1 << 0,
+  isWhiteL = 1 << 1,
+  isBlackL = 1 << 2
+};
+
 struct decompose{
   char subject[4];
   int start;

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -55,12 +55,9 @@ struct BLEdevice{
   bool isBlkL;
 };
 
-enum device_flags {
-  unknown = 0,
-  isDisc = 1 << 0,
-  isWhiteL = 1 << 1,
-  isBlackL = 1 << 2
-};
+#define device_flags_isDisc 1 << 0
+#define device_flags_isWhiteL 1 << 1
+#define device_flags_isBlackL 1 << 2
 
 struct decompose{
   char subject[4];

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -29,6 +29,7 @@
 
 extern String getUniqueId(String name, String sufix);
 extern void pubMqttDiscovery();
+extern void createDiscoveryFromList(char *mac, char *sensorList[][8], int sensorCount);
 extern void createDiscovery(char * sensor_type,
                     char * state_topic, char * s_name, char * unique_id,
                     char * availability_topic, char * device_class, char * value_template,


### PR DESCRIPTION
Based on my original PR #553 I have further developed the idea to remove duplicate code inside the Bluetooth module step by step to improve the readability and maintainability.

During this, I found a data corruption with is triggered if the white-list is set before the devices are discovered. this is addressed with 92a833eb3d6598b489bf88001fb9a772edd30da2

The last two patches of this series finally reduce the need for device-tree walks and increase the overall speed if many supported ble devices are in range.

Summarizing, these changes save over 141 KB flash size (~9%) and ~600 bytes of memory