### PR TITLE
Fixed Pilight can not send on RX pin

### DIFF
--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -60,6 +60,7 @@ void setupPilight()
 #ifndef ZgatewayRF &&ZgatewayRF2 //receiving with Pilight is not compatible with ZgatewayRF or RF2 or RF315 as far as I can tell
   rf.setCallback(pilightCallback);
   rf.initReceiver(RF_RECEIVER_PIN);
+  pinMode(RF_EMITTER_PIN, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
   Log.notice(F("RF_EMITTER_PIN: %d " CR), RF_EMITTER_PIN);
   Log.notice(F("RF_RECEIVER_PIN: %d " CR), RF_RECEIVER_PIN);
   Log.trace(F("ZgatewayPilight setup done " CR));


### PR DESCRIPTION
Set the pin mode of the `RF_EMITTER_PIN` in the `setupPilight`. Actually the pin mode is already set in the ESPiLight constructor, but if the `RF_EMITTER_PIN` is the RX pin the [pin mode is reset](https://github.com/esp8266/Arduino/blob/007e495e0d88eabc6dae31fad311df38f8914607/cores/esp8266/uart.cpp#L714) with the `Serial.end();` call in [main.ino](https://github.com/1technophile/OpenMQTTGateway/blob/development/main/main.ino#L622). So it must be set again.