### PR TITLE
Allow pins/settings to be defined in INI file

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -341,8 +341,10 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks
     { //if not black listed mac we go AND if we have no white mac or this mac is  white we go out
       if (advertisedDevice.haveName())
         BLEdata.set("name", (char *)advertisedDevice.getName().c_str());
+      #if pubBLEManufacturerData
       if (advertisedDevice.haveManufacturerData())
         BLEdata.set("manufacturerdata", (char *)advertisedDevice.getManufacturerData().c_str());
+      #endif
       if (advertisedDevice.haveRSSI())
         BLEdata.set("rssi", (int)advertisedDevice.getRSSI());
       if (advertisedDevice.haveTXPower())

--- a/main/config_2G.h
+++ b/main/config_2G.h
@@ -42,18 +42,21 @@ extern void MQTTto2G(char *topicOri, JsonObject &SMSdata);
 #define _2G_MAX_SIGNAL 1000
 
 /*-------------------PIN DEFINITIONS----------------------*/
-#ifdef ESP8266
-  #define _2G_TX_PIN D6  //D6 to A6 RX,
-  #define _2G_RX_PIN D7  //D7 to A6 TX
-  #define _2G_PWR_PIN D5 // connect a MOSFET to power on and off your A6/7 module
-#elif defined(ESP32)
-  #define _2G_TX_PIN 16 //D16 to A6 RX,
-  #define _2G_RX_PIN 17 //D17 to A6 TX
-  #define _2G_PWR_PIN 5 // connect a MOSFET to power on and off your A6/7 module
-#else
-  #define _2G_TX_PIN 6  //D6 to A6 RX,
-  #define _2G_RX_PIN 7  //D7 to A6 TX
-  #define _2G_PWR_PIN 5 // connect a MOSFET to power on and off your A6/7 module
+
+#if !defined(_2G_TX_PIN) || !defined(_2G_RX_PIN) || !defined(_2G_PWR_PIN)
+  #ifdef ESP8266
+    #define _2G_TX_PIN D6  //D6 to A6 RX,
+    #define _2G_RX_PIN D7  //D7 to A6 TX
+    #define _2G_PWR_PIN D5 // connect a MOSFET to power on and off your A6/7 module
+  #elif defined(ESP32)
+    #define _2G_TX_PIN 16 //D16 to A6 RX,
+    #define _2G_RX_PIN 17 //D17 to A6 TX
+    #define _2G_PWR_PIN 5 // connect a MOSFET to power on and off your A6/7 module
+  #else
+    #define _2G_TX_PIN 6  //D6 to A6 RX,
+    #define _2G_RX_PIN 7  //D7 to A6 TX
+    #define _2G_PWR_PIN 5 // connect a MOSFET to power on and off your A6/7 module
+  #endif
 #endif
 
 #endif

--- a/main/config_2G.h
+++ b/main/config_2G.h
@@ -42,7 +42,6 @@ extern void MQTTto2G(char *topicOri, JsonObject &SMSdata);
 #define _2G_MAX_SIGNAL 1000
 
 /*-------------------PIN DEFINITIONS----------------------*/
-
 #if !defined(_2G_TX_PIN) || !defined(_2G_RX_PIN) || !defined(_2G_PWR_PIN)
   #ifdef ESP8266
     #define _2G_TX_PIN D6  //D6 to A6 RX,

--- a/main/config_ADC.h
+++ b/main/config_ADC.h
@@ -31,10 +31,18 @@ extern void ADCtoMQTT();
 /*----------------------------USER PARAMETERS-----------------------------*/
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 #define ADCTOPIC  "/ADCtoMQTT"
-#define TimeBetweenReadingADC 500 // time between 2 ADC readings, minimum 200 to let the time of the ESP to keep the connection
-#define ThresholdReadingADC 50  //  following the comparison between the previous value and the current one +- the threshold the value will be published or not
+
+#if !defined(TimeBetweenReadingADC) || (TimeBetweenReadingADC < 200)
+  #define TimeBetweenReadingADC 500 // time between 2 ADC readings, minimum 200 to let the time of the ESP to keep the connection
+#endif
+
+#ifndef ThresholdReadingADC
+  #define ThresholdReadingADC 50  //  following the comparison between the previous value and the current one +- the threshold the value will be published or not
+#endif
 
 /*-------------------PIN DEFINITIONS----------------------*/
-#define ADC_PIN A0 //on nodeMCU this is D3 GPIO0
+#if defined(ESP8266) || !defined(ADC_PIN)
+  #define ADC_PIN A0 //on nodeMCU this is D3 GPIO0
+#endif
 
 #endif

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -48,7 +48,7 @@ extern void MQTTtoBT(char * topicOri, JsonObject& RFdata);
 #endif
 
 #ifndef pubBLEManufacturerData
-  #define pubBLEManufacturerData true // comment if you don't want to publish the manufacturer's data (in case data has characters that aren't valid with receiving client)
+  #define pubBLEManufacturerData false // define true if you want to publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
 #endif
 
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -39,7 +39,10 @@ extern void MQTTtoBT(char * topicOri, JsonObject& RFdata);
 //#define HM-11 // uncomment this line if you use HM-11 and comment the line above
 //#define HM_BLUE_LED_STOP true //uncomment to stop the blue led light of HM1X
 #define BLEdelimiter "4f4b2b444953413a"
-#define pubBLEServiceData true // comment if you don't want to publish service data (in case you are having too heavy service data) https://github.com/1technophile/OpenMQTTGateway/issues/318#issuecomment-446064707
+
+#ifndef pubBLEServiceData
+  #define pubBLEServiceData true // comment if you don't want to publish service data (in case you are having too heavy service data) https://github.com/1technophile/OpenMQTTGateway/issues/318#issuecomment-446064707
+#endif
 
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/
 // if not commented Home presence integration with HOME ASSISTANT is activated
@@ -68,15 +71,17 @@ struct decompose{
 };
      
 /*-------------------PIN DEFINITIONS----------------------*/
-#ifdef ESP8266
-  #define BT_RX 13 //D7 ESP8266 RX connect HM-10 or 11 TX
-  #define BT_TX 12 //D6 ESP8266 TX connect HM-10 or 11 RX
-#elif defined(ESP32)
-  #define BT_RX 18 // not tested
-  #define BT_TX 19 // not tested
-#else
-  #define BT_RX 5 //arduino RX connect HM-10 or 11 TX
-  #define BT_TX 6 //arduino TX connect HM-10 or 11 RX
+#if !defined(BT_RX) || !defined(BT_TX)
+  #ifdef ESP8266
+    #define BT_RX 13 //D7 ESP8266 RX connect HM-10 or 11 TX
+    #define BT_TX 12 //D6 ESP8266 TX connect HM-10 or 11 RX
+  #elif defined(ESP32)
+    #define BT_RX 18 // not tested
+    #define BT_TX 19 // not tested
+  #else
+    #define BT_RX 5 //arduino RX connect HM-10 or 11 TX
+    #define BT_TX 6 //arduino TX connect HM-10 or 11 RX
+  #endif
 #endif
 
 #endif

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -32,7 +32,6 @@ extern void MQTTtoBT(char * topicOri, JsonObject& RFdata);
 /*----------------------BT topics & parameters-------------------------*/
 #define subjectBTtoMQTT  "/BTtoMQTT"
 #define subjectMQTTtoBTset  "/commands/MQTTtoBT/config"
-#define TimeBtw_Read 55555 //define default time between 2 scans
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -90 will not be reported
 #define Scan_duration 10 //define the time for a scan --WARNING-- changing this value can lead to instability on ESP32
 #define HM-10
@@ -40,8 +39,16 @@ extern void MQTTtoBT(char * topicOri, JsonObject& RFdata);
 //#define HM_BLUE_LED_STOP true //uncomment to stop the blue led light of HM1X
 #define BLEdelimiter "4f4b2b444953413a"
 
+#ifndef TimeBtw_Read
+  #define TimeBtw_Read 55555 //define default time between 2 scans
+#endif
+
 #ifndef pubBLEServiceData
   #define pubBLEServiceData true // comment if you don't want to publish service data (in case you are having too heavy service data) https://github.com/1technophile/OpenMQTTGateway/issues/318#issuecomment-446064707
+#endif
+
+#ifndef pubBLEManufacturerData
+  #define pubBLEManufacturerData true // comment if you don't want to publish the manufacturer's data (in case data has characters that aren't valid with receiving client)
 #endif
 
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/

--- a/main/config_DHT.h
+++ b/main/config_DHT.h
@@ -38,12 +38,15 @@ extern void DHTtoMQTT();
 //#define DHT_SENSOR_TYPE DHT21 //uncomment for DHT21 Sensor
 #define DHT_SENSOR_TYPE DHT22 //uncomment for DHT22 Sensor (default for backwards compatibility)
 /*-------------------PIN DEFINITIONS----------------------*/
-#if defined(ESP8266)
-  #define DHT_RECEIVER_PIN 5 //5 = D1 you can put 14 = D5 if you don't use HCSR501 sensor and the RFM69
-#elif defined(ESP32)
-  #define DHT_RECEIVER_PIN 16
-#else
-  #define DHT_RECEIVER_PIN 8
+
+#ifndef DHT_RECEIVER_PIN
+  #if defined(ESP8266)
+    #define DHT_RECEIVER_PIN 5 //5 = D1 you can put 14 = D5 if you don't use HCSR501 sensor and the RFM69
+  #elif defined(ESP32)
+    #define DHT_RECEIVER_PIN 16
+  #else
+    #define DHT_RECEIVER_PIN 8
+  #endif
 #endif
 
 #endif

--- a/main/config_DHT.h
+++ b/main/config_DHT.h
@@ -38,7 +38,6 @@ extern void DHTtoMQTT();
 //#define DHT_SENSOR_TYPE DHT21 //uncomment for DHT21 Sensor
 #define DHT_SENSOR_TYPE DHT22 //uncomment for DHT22 Sensor (default for backwards compatibility)
 /*-------------------PIN DEFINITIONS----------------------*/
-
 #ifndef DHT_RECEIVER_PIN
   #if defined(ESP8266)
     #define DHT_RECEIVER_PIN 5 //5 = D1 you can put 14 = D5 if you don't use HCSR501 sensor and the RFM69

--- a/main/config_DS1820.h
+++ b/main/config_DS1820.h
@@ -35,16 +35,21 @@ extern void DS1820toMQTT();
 #define DS1820_ALWAYS  true // if false only published current temperature if has changed from previous reading
 #define DS1820_INTERVAL_SEC 60 // time between DS1820 readings (seconds)
 #define DS1820_RESOLUTION  10  // conversion times: 9 bit (93.75 ms), 10 bit (187.5 ms), 11 bit (375 ms), 12 bit (750 ms)
-#define DS1820_FAHRENHEIT  false // defaults to Celcius
+#ifndef DS1820_FAHRENHEIT
+  #define DS1820_FAHRENHEIT  false // defaults to Celcius
+#endif
 #define DS1820_DETAILS  true // publish extented info for each sensor (resolution, address, type)
 #define DS1820_CONV_TIME  2000  // trigger conversion before requesting temperature readings (ms)
 /*-------------------PIN DEFINITIONS----------------------*/
-#if defined(ESP8266)
-  #define DS1820_OWBUS_PIN 2
-#elif defined(ESP32)
-  #define DS1820_OWBUS_PIN 2
-#else
-  #define DS1820_OWBUS_PIN 2
+
+#ifndef DS1820_OWBUS_PIN
+  #if defined(ESP8266)
+    #define DS1820_OWBUS_PIN 2
+  #elif defined(ESP32)
+    #define DS1820_OWBUS_PIN 2
+  #else
+    #define DS1820_OWBUS_PIN 2
+  #endif
 #endif
 
 #endif

--- a/main/config_FASTLED.h
+++ b/main/config_FASTLED.h
@@ -21,6 +21,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef config_FASTLED_h
+#define config_FASTLED_h
+
 /*-------------------FASTLED topics & parameters----------------------*/
 //FASTLED MQTT Subjects
 #define subjectMQTTtoFASTLED "/commands/MQTTtoFASTLED"
@@ -67,14 +70,6 @@
 //#define CLOCK_PIN 13
 
 #ifdef ESP8266
-
-#elif ESP32
-
-#else
-
-#endif
-
-#ifdef ESP8266
 //#define FASTLED_ESP8266_RAW_PIN_ORDER
 //#define FASTLED_ESP8266_NODEMCU_PIN_ORDER
 #define FASTLED_ESP8266_D1_PIN_ORDER
@@ -86,4 +81,6 @@
 #else
 #define FASTLED_DATA_PIN 10
 #define FASTLED_CLOCK_PIN 13
+#endif
+
 #endif

--- a/main/config_HCSR501.h
+++ b/main/config_HCSR501.h
@@ -32,15 +32,19 @@ extern void HCSR501toMQTT();
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 #define subjectHCSR501toMQTT    "/HCSR501toMQTT"
 
-#define TimeBeforeStartHCSR501 60000 //define the time necessary for HC SR501 init
+#ifndef TimeBeforeStartHCSR501
+  #define TimeBeforeStartHCSR501 60000 //define the time necessary for HC SR501 init
+#endif
 
 /*-------------------PIN DEFINITIONS----------------------*/
-#if defined(ESP8266) 
-  #define HCSR501_PIN D5
-#elif defined(ESP32)
-  #define HCSR501_PIN 5
-#else
-  #define HCSR501_PIN 7
+#ifndef HCSR501_PIN
+  #if defined(ESP8266) 
+    #define HCSR501_PIN D5
+  #elif defined(ESP32)
+    #define HCSR501_PIN 5
+  #else
+    #define HCSR501_PIN 7
+  #endif
 #endif
 
 #endif

--- a/main/config_HTU21.h
+++ b/main/config_HTU21.h
@@ -49,8 +49,10 @@ extern void HTU21toMQTT();
 #define HTUTOPIC   "/CLIMAtoMQTT/htu"
 
 #if defined(ESP32)
-  #define I2C_SDA 16
-  #define I2C_SCL 0
+  #if !defined(I2C_SDA) || !defined(I2C_SCL)
+    #define I2C_SDA 16
+    #define I2C_SCL 0
+  #endif
 #endif
 
 #endif


### PR DESCRIPTION
As mentioned in Issue #595, I've added #ifndef's to several sensors. 

For sensors that require multiple pins, I have it set so the user must specify all required pins in the platformio.ini file. (i.e. For the BT module, the user can't specify the TX pin and use the default RX pin. They must specify both RX and TX pins.)
I did this to force the user to keep all the definitions together, but they can be separated if needed.

If you see any other fields that would benefit from being assigned in the platformio.ini file (like the 2G BAUD rate), let me know and I can add them.