### PR TITLE
Ds1820 HADiscovery

### DIFF
--- a/docs/use/sensors.md
+++ b/docs/use/sensors.md
@@ -20,3 +20,13 @@ You will receive the HTU21 sensor readings every TimeBetweenReadinghtu21 (set in
 `home/OpenMQTTGateway/CLIMAtoMQTT/htu {"tempc":25.34064,"tempf":77.61314,"hum":56.53052}`
 
 If you don't want to resend values that haven't changed you can set htu21_always = false in config_HTU21.h
+
+### DS18x20
+You will receive the DS18x20 sensor readings every DS1820_INTERVAL_SEC (set into config_DS1820.h) (60s by default).
+Each sensor will be published under the following topic using each sensors' address.
+
+`home/OpenMQTTGateway/CLIMAtoMQTT/ds1820/0x0000000000000000 {"temp":27.8,"unit":"C","type":"DS18B20","res":"12bit\n","addr":"0x28616411907650bc"}`
+
+The units for temperature readings are sent in Celcius by default can be changed to ferenheight by setting DS1820_FAHRENHEIT = true in in config_DS1820.h
+
+If you don't want to resend values that haven't changed you can set DS1820_ALWAYS = false in config_DS1820.h

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -324,6 +324,7 @@ void pubMqttDiscovery()
 #endif
 
 #ifdef ZsensorDS1820
+  // Publish any DS1820 sensors found on the OneWire bus
   pubOneWire_HADiscovery();
 #endif
 

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -323,6 +323,10 @@ void pubMqttDiscovery()
   }
 #endif
 
+#ifdef ZsensorDS1820
+  pubOneWire_HADiscovery();
+#endif
+
 #ifdef ZactuatorONOFF
   Log.trace(F("actuatorONOFFDiscovery" CR));
   char *actuatorONOFF[8] = {"switch", "actuatorONOFF", "", "", "", "{\"cmd\":1}", "{\"cmd\":0}", ""};

--- a/main/ZsensorDS1820.ino
+++ b/main/ZsensorDS1820.ino
@@ -41,7 +41,7 @@ static String ds1820_addr[OW_MAX_SENSORS];
 
 void setupZsensorDS1820()
 {
-  Log.notice(F("DS1820: configured pin: %d for 1-wire bus" CR), DS1820_OWBUS_PIN );
+  Log.trace(F("DS1820: configured pin: %d for 1-wire bus" CR), DS1820_OWBUS_PIN );
   ds1820.begin();
 
   // locate device(s) on 1-wire bus

--- a/main/ZsensorDS1820.ino
+++ b/main/ZsensorDS1820.ino
@@ -51,7 +51,7 @@ void setupZsensorDS1820()
   Log.notice(F("DS1820: Found %d devices" CR), numDevicesOnBus);
 
   // Cycle though all of the devices on the OneWire bus
-  for (int deviceIndex = 0; deviceIndex < numDevicesOnBus; deviceIndex++)
+  for (int deviceIndex = 0; deviceIndex < numDevicesOnBus && ds1820_count < OW_MAX_SENSORS; deviceIndex++)
   {
     // get the next device on the OneWire bus and confirm it is a sensor the library can handle (Dallas DS18X20 1-wire devices)
     if ( ds1820.getAddress(ds1820_address, deviceIndex) && ds1820.validFamily(ds1820_address) )

--- a/main/ZsensorDS1820.ino
+++ b/main/ZsensorDS1820.ino
@@ -44,11 +44,14 @@ void setupZsensorDS1820()
   Log.trace(F("DS1820: configured pin: %d for 1-wire bus" CR), DS1820_OWBUS_PIN );
   ds1820.begin();
 
+  // Search the OneWire bus for all devices
+  uint8_t numDevicesOnBus = ds1820.getDeviceCount();
+
   // locate device(s) on 1-wire bus
-  Log.notice(F("DS1820: Found %d devices" CR), ds1820.getDeviceCount());
+  Log.notice(F("DS1820: Found %d devices" CR), numDevicesOnBus);
 
   // Cycle though all of the devices on the OneWire bus
-  for (int deviceIndex = 0; deviceIndex < ds1820.getDeviceCount(); deviceIndex++)
+  for (int deviceIndex = 0; deviceIndex < numDevicesOnBus; deviceIndex++)
   {
     // get the next device on the OneWire bus and confirm it is a sensor the library can handle (Dallas DS18X20 1-wire devices)
     if ( ds1820.getAddress(ds1820_address, deviceIndex) && ds1820.validFamily(ds1820_address) )

--- a/main/ZsensorDS1820.ino
+++ b/main/ZsensorDS1820.ino
@@ -41,66 +41,63 @@ static String ds1820_addr[OW_MAX_SENSORS];
 
 void setupZsensorDS1820()
 {
-  Log.trace(F("DS1820: configured pin: %d for 1-wire bus" CR), DS1820_OWBUS_PIN );
+  Log.notice(F("DS1820: configured pin: %d for 1-wire bus" CR), DS1820_OWBUS_PIN );
   ds1820.begin();
 
   // locate device(s) on 1-wire bus
   Log.notice(F("DS1820: Found %d devices" CR), ds1820.getDeviceCount());
 
-  // determine device addresses on 1-wire bus
-  if (owbus.search(ds1820_address)) 
+  // Cycle though all of the devices on the OneWire bus
+  for (int deviceIndex = 0; deviceIndex < ds1820.getDeviceCount(); deviceIndex++)
   {
-    do {
-      // we only care about Dallas DS18X20 1-wire devices
-      if (ds1820_address[0] == 0x10 || ds1820_address[0] == 0x28 || 
-          ds1820_address[0] == 0x22 || ds1820_address[0] == 0x3B) 
+    // get the next device on the OneWire bus and confirm it is a sensor the library can handle (Dallas DS18X20 1-wire devices)
+    if ( ds1820.getAddress(ds1820_address, deviceIndex) && ds1820.validFamily(ds1820_address) )
+    {
+      ds1820_addr[ds1820_count] = String("0x");
+      for (uint8_t i = 0; i < 8; i++)
+      {  
+        if (ds1820_address[i] < 0x10) ds1820_addr[ds1820_count] += String("0");
+        ds1820_devices[ds1820_count][i] = ds1820_address[i];
+        ds1820_addr[ds1820_count] += String(ds1820_address[i], HEX);
+      }          
+      
+      // set the resolution and thus conversion timing
+      if (ds1820_address[0] == 0x10) 
       {
-        ds1820_addr[ds1820_count] = String("0x");
-        for (uint8_t i = 0; i < 8; i++)
-        {  
-          if (ds1820_address[i] < 0x10) ds1820_addr[ds1820_count] += String("0");
-          ds1820_devices[ds1820_count][i] = ds1820_address[i];
-          ds1820_addr[ds1820_count] += String(ds1820_address[i], HEX);
-        }          
-        
-        // set the resolution and thus conversion timing
-        if (ds1820_address[0] == 0x10) 
-        {
-          // DS1820/DS18S20 have no resolution configuration register,
-          // both have a 9-bit temperature register. Resolutions greater 
-          // than 9-bit can be calculated using the data from the temperature, 
-          // and COUNT REMAIN and COUNT PER °C registers in the scratchpad.
-          // The resolution of the calculation depends on the model.
-          ds1820_type[ds1820_count] = String("DS1820/DS18S20"); 
-        } 
-        else if (ds1820_address[0] == 0x28) 
-        {
-          // DS18B20 and 18B22 are capable of different resolutions (9-12 bit)
-          ds1820_type[ds1820_count] = String("DS18B20");
-          ds1820.setResolution(ds1820_address, DS1820_RESOLUTION);
-        } 
-        else if (ds1820_address[0] == 0x22)
-        {
-          ds1820_type[ds1820_count] = String("DS1822");
-          ds1820.setResolution(ds1820_address, DS1820_RESOLUTION);
-        } 
-        else 
-        {
-          ds1820_type[ds1820_count] = String("DS1825");
-          ds1820.setResolution(ds1820_address, DS1820_RESOLUTION);
-        }  
-        ds1820_resolution[ds1820_count] = ds1820.getResolution(ds1820_address);
-        Log.trace(F("DS1820: Device %d, Type: %s, Address: %s, Resolution: %d" CR),
-          ds1820_count,
-          (char *)ds1820_type[ds1820_count].c_str(),
-          (char *)ds1820_addr[ds1820_count].c_str(),
-          ds1820_resolution[ds1820_count]);
-        ds1820_count++;
-      }       
-    } while (owbus.search(ds1820_address));
-    
-  } 
-  else
+        // DS1820/DS18S20 have no resolution configuration register,
+        // both have a 9-bit temperature register. Resolutions greater 
+        // than 9-bit can be calculated using the data from the temperature, 
+        // and COUNT REMAIN and COUNT PER °C registers in the scratchpad.
+        // The resolution of the calculation depends on the model.
+        ds1820_type[ds1820_count] = String("DS1820/DS18S20"); 
+      } 
+      else if (ds1820_address[0] == 0x28) 
+      {
+        // DS18B20 and 18B22 are capable of different resolutions (9-12 bit)
+        ds1820_type[ds1820_count] = String("DS18B20");
+        ds1820.setResolution(ds1820_address, DS1820_RESOLUTION);
+      } 
+      else if (ds1820_address[0] == 0x22)
+      {
+        ds1820_type[ds1820_count] = String("DS1822");
+        ds1820.setResolution(ds1820_address, DS1820_RESOLUTION);
+      } 
+      else 
+      {
+        ds1820_type[ds1820_count] = String("DS1825");
+        ds1820.setResolution(ds1820_address, DS1820_RESOLUTION);
+      } 
+      ds1820_resolution[ds1820_count] = ds1820.getResolution(ds1820_address);
+      Log.trace(F("DS1820: Device %d, Type: %s, Address: %s, Resolution: %d" CR),
+        ds1820_count,
+        (char *)ds1820_type[ds1820_count].c_str(),
+        (char *)ds1820_addr[ds1820_count].c_str(),
+        ds1820_resolution[ds1820_count]);
+      ds1820_count++;
+    }
+  }
+  
+  if (ds1820.getDS18Count() == 0)
   {  
     Log.error(F("DS1820: Failed to enumerate sensors on 1-wire bus. Check your pin assignment!" CR));
   }

--- a/main/config_DS1820.h
+++ b/main/config_DS1820.h
@@ -28,6 +28,7 @@
 
 extern void setupZsensorDS1820();
 extern void DS1820toMQTT();
+extern void pubOneWire_HADiscovery();
 /*----------------------------USER PARAMETERS-----------------------------*/
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 #define OW_TOPIC    "/OneWiretoMQTT/ds1820"

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -77,7 +77,7 @@ extern void createDiscovery(char * sensor_type,
 #define jsonFer       "{{ value_json.fer | is_defined }}"
 #define jsonMoi       "{{ value_json.moi | is_defined }}"
 #define jsonHum       "{{ value_json.hum | is_defined }}"
-#define jsonTemp      "{{ value_json.tem | is_defined }}"
+#define jsonTemp      "{{ value_json.temp | is_defined }}"
 #define jsonStep      "{{ value_json.steps | is_defined }}"
 #define jsonWeight    "{{ value_json.weight | is_defined }}"
 #define jsonPresence  "{{ value_json.presence | is_defined }}"

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -77,7 +77,7 @@ extern void createDiscovery(char * sensor_type,
 #define jsonFer       "{{ value_json.fer | is_defined }}"
 #define jsonMoi       "{{ value_json.moi | is_defined }}"
 #define jsonHum       "{{ value_json.hum | is_defined }}"
-#define jsonTemp      "{{ value_json.temp | is_defined }}"
+#define jsonTemp      "{{ value_json.tem | is_defined }}"
 #define jsonStep      "{{ value_json.steps | is_defined }}"
 #define jsonWeight    "{{ value_json.weight | is_defined }}"
 #define jsonPresence  "{{ value_json.presence | is_defined }}"


### PR DESCRIPTION
Pull Request in response to Issue #598 ; to add HADiscovery for DS18b20 1-Wire sensors

@1technophile 
   Looking at the source code and through testing with hardware, I was only able to get 1 sensor at a time to work using the original ZsensorDS1820 code. As it looks as the intention was to allow up to 8 sensors by default, I've modified the following:

-    I changed setupZsensorDS1820 to use the DallasTemperature library to scan the 1-Wire bus and validate that the sensor is a valid DS1820 sensor that can be used instead of using the OneWire library directly.
-    I changed the DS1820 MQTT topic so that all sensors are published as a sub-topic of the DS1820 topic, using their device address as the topic name.
-    Added function to publish the HADiscovery config for each DS1820 device found. This is called during the normal 'pubMqttDiscovery()' call from the main loop() function on the first WiFi connect.