### PR TITLE
fixed wrong string type after refactoring

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -521,7 +521,7 @@ void setup() {
   IPAddress mqtt_server_ip;
   WiFi.hostByName(mqtt_server_name, mqtt_server_ip);
   client.setServer(mqtt_server_ip, port);
-  Log.trace(F("Mqtt server connection by host name: %s" CR), mqtt_server_ip.toString());
+  Log.trace(F("Mqtt server connection by host name: %s" CR), mqtt_server_ip.toString().c_str());
 #  else // if not by its IP adress
   client.setServer(mqtt_server, port);
   Log.trace(F("Mqtt server connection by IP: %s" CR), mqtt_server);


### PR DESCRIPTION
the `.c_str()` is missing in one log call when using mqtt server host name instead of ip.

introduced in #546