### PR TITLE
Remove duplicate Weatherstation library definition from platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -93,7 +93,6 @@ dallastemperature = DallasTemperature
 m5stickc = M5StickC@0.2.0
 m5stack = M5Stack@0.3.0
 smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.3.5
-weatherstationrx = WeatherStationDataRx@0.3.3
 
 [env]
 framework = arduino
@@ -183,7 +182,7 @@ lib_deps =
   ${libraries.fastled}
   ${libraries.onewire}
   ${libraries.dallastemperature}
-  ${libraries.weatherstationrx}
+  ${libraries.rfWeatherStation}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
@@ -377,7 +376,7 @@ lib_deps =
   ${libraries.fastled}
   ${libraries.onewire}
   ${libraries.dallastemperature}
-  ${libraries.weatherstationrx}
+  ${libraries.rfWeatherStation}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
@@ -595,6 +594,7 @@ lib_deps =
   ${libraries.fastled}
   ${libraries.onewire}
   ${libraries.dallastemperature}
+  ${libraries.rfWeatherStation}
 build_flags =
   ${com-arduino.build_flags}
   '-DZgatewayRF="RF"'
@@ -614,6 +614,7 @@ build_flags =
   '-DZsensorDHT="DHT"'
   '-DZsensorDS1820="DS1820"'
   '-DZgatewayRFM69="RFM69"'
+  '-DZgatewayWeatherStation="WeatherStation"'
   '-DZsensorGPIOInput="GPIOInput"'
   ;'-DZsensorGPIOKeyCode="GPIOKeyCode"'
   '-DZmqttDiscovery="HADiscovery"'


### PR DESCRIPTION
@Alomon31 from Issue #591 noticed that the WeatherStation library was already in the Platformio.ini file, so my entry was a duplicate. I removed my entry and changed the *-all definitions to use the sensor author's version.
There are also definitions for ATMega to use this library, so I added it to the [env:atmega-all] block.