### PR TITLE
HTU21.begin bug fix

### DIFF
--- a/main/ZsensorHTU21.ino
+++ b/main/ZsensorHTU21.ino
@@ -58,8 +58,8 @@ void setupZsensorHTU21()
   Wire.begin(I2C_SDA, I2C_SCL);
   htuSensor.begin(Wire);
 #else
-#endif
   htuSensor.begin();
+#endif
 }
 
 void MeasureTempHum()


### PR DESCRIPTION
I found that I had an error in my HTU21 sensor code.
I didn't have the begin() statement inside of the #else directive for non-ESP32 devices.