### PR TITLE
Added HTU21 Sensor

### DIFF
--- a/docs/setitup/sensors.md
+++ b/docs/setitup/sensors.md
@@ -7,6 +7,7 @@
 |HCSR501|PIR|[parts list](https://docs.google.com/spreadsheets/d/1_5fQjAixzRtepkykmL-3uN3G5bLfQ0zMajM9OBZ1bx0/edit#gid=1323184277)|
 |BH1750|Digital light|[parts list](https://docs.google.com/spreadsheets/d/1_5fQjAixzRtepkykmL-3uN3G5bLfQ0zMajM9OBZ1bx0/edit#gid=1323184277)|
 |BME280|Temperature, Humidity and pressure|[parts list](https://docs.google.com/spreadsheets/d/1_5fQjAixzRtepkykmL-3uN3G5bLfQ0zMajM9OBZ1bx0/edit#gid=1323184277)|
+|HTU21|Temperature, Humidity|[parts list](https://docs.google.com/spreadsheets/d/1_5fQjAixzRtepkykmL-3uN3G5bLfQ0zMajM9OBZ1bx0/edit#gid=1323184277)|
 |GPIO Input|Inputs|-|
 |GPIO KeyCode|Keycode|[parts list](https://docs.google.com/spreadsheets/d/1_5fQjAixzRtepkykmL-3uN3G5bLfQ0zMajM9OBZ1bx0/edit#gid=1323184277)|
 |INA226|Current and voltage|[parts list](https://docs.google.com/spreadsheets/d/1_5fQjAixzRtepkykmL-3uN3G5bLfQ0zMajM9OBZ1bx0/edit#gid=1323184277)|
@@ -22,6 +23,8 @@
 |BH1750 SCL|A5|D1|22|
 |BME280 SDA|A4|D2|21|
 |BME280 SCL|A5|D1|22|
+|HTU21 SDA|A4|D2|21|
+|HTU21 SCL|A5|D1|22|
 |INA226 SDA|A4|D2|21|
 |INA226 SCL|A5|D1|22|
 |TSL2561 SDA|A4|D2|21|

--- a/docs/use/sensors.md
+++ b/docs/use/sensors.md
@@ -4,7 +4,7 @@ Subscribe to all the messages with mosquitto or open your MQTT client software:
 `    sudo mosquitto_sub -t +/# -v`
 
 ### ADC
-The value is between 0 and 1024 and is tranmitted via Mqtt when it changes. 
+The value is between 0 and 1024 and is tranmitted via Mqtt when it changes.
 `home/OpenMQTTGateway/DHTtoMQTT {"value":543}`
 
 ### DHT
@@ -13,3 +13,10 @@ You will receive every TimeBetweenReadingDHT (set into config_DHT.h) the DHT mea
 `home/OpenMQTTGateway/DHTtoMQTT {"temp":21,"hum":51}`
 
 If you want to don't resend value when it is the same you can set dht_always = false in config_DHT.h
+
+### HTU21
+You will receive the HTU21 sensor readings every TimeBetweenReadinghtu21 (set into config_HTU21.h) (30s by default).
+
+`home/OpenMQTTGateway/CLIMAtoMQTT/htu {"tempc":25.34064,"tempf":77.61314,"hum":56.53052}`
+
+If you don't want to resend values that haven't changed you can set htu21_always = false in config_HTU21.h

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -170,6 +170,7 @@ int low_power_mode = DEFAULT_LOW_POWER_MODE;
 //#define ZsensorBH1750  "BH1750"   //ESP8266, Arduino, ESP32
 //#define ZsensorTSL2561 "TSL2561"  //ESP8266, Arduino, ESP32
 //#define ZsensorBME280  "BME280"   //ESP8266, Arduino, ESP32
+//#define ZsensorHTU21   "HTU21"    //ESP8266, Arduino, ESP32
 //#define ZsensorDHT     "DHT"      //ESP8266, Arduino, ESP32,  Sonoff RF Bridge
 //#define ZsensorDS1820  "DS1820"   //ESP8266, Arduino, ESP32
 //#define ZsensorGPIOKeyCode "GPIOKeyCode" //ESP8266, Arduino, ESP32

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -182,6 +182,28 @@ void pubMqttDiscovery()
   }
 #endif
 
+#ifdef ZsensorHTU21
+#define HTUparametersCount 3
+  Log.trace(F("htu21Discovery" CR));
+  char *HTUsensor[HTUparametersCount][8] = {
+      {"sensor", "tempc", "htu", "temperature", "{{ value_json.tempc }}", "", "", "°C"},
+      {"sensor", "tempf", "htu", "temperature", "{{ value_json.tempf }}", "", "", "°F"},
+      {"sensor", "hum", "htu", "humidity", "{{ value_json.hum }}", "", "", "%"}
+      //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
+  };
+
+  for (int i = 0; i < HTUparametersCount; i++)
+  {
+    Log.trace(F("CreateDiscoverySensor" CR));
+    //trc(HTUsensor[i][1]);
+    createDiscovery(HTUsensor[i][0],
+                    HTUTOPIC, HTUsensor[i][1], (char *)getUniqueId(HTUsensor[i][1], HTUsensor[i][2]).c_str(),
+                    will_Topic, HTUsensor[i][3], HTUsensor[i][4],
+                    HTUsensor[i][5], HTUsensor[i][6], HTUsensor[i][7],
+                    0, "", "", true, "");
+  }
+#endif
+
 #ifdef ZsensorDHT
 #define DHTparametersCount 2
   Log.trace(F("DHTDiscovery" CR));

--- a/main/ZsensorHTU21.ino
+++ b/main/ZsensorHTU21.ino
@@ -47,7 +47,7 @@
 unsigned long timehtu21 = 0;
 
 //Global sensor object
-HTU21D mySensor;
+HTU21D htuSensor;
 
 void setupZsensorHTU21()
 {
@@ -56,10 +56,10 @@ void setupZsensorHTU21()
 
 #if defined(ESP32)
   Wire.begin(I2C_SDA, I2C_SCL);
-  mySensor.begin(Wire);
+  htuSensor.begin(Wire);
 #else
 #endif
-  mySensor.begin();
+  htuSensor.begin();
 }
 
 void MeasureTempHum()
@@ -73,8 +73,8 @@ void MeasureTempHum()
     static float persisted_htu_tempc;
     static float persisted_htu_hum;
 
-    float HtuTempC = mySensor.readTemperature();
-    float HtuHum = mySensor.readHumidity();
+    float HtuTempC = htuSensor.readTemperature();
+    float HtuHum = htuSensor.readHumidity();
 
     if (HtuTempC >= 998 || HtuHum >= 998 )
     {

--- a/main/ZsensorHTU21.ino
+++ b/main/ZsensorHTU21.ino
@@ -19,9 +19,7 @@
    GND ---------> GND ------------------> GND
    SCL ---------> Pin A5 ---------------> D1
    SDA ---------> Pin A4 ---------------> D2
- 
-    Copyright: (c) Hans-Juergen Dinges
-  
+   
     This file is part of OpenMQTTGateway.
     
     OpenMQTTGateway is free software: you can redistribute it and/or modify
@@ -45,13 +43,16 @@
 #include "SparkFunHTU21D.h"
 #include "config_HTU21.h"
 
+//Time used to wait for an interval before resending measured values
+unsigned long timehtu21 = 0;
+
 //Global sensor object
 HTU21D mySensor;
 
 void setupZsensorHTU21()
 {
   delay(10); // Gives the Sensor enough time to turn on
-  Serial.println("HTU21 Initialized - begin()");
+  Log.notice(F("HTU21 Initialized - begin()" CR));
 
 #if defined(ESP32)
   Wire.begin(I2C_SDA, I2C_SCL);

--- a/main/ZsensorHTU21.ino
+++ b/main/ZsensorHTU21.ino
@@ -1,0 +1,124 @@
+/*  
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+ 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
+   Send and receiving command by MQTT
+   
+   This is the Climate Addon:
+   - Measures Temperature, Humidity and Pressure
+   - Generates Values for: Temperature in degrees C and F, Humidity in %, Pressure in Pa, Altitude in Meter and Feet
+   - Required Hardware Module: HTU21
+   - Required Library: SparkFun HTU21 Library v1.1.3
+
+   Connection Schemata:
+   --------------------
+
+   HTU21 ------> Arduino Uno ----------> ESP8266
+   ==============================================
+   Vcc ---------> 5V -------------------> Vu (5V)
+   GND ---------> GND ------------------> GND
+   SCL ---------> Pin A5 ---------------> D1
+   SDA ---------> Pin A4 ---------------> D2
+ 
+    Copyright: (c) Hans-Juergen Dinges
+  
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "User_config.h"
+
+#ifdef ZsensorHTU21
+#include "Wire.h" // Library for communication with I2C / TWI devices
+#include <stdint.h>
+#include "SparkFunHTU21D.h"
+#include "config_HTU21.h"
+
+//Global sensor object
+HTU21D mySensor;
+
+void setupZsensorHTU21()
+{
+  delay(10); // Gives the Sensor enough time to turn on
+  Serial.println("HTU21 Initialized - begin()");
+
+#if defined(ESP32)
+  Wire.begin(I2C_SDA, I2C_SCL);
+  mySensor.begin(Wire);
+#else
+#endif
+  mySensor.begin();
+}
+
+void MeasureTempHum()
+{
+
+  if (millis() > (timehtu21 + TimeBetweenReadinghtu21))
+  {
+    Log.trace(F("Read HTU21 Sensor" CR));
+
+    timehtu21 = millis();
+    static float persisted_htu_tempc;
+    static float persisted_htu_hum;
+
+    float HtuTempC = mySensor.readTemperature();
+    float HtuHum = mySensor.readHumidity();
+
+    if (HtuTempC >= 998 || HtuHum >= 998 )
+    {
+      Log.error(F("Failed to read from sensor HTU21!" CR));
+      return;
+    }
+
+    // Check if reads failed and exit early (to try again).
+    if (isnan(HtuTempC) || isnan(HtuHum))
+    {
+      Log.error(F("Failed to read from sensor HTU21!" CR));
+    }
+    else
+    {
+      Log.notice(F("Creating HTU21 buffer" CR));
+      StaticJsonBuffer<JSON_MSG_BUFFER> jsonBuffer;
+      JsonObject &HTU21data = jsonBuffer.createObject();
+      // Generate Temperature in degrees C
+      if (HtuTempC != persisted_htu_tempc || htu21_always)
+      {
+        float HtuTempF = (HtuTempC*1.8)+32;
+        HTU21data.set("tempc", (float)HtuTempC);
+        HTU21data.set("tempf", (float)HtuTempF);
+      }
+      else
+      {
+        Log.notice(F("Same Temp. Don't send it" CR));
+      }
+
+      // Generate Humidity in percent
+      if (HtuHum != persisted_htu_hum || htu21_always)
+      {
+        HTU21data.set("hum", (float)HtuHum);
+      }
+      else
+      {
+        Log.notice(F("Same Humidity. Don't send it" CR));
+      }
+
+      if (HTU21data.size() > 0)
+        pub(HTUTOPIC, HTU21data);
+    }
+    persisted_htu_tempc = HtuTempC;
+    persisted_htu_hum = HtuHum;
+  }
+}
+
+#endif

--- a/main/config_HTU21.h
+++ b/main/config_HTU21.h
@@ -1,0 +1,61 @@
+/*  
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+ 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
+   Send and receiving command by MQTT
+   
+   This is the Climate Addon:
+   - Measures Temperature, Humidity and Pressure
+   - Generates Values for: Temperature in degrees C and F, Humidity in %, Pressure in Pa, Altitude in Meter and Feet
+   - Required Hardware Module: HTU21
+   - Required Library: SparkFun HTU21 Library v1.1.3
+
+   Connection Schemata:
+   --------------------
+
+   HTU21 ------> Arduino Uno ----------> ESP8266
+   ==============================================
+   Vcc ---------> 5V -------------------> Vu (5V)
+   GND ---------> GND ------------------> GND
+   SCL ---------> Pin A5 ---------------> D1
+   SDA ---------> Pin A4 ---------------> D2
+ 
+    Copyright: (c) Hans-Juergen Dinges
+  
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef config_HTU21_h
+#define config_HTU21_h
+
+extern void setupHTU21();
+extern void HTU21toMQTT();
+
+#define htu21_always true // if false when the current value of the parameter is the same as previous one don't send it by MQTT
+#define TimeBetweenReadinghtu21 30000
+
+/*----------------------------USER PARAMETERS-----------------------------*/
+/*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
+#define HTUTOPIC   "/CLIMAtoMQTT/htu"
+
+//Time used to wait for an interval before resending measured values
+unsigned long timehtu21 = 0;
+
+#if defined(ESP32)
+  #define I2C_SDA 16
+  #define I2C_SCL 0
+#endif
+
+#endif

--- a/main/config_HTU21.h
+++ b/main/config_HTU21.h
@@ -19,9 +19,7 @@
    GND ---------> GND ------------------> GND
    SCL ---------> Pin A5 ---------------> D1
    SDA ---------> Pin A4 ---------------> D2
- 
-    Copyright: (c) Hans-Juergen Dinges
-  
+   
     This file is part of OpenMQTTGateway.
     
     OpenMQTTGateway is free software: you can redistribute it and/or modify
@@ -49,9 +47,6 @@ extern void HTU21toMQTT();
 /*----------------------------USER PARAMETERS-----------------------------*/
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 #define HTUTOPIC   "/CLIMAtoMQTT/htu"
-
-//Time used to wait for an interval before resending measured values
-unsigned long timehtu21 = 0;
 
 #if defined(ESP32)
   #define I2C_SDA 16

--- a/main/main.ino
+++ b/main/main.ino
@@ -85,6 +85,9 @@ unsigned long ReceivedSignal[array_size][2] = {{0, 0}, {0, 0}, {0, 0}, {0, 0}};
 #ifdef ZsensorBME280
 #include "config_BME280.h"
 #endif
+#ifdef ZsensorHTU21
+#include "config_HTU21.h"
+#endif
 #ifdef ZsensorHCSR04
 #include "config_HCSR04.h"
 #endif
@@ -598,6 +601,9 @@ void setup()
 
   #ifdef ZsensorBME280
   setupZsensorBME280();
+  #endif
+  #ifdef ZsensorHTU21
+  setupZsensorHTU21();
   #endif
   #ifdef ZsensorBH1750
   setupZsensorBH1750();
@@ -1157,6 +1163,9 @@ void loop()
       #ifdef ZsensorBME280
       MeasureTempHumAndPressure(); //Addon to measure Temperature, Humidity, Pressure and Altitude with a Bosch BME280
       #endif
+      #ifdef ZsensorHTU21
+      MeasureTempHum(); //Addon to measure Temperature, Humidity, of a HTU21 sensor
+      #endif
       #ifdef ZsensorHCSR04
       MeasureDistance(); //Addon to measure distance with a HC-SR04
       #endif
@@ -1285,6 +1294,9 @@ void stateMeasures()
   #endif
   #ifdef ZsensorBME280
   modules = modules + ZsensorBME280;
+  #endif
+  #ifdef ZsensorHTU21
+  modules = modules + ZsensorHTU21;
   #endif
   #ifdef ZsensorHCSR04
   modules = modules + ZsensorHCSR04;

--- a/platformio.ini
+++ b/platformio.ini
@@ -174,6 +174,7 @@ lib_deps =
   ${libraries.newremoteswitch}
   ${libraries.bme280}
   ${libraries.bmp180}
+  ${libraries.htu21}
   ${libraries.unifiedsensor}
   ${libraries.dht}
   ${libraries.tsl2561}
@@ -195,6 +196,7 @@ build_flags =
   '-DZsensorADC="ADC"'
   '-DZsensorBH1750="BH1750"'
   '-DZsensorBME280="BME280"'
+  '-DZsensorHTU21="HTU21"'
   '-DZsensorTSL2561="TSL2561"'
   '-DZsensorDHT="DHT"'
   '-DZsensorDS1820="DS1820"'
@@ -362,6 +364,7 @@ lib_deps =
   ${libraries.newremoteswitch}
   ${libraries.bme280}
   ${libraries.bmp180}
+  ${libraries.htu21}
   ${libraries.unifiedsensor}
   ${libraries.dht}
   ${libraries.tsl2561}
@@ -387,6 +390,7 @@ build_flags =
   '-DZsensorADC="ADC"'
   '-DZsensorBH1750="BH1750"'
   '-DZsensorBME280="BME280"'
+  '-DZsensorHTU21="HTU21"'
   '-DZsensorTSL2561="TSL2561"'
   '-DZsensorDHT="DHT"'
   '-DZsensorDS1820="DS1820"'
@@ -577,6 +581,7 @@ lib_deps =
   ${libraries.newremoteswitch}
   ${libraries.bme280}
   ${libraries.bmp180}
+  ${libraries.htu21}
   ${libraries.unifiedsensor}
   ${libraries.dht}
   ${libraries.tsl2561}
@@ -599,6 +604,7 @@ build_flags =
   '-DZsensorADC="ADC"'
   '-DZsensorBH1750="BH1750"'
   '-DZsensorBME280="BME280"'
+  '-DZsensorHTU21="HTU21"'
   '-DZsensorTSL2561="TSL2561"'
   '-DZsensorDHT="DHT"'
   '-DZsensorDS1820="DS1820"'


### PR DESCRIPTION
I ran out of BME280 sensors, but have a bunch of HTU21 sensors. I based the new sensor on the BME80 code. It's basic, but it works on me.

Can be enabled by adding the following to the platform.ini file (in one of the env sections)
lib_deps
  ${libraries.htu21}
  ${libraries.wire}
build_flags
  '-DZsensorHTU21="HTU21"'

ESP8266 - Uses hardware I2C pins
ESP32 - The SLA/SCL pins can be selected

------------

Successfully compiles for all platforms in the platform.ini file.
Tested on ESP8266 (esp12e) and ESP32 (esp32-cam board) without issues.