### PR TITLE
Fix ESPWifiManualSetup / Move MQTT variables

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -305,6 +305,6 @@ uint8_t wifiProtocol = 0; // default mode, automatic selection
 #define subjectMQTTtoSYSset          "/commands/MQTTtoSYS/config"
 
 /*-------------------DEFINE LOG LEVEL----------------------*/
-#define LOG_LEVEL LOG_LEVEL_TRACE
+#define LOG_LEVEL LOG_LEVEL_NOTICE
 
 #endif

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -105,12 +105,11 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #  define mqtt_topic_max_size  50
 #  define mqtt_max_packet_size 128
 #endif
-char mqtt_user[parameters_size] = "your_username"; // not compulsory only if your broker needs authentication
-char mqtt_pass[parameters_size] = "your_password"; // not compulsory only if your broker needs authentication
-char mqtt_server[parameters_size] = "192.168.1.17";
-char mqtt_port[6] = "1883";
-char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
-char gateway_name[parameters_size * 2] = Gateway_Name;
+
+#define MQTT_USER_DEFAULT "your_username"
+#define MQTT_PASS_DEFAULT "your_password"
+#define MQTT_MQTT_DEFAULT "192.168.1.17"
+#define MQTT_PORT_DEFAULT "1883"
 
 #if defined(ESP8266) || defined(ESP32)
 #  define ATTEMPTS_BEFORE_BG 10 // Number of wifi connection attempts before going to BG protocol

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -84,7 +84,6 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #  endif
 #endif
 
-
 #define WifiManager_password            "your_password" //this is going to be the WPA2-PSK password for the initial setup access point
 #define WifiManager_ssid                Gateway_Name //this is the network name of the initial setup access point
 #define WifiManager_ConfigPortalTimeOut 120

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -76,9 +76,14 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #endif
 
 #if defined(ESPWifiManualSetup) // for nodemcu, weemos and esp8266
-#  define wifi_ssid     "wifi ssid"
-#  define wifi_password "wifi password"
+#  ifndef wifi_ssid
+#    define wifi_ssid    "wifi ssid"
+#  endif
+#  ifndef wifi_password
+#    define wifi_password "wifi password"
+#  endif
 #endif
+
 
 #define WifiManager_password            "your_password" //this is going to be the WPA2-PSK password for the initial setup access point
 #define WifiManager_ssid                Gateway_Name //this is the network name of the initial setup access point
@@ -106,10 +111,18 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #  define mqtt_max_packet_size 128
 #endif
 
-#define MQTT_USER_DEFAULT "your_username"
-#define MQTT_PASS_DEFAULT "your_password"
-#define MQTT_MQTT_DEFAULT "192.168.1.17"
-#define MQTT_PORT_DEFAULT "1883"
+#ifndef MQTT_USER_DEFAULT
+#  define MQTT_USER_DEFAULT "your_username"
+#endif
+#ifndef MQTT_PASS_DEFAULT
+#  define MQTT_PASS_DEFAULT "your_password"
+#endif
+#ifndef MQTT_MQTT_DEFAULT
+#  define MQTT_MQTT_DEFAULT "192.168.1.17"
+#endif
+#ifndef MQTT_PORT_DEFAULT
+#  define MQTT_PORT_DEFAULT "1883"
+#endif
 
 #if defined(ESP8266) || defined(ESP32)
 #  define ATTEMPTS_BEFORE_BG 10 // Number of wifi connection attempts before going to BG protocol
@@ -293,6 +306,6 @@ uint8_t wifiProtocol = 0; // default mode, automatic selection
 #define subjectMQTTtoSYSset          "/commands/MQTTtoSYS/config"
 
 /*-------------------DEFINE LOG LEVEL----------------------*/
-#define LOG_LEVEL LOG_LEVEL_NOTICE
+#define LOG_LEVEL LOG_LEVEL_TRACE
 
 #endif

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -77,7 +77,7 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 
 #if defined(ESPWifiManualSetup) // for nodemcu, weemos and esp8266
 #  ifndef wifi_ssid
-#    define wifi_ssid    "wifi ssid"
+#    define wifi_ssid "wifi ssid"
 #  endif
 #  ifndef wifi_password
 #    define wifi_password "wifi password"

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -99,7 +99,6 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 //MQTT Parameters definition
-//#define mqtt_server_name "www.mqtt_broker.com" // instead of defining the server by its IP you can define it by its name, uncomment this line and set the correct MQTT server host name
 #if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
 #  define parameters_size      20
 #  define mqtt_topic_max_size  100
@@ -110,17 +109,17 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #  define mqtt_max_packet_size 128
 #endif
 
-#ifndef MQTT_USER_DEFAULT
-#  define MQTT_USER_DEFAULT "your_username"
+#ifndef MQTT_USER
+#  define MQTT_USER "your_username"
 #endif
-#ifndef MQTT_PASS_DEFAULT
-#  define MQTT_PASS_DEFAULT "your_password"
+#ifndef MQTT_PASS
+#  define MQTT_PASS "your_password"
 #endif
-#ifndef MQTT_MQTT_DEFAULT
-#  define MQTT_MQTT_DEFAULT "192.168.1.17"
+#ifndef MQTT_SERVER
+#  define MQTT_SERVER "192.168.1.17"
 #endif
-#ifndef MQTT_PORT_DEFAULT
-#  define MQTT_PORT_DEFAULT "1883"
+#ifndef MQTT_PORT
+#  define MQTT_PORT "1883"
 #endif
 
 #if defined(ESP8266) || defined(ESP32)

--- a/main/main.ino
+++ b/main/main.ino
@@ -134,8 +134,8 @@ unsigned long timer_sys_measures = 0;
 void callback(char* topic, byte* payload, unsigned int length);
 
 #ifdef ESPWifiManualSetup
-  char manual_wifi_ssid[] = wifi_ssid;
-  char manual_wifi_password[] = wifi_password;
+char manual_wifi_ssid[] = wifi_ssid;
+char manual_wifi_password[] = wifi_password;
 #endif
 
 char mqtt_user[parameters_size] = MQTT_USER_DEFAULT; // not compulsory only if your broker needs authentication

--- a/main/main.ino
+++ b/main/main.ino
@@ -134,15 +134,15 @@ unsigned long timer_sys_measures = 0;
 void callback(char* topic, byte* payload, unsigned int length);
 
 #ifdef ESPWifiManualSetup
-  char manual_wifi_ssid[]     = wifi_ssid;
+  char manual_wifi_ssid[] = wifi_ssid;
   char manual_wifi_password[] = wifi_password;
 #endif
 
-char mqtt_user[parameters_size]        = MQTT_USER_DEFAULT; // not compulsory only if your broker needs authentication
-char mqtt_pass[parameters_size]        = MQTT_PASS_DEFAULT; // not compulsory only if your broker needs authentication
-char mqtt_server[parameters_size]      = MQTT_MQTT_DEFAULT;
-char mqtt_port[6]                      = MQTT_PORT_DEFAULT;
-char mqtt_topic[mqtt_topic_max_size]   = Base_Topic;
+char mqtt_user[parameters_size] = MQTT_USER_DEFAULT; // not compulsory only if your broker needs authentication
+char mqtt_pass[parameters_size] = MQTT_PASS_DEFAULT; // not compulsory only if your broker needs authentication
+char mqtt_server[parameters_size] = MQTT_MQTT_DEFAULT;
+char mqtt_port[6] = MQTT_PORT_DEFAULT;
+char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
 char gateway_name[parameters_size * 2] = Gateway_Name;
 
 bool connectedOnce = false; //indicate if we have been connected once to MQTT

--- a/main/main.ino
+++ b/main/main.ino
@@ -133,15 +133,10 @@ unsigned long timer_sys_measures = 0;
 //adding this to bypass the problem of the arduino builder issue 50
 void callback(char* topic, byte* payload, unsigned int length);
 
-#ifdef ESPWifiManualSetup
-char manual_wifi_ssid[] = wifi_ssid;
-char manual_wifi_password[] = wifi_password;
-#endif
-
-char mqtt_user[parameters_size] = MQTT_USER_DEFAULT; // not compulsory only if your broker needs authentication
-char mqtt_pass[parameters_size] = MQTT_PASS_DEFAULT; // not compulsory only if your broker needs authentication
-char mqtt_server[parameters_size] = MQTT_MQTT_DEFAULT;
-char mqtt_port[6] = MQTT_PORT_DEFAULT;
+char mqtt_user[parameters_size] = MQTT_USER; // not compulsory only if your broker needs authentication
+char mqtt_pass[parameters_size] = MQTT_PASS; // not compulsory only if your broker needs authentication
+char mqtt_server[parameters_size] = MQTT_SERVER;
+char mqtt_port[6] = MQTT_PORT;
 char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
 char gateway_name[parameters_size * 2] = Gateway_Name;
 
@@ -548,13 +543,8 @@ void setup() {
   long port;
   port = strtol(mqtt_port, NULL, 10);
   Log.trace(F("Port: %l" CR), port);
-#  ifdef mqtt_server_name // if name is defined we define the mqtt server by its name
-  client.setServer(mqtt_server_name, port);
-  Log.trace(F("Mqtt server connection by host name: %s" CR), mqtt_server_name);
-#  else // if not by its IP adress
   client.setServer(mqtt_server, port);
-  Log.trace(F("Mqtt server connection by IP: %s" CR), mqtt_server);
-#  endif
+  Log.trace(F("Mqtt server: %s" CR), mqtt_server);
 #endif
 
   setup_parameters();
@@ -773,6 +763,10 @@ void setOTA() {
 
 #if defined(ESPWifiManualSetup)
 void setup_wifi() {
+
+  char manual_wifi_ssid[] = wifi_ssid;
+  char manual_wifi_password[] = wifi_password;
+
   delay(10);
   WiFi.mode(WIFI_STA);
   if (wifiProtocol) forceWifiProtocol();

--- a/main/main.ino
+++ b/main/main.ino
@@ -763,7 +763,6 @@ void setOTA() {
 
 #if defined(ESPWifiManualSetup)
 void setup_wifi() {
-
   char manual_wifi_ssid[] = wifi_ssid;
   char manual_wifi_password[] = wifi_password;
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -133,11 +133,16 @@ unsigned long timer_sys_measures = 0;
 //adding this to bypass the problem of the arduino builder issue 50
 void callback(char* topic, byte* payload, unsigned int length);
 
-char mqtt_user[parameters_size] = MQTT_USER_DEFAULT; // not compulsory only if your broker needs authentication
-char mqtt_pass[parameters_size] = MQTT_PASS_DEFAULT; // not compulsory only if your broker needs authentication
-char mqtt_server[parameters_size] = MQTT_MQTT_DEFAULT;
-char mqtt_port[6] = MQTT_PORT_DEFAULT;
-char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
+#ifdef ESPWifiManualSetup
+  char manual_wifi_ssid[]     = wifi_ssid;
+  char manual_wifi_password[] = wifi_password;
+#endif
+
+char mqtt_user[parameters_size]        = MQTT_USER_DEFAULT; // not compulsory only if your broker needs authentication
+char mqtt_pass[parameters_size]        = MQTT_PASS_DEFAULT; // not compulsory only if your broker needs authentication
+char mqtt_server[parameters_size]      = MQTT_MQTT_DEFAULT;
+char mqtt_port[6]                      = MQTT_PORT_DEFAULT;
+char mqtt_topic[mqtt_topic_max_size]   = Base_Topic;
 char gateway_name[parameters_size * 2] = Gateway_Name;
 
 bool connectedOnce = false; //indicate if we have been connected once to MQTT
@@ -773,7 +778,7 @@ void setup_wifi() {
   if (wifiProtocol) forceWifiProtocol();
 
   // We start by connecting to a WiFi network
-  Log.trace(F("Connecting to %s" CR), wifi_ssid);
+  Log.trace(F("Connecting to %s" CR), manual_wifi_ssid);
 #  ifdef ESPWifiAdvancedSetup
   IPAddress ip_adress(ip);
   IPAddress gateway_adress(gateway);
@@ -782,9 +787,9 @@ void setup_wifi() {
   if (!WiFi.config(ip_adress, gateway_adress, subnet_adress, dns_adress)) {
     Log.error(F("Wifi STA Failed to configure" CR));
   }
-  WiFi.begin(wifi_ssid, wifi_password);
+  WiFi.begin(manual_wifi_ssid, manual_wifi_password);
 #  else
-  WiFi.begin(wifi_ssid, wifi_password);
+  WiFi.begin(manual_wifi_ssid, manual_wifi_password);
 #  endif
 
   if (wifi_reconnect_bypass())

--- a/main/main.ino
+++ b/main/main.ino
@@ -133,6 +133,13 @@ unsigned long timer_sys_measures = 0;
 //adding this to bypass the problem of the arduino builder issue 50
 void callback(char* topic, byte* payload, unsigned int length);
 
+char mqtt_user[parameters_size] = MQTT_USER_DEFAULT; // not compulsory only if your broker needs authentication
+char mqtt_pass[parameters_size] = MQTT_PASS_DEFAULT; // not compulsory only if your broker needs authentication
+char mqtt_server[parameters_size] = MQTT_MQTT_DEFAULT;
+char mqtt_port[6] = MQTT_PORT_DEFAULT;
+char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
+char gateway_name[parameters_size * 2] = Gateway_Name;
+
 bool connectedOnce = false; //indicate if we have been connected once to MQTT
 int failure_number_ntwk = 0; // number of failure connecting to network
 int failure_number_mqtt = 0; // number of failure connecting to MQTT

--- a/test/Test_config.h
+++ b/test/Test_config.h
@@ -75,7 +75,7 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 
 #if defined(ESPWifiManualSetup) // for nodemcu, weemos and esp8266
 #  ifndef wifi_ssid
-#    define wifi_ssid    "wifi ssid"
+#    define wifi_ssid "wifi ssid"
 #  endif
 #  ifndef wifi_password
 #    define wifi_password "wifi password"

--- a/test/Test_config.h
+++ b/test/Test_config.h
@@ -94,22 +94,21 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 //MQTT Parameters definition
-//#define mqtt_server_name "www.mqtt_broker.com" // instead of defining the server by its IP you can define it by its name, uncomment this line and set the correct MQTT server host name
 #define parameters_size      20
 #define mqtt_topic_max_size  100
 #define mqtt_max_packet_size 128
 
-#ifndef MQTT_USER_DEFAULT
-#  define MQTT_USER_DEFAULT "your_username"
+#ifndef MQTT_USER
+#  define MQTT_USER "your_username"
 #endif
-#ifndef MQTT_PASS_DEFAULT
-#  define MQTT_PASS_DEFAULT "your_password"
+#ifndef MQTT_PASS
+#  define MQTT_PASS "your_password"
 #endif
-#ifndef MQTT_MQTT_DEFAULT
-#  define MQTT_MQTT_DEFAULT "192.168.1.17"
+#ifndef MQTT_SERVER
+#  define MQTT_SERVER "192.168.1.17"
 #endif
-#ifndef MQTT_PORT_DEFAULT
-#  define MQTT_PORT_DEFAULT "1883"
+#ifndef MQTT_PORT
+#  define MQTT_PORT "1883"
 #endif
 
 #define version_Topic           "/version"

--- a/test/Test_config.h
+++ b/test/Test_config.h
@@ -74,8 +74,12 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #endif
 
 #if defined(ESPWifiManualSetup) // for nodemcu, weemos and esp8266
-#  define wifi_ssid     "wifi ssid"
-#  define wifi_password "wifi password"
+#  ifndef wifi_ssid
+#    define wifi_ssid    "wifi ssid"
+#  endif
+#  ifndef wifi_password
+#    define wifi_password "wifi password"
+#  endif
 #endif
 
 #define WifiManager_password            "your_password" //this is going to be the WPA2-PSK password for the initial setup access point
@@ -94,12 +98,19 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #define parameters_size      20
 #define mqtt_topic_max_size  100
 #define mqtt_max_packet_size 128
-char mqtt_user[parameters_size] = "your_username"; // not compulsory only if your broker needs authentication
-char mqtt_pass[parameters_size] = "your_password"; // not compulsory only if your broker needs authentication
-char mqtt_server[parameters_size] = "192.168.1.17";
-char mqtt_port[6] = "1883";
-char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
-char gateway_name[parameters_size * 2] = Gateway_Name;
+
+#ifndef MQTT_USER_DEFAULT
+#  define MQTT_USER_DEFAULT "your_username"
+#endif
+#ifndef MQTT_PASS_DEFAULT
+#  define MQTT_PASS_DEFAULT "your_password"
+#endif
+#ifndef MQTT_MQTT_DEFAULT
+#  define MQTT_MQTT_DEFAULT "192.168.1.17"
+#endif
+#ifndef MQTT_PORT_DEFAULT
+#  define MQTT_PORT_DEFAULT "1883"
+#endif
 
 #define version_Topic           "/version"
 #define will_Topic              "/LWT"


### PR DESCRIPTION
I think I started to hit the limit of available RAM in my esp8266's, so I tried setting up ESPWifiManualSetup to save a few Kb's.
In doing so, I found that it wasn't working as expected... or at all.

In the User_config.h `wifi_ssid` and `wifi_password` are set using `#define`, where the `Wifi.begin()` function requires a char[]. An error wasn't being thrown during compile or at runtime in the Serial monitor, but WiFi never connects.

I left the #define's in `User_config.h`, just adding checks to see if they're already set, so they can be set via platformio.ini, and added 2 char[] variables in `main.ino` and assigned them the `User_config.h` values. Doing it this way seemed the least disruptive to users

------

I've also moved the MQTT config variables from the `User_config.h` file into the `main.ino` file and added `#define` values to replace the original default values. This will allow users to set the values in the `platformio.ini` file for easier custom/advanced builds.