### PR TITLE
Concat OMG's Short Name to each sensor name

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -82,7 +82,11 @@ void createDiscovery(char *sensor_type,
   strcat(state_topic, st_topic);
   sensor.set("stat_t", state_topic); //state_topic
 
-  sensor.set("name", s_name);       //name
+  String grouped_s_name = String(Gateway_Short_Name);
+  grouped_s_name.concat('_');
+  grouped_s_name.concat(s_name);
+
+  sensor.set("name", grouped_s_name);       //name
   sensor.set("uniq_id", unique_id); //unique_id
   if (device_class[0])
     sensor.set("dev_cla", device_class); //device_class

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -82,9 +82,7 @@ void createDiscovery(char *sensor_type,
   strcat(state_topic, st_topic);
   sensor.set("stat_t", state_topic); //state_topic
 
-  String grouped_s_name = String(Gateway_Short_Name);
-  grouped_s_name.concat('_');
-  grouped_s_name.concat(s_name);
+  String grouped_s_name = String(Gateway_Short_Name) + "_" + String(s_name);
 
   sensor.set("name", grouped_s_name);       //name
   sensor.set("uniq_id", unique_id); //unique_id


### PR DESCRIPTION
The Gateway_Short_Name is added as a prefix to each sensor name in ZmqttDiscovery so that they are grouped/searchable within Home Assistant. ( Brought up in Issue #599 )

I'm not sure if using the String concat is the most efficient method to do this, but as the method is only run once per sensor per boot, it shouldn't cause issues or slowdown.