### PR TITLE
Automatically set mqtt buffer size

### DIFF
--- a/docs/upload/arduino-ide.md
+++ b/docs/upload/arduino-ide.md
@@ -6,16 +6,6 @@
 * Download OpenMQTTGateway code (OpenMQTTGateway_sources.zip) from the [release page](https://github.com/1technophile/OpenMQTTGateway/releases) and unzip it
 * Download the libraries package corresponding to your board and module wished into the same page (example esp32-m5stick-c-ble-libraries.zip)
 * Unzip the libraries into your arduino libraries folder (example D:/Users/XXXX/Documents/Arduino/libraries)
-* If you are using an ESP, Mega or other powerfull board; Open the *PubSubClient* folder, open the file src/PubSubClient.h, replace 
-```C++
-#define MQTT_MAX_PACKET_SIZE 128
-```
-by
-```C++
-#define MQTT_MAX_PACKET_SIZE 1024
-```
-This modification will enable to send and receive by MQTT long json messages.
-
 * If necessary replace the spaces into each library folder by _: example rename “ESP32 BLE Arduino” folder to “ESP32_BLE_Arduino”
 * Open the file main.ino from OpenMQTTGateway/main folder with the arduino IDE
 * Change the settings and the desired gateways into user_config.h (uncomment the modules you want)

--- a/docs/upload/troubleshoot.md
+++ b/docs/upload/troubleshoot.md
@@ -46,10 +46,8 @@ Exception (2):
 → You are not using the last update of ESP8266 into board manager, go to your Arduino IDE and update it, should be at least 2.3.0
 
 ## You don't see the messages appearing on your broker but they appears on the serial monitor
-This is due to a too small mqtt packet size, open pubsubclient.h from pubsubclient library and set:
-try to modify in pubsubclient.h:
-`#define MQTT_MAX_PACKET_SIZE 1024`
-The other option is to use the [pubsubclient library](https://github.com/1technophile/OpenMQTTGateway/tree/master/lib/pubsubclient) provided in the OMG repository folder.
+This is due to a too small mqtt packet size, open User_config.h and set:
+`#define mqtt_max_packet_size 1024`
 
 ## Your Arduino with w5100 Ethernet shield does not connect to network until you press Reset button
 If you notice that your Arduino with w5100 Ethernet shield does not connect to network until you press its Reset button, but connects fine if you connect the Arduino with a USB cable to a computer/laptop with Arduino IDE running and open Serial Monitor, the problem is most likely the Ethernet shield and/or the power supply you're using.

--- a/docs/use/ir.md
+++ b/docs/use/ir.md
@@ -104,14 +104,12 @@ mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoIR -m '{"raw":"8850,4450,60
 With big raw array you may cross the limit of default payload size. In this case the gateway will not receive the message or will not send it to the broker.
 In this case the best way is to use hex values instead, but if you can't you may change the parameters below:
 In user_config.h replace:
-`#define JSON_MSG_BUFFER 512`
+`# define JSON_MSG_BUFFER 512`
+`# define mqtt_max_packet_size 1024
 by
-`#define JSON_MSG_BUFFER 1280`
+`# define JSON_MSG_BUFFER 1280`
+`# define mqtt_max_packet_size 1280`
 
-And into platformio.ini
-`MQTT_MAX_PACKET_SIZE=1024`
-by
-`MQTT_MAX_PACKET_SIZE=1280`
 
 ## Repeat the IR signal OpenMQTTGateway receive
 So as to repeat the IR signal received by the gateway once set the following parameter to true in [config_IR.h](https://github.com/1technophile/OpenMQTTGateway/blob/091b317660fd201a30e2cd0e15424a13c5a6bd71/config_IR.h#L37)

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -99,9 +99,11 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
 #  define parameters_size     20
 #  define mqtt_topic_max_size 100
+#  define mqtt_max_packet_size 1024
 #else
 #  define parameters_size     15
 #  define mqtt_topic_max_size 50
+#  define mqtt_max_packet_size 128
 #endif
 char mqtt_user[parameters_size] = "your_username"; // not compulsory only if your broker needs authentication
 char mqtt_pass[parameters_size] = "your_password"; // not compulsory only if your broker needs authentication

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -97,12 +97,12 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 //MQTT Parameters definition
 //#define mqtt_server_name "www.mqtt_broker.com" // instead of defining the server by its IP you can define it by its name, uncomment this line and set the correct MQTT server host name
 #if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
-#  define parameters_size     20
-#  define mqtt_topic_max_size 100
+#  define parameters_size      20
+#  define mqtt_topic_max_size  100
 #  define mqtt_max_packet_size 1024
 #else
-#  define parameters_size     15
-#  define mqtt_topic_max_size 50
+#  define parameters_size      15
+#  define mqtt_topic_max_size  50
 #  define mqtt_max_packet_size 128
 #endif
 char mqtt_user[parameters_size] = "your_username"; // not compulsory only if your broker needs authentication

--- a/main/main.ino
+++ b/main/main.ino
@@ -605,11 +605,7 @@ void setup() {
 #ifdef ZsensorDHT
   setupDHT();
 #endif
-  Log.trace(F("MQTT_MAX_PACKET_SIZE: %d" CR), MQTT_MAX_PACKET_SIZE);
-#if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
-  if (MQTT_MAX_PACKET_SIZE == 128)
-    Log.error(F("WRONG PUBSUBCLIENT LIBRARY USED PLEASE INSTALL THE ONE FROM RELEASE PAGE" CR));
-#endif
+  Log.trace(F("mqtt_max_packet_size: %d" CR), mqtt_max_packet_size);
   Log.notice(F("Setup OpenMQTTGateway end" CR));
 }
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -401,6 +401,7 @@ void connectMQTT() {
   char topic[mqtt_topic_max_size];
   strcpy(topic, mqtt_topic);
   strcat(topic, will_Topic);
+  client.setBufferSize(mqtt_max_packet_size);
   if (client.connect(gateway_name, mqtt_user, mqtt_pass, topic, will_QoS, will_Retain, will_Message)) {
 #if defined(ZboardM5STICKC) || defined(ZboardM5STACK)
     if (low_power_mode < 2)

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,7 +118,6 @@ lib_deps =
   ${libraries.wifimanager}
 build_flags =
   ${env.build_flags}
-  -DMQTT_MAX_PACKET_SIZE=1024
   '-DsimpleReceiving=true'
   '-DZmqttDiscovery="HADiscovery"'
   '-DTRACE=1'
@@ -130,7 +129,6 @@ lib_deps =
   ${libraries.ethernet}
 build_flags =
   ${env.build_flags}
-  -DMQTT_MAX_PACKET_SIZE=1024
   '-DsimpleReceiving=true'
   '-DZmqttDiscovery="HADiscovery"'
   '-DTRACE=1'
@@ -141,7 +139,6 @@ lib_deps =
   ${libraries.ethernet}
 build_flags =
   ${env.build_flags}
-  -DMQTT_MAX_PACKET_SIZE=128
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                 ENVIRONMENTS LIST                                    ;

--- a/test/Test_config.h
+++ b/test/Test_config.h
@@ -93,6 +93,7 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 //#define mqtt_server_name "www.mqtt_broker.com" // instead of defining the server by its IP you can define it by its name, uncomment this line and set the correct MQTT server host name
 #define parameters_size     20
 #define mqtt_topic_max_size 100
+#define mqtt_max_packet_size 128
 char mqtt_user[parameters_size] = "your_username"; // not compulsory only if your broker needs authentication
 char mqtt_pass[parameters_size] = "your_password"; // not compulsory only if your broker needs authentication
 char mqtt_server[parameters_size] = "192.168.1.17";

--- a/test/Test_config.h
+++ b/test/Test_config.h
@@ -91,8 +91,8 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 //MQTT Parameters definition
 //#define mqtt_server_name "www.mqtt_broker.com" // instead of defining the server by its IP you can define it by its name, uncomment this line and set the correct MQTT server host name
-#define parameters_size     20
-#define mqtt_topic_max_size 100
+#define parameters_size      20
+#define mqtt_topic_max_size  100
 #define mqtt_max_packet_size 128
 char mqtt_user[parameters_size] = "your_username"; // not compulsory only if your broker needs authentication
 char mqtt_pass[parameters_size] = "your_password"; // not compulsory only if your broker needs authentication


### PR DESCRIPTION
Thank you for creating (and maintaining!) this fantastic project!

I happened to notice that current versions of `pubsubclient` allow the buffer size to be set
dynamically: https://github.com/knolleary/pubsubclient/pull/282

We can take advantage of this to avoid having to modify one of the
dependencies and instead automatically increase the buffer size when a
powerful board is detected.

It also reduces a step in the documentation.

My first PR to an Arduino project so let me know if I'm doing something
wrong! 😅 🙏 

I suppose this would mean changing the version of the library that is bundled with the
project (`PubSubClient_ID89`?) as well, but I'm not sure how to go about doing so...? 🙇


