### PR TITLE
[Breaking Change] Change HCSR501 MQTT key to 'presence'

### DIFF
--- a/docs/integrate/home_assistant.md
+++ b/docs/integrate/home_assistant.md
@@ -71,7 +71,7 @@ binary_sensor:
         name: "Bewegung_Schlafzimmer"
         #device_class: motion
         state_topic: "home/OpenMQTTGateway1/HCSR501toMQTT"
-        value_template: '{{ value_json["hcsr501"] }}'
+        value_template: '{{ value_json["presence"] }}'
         payload_on: "true"
         payload_off: "false"
 ```

--- a/docs/use/sensors.md
+++ b/docs/use/sensors.md
@@ -47,7 +47,7 @@ If you don't want to resend values that haven't changed you can set DS1820_ALWAY
 ### HCSR501
 A boolean value of the PIR sensors state is sent when a state change occurs. The length of time that the PIR stays in a triggered state depends on the PIR hardware and is not changed by OpenMQTTGateway.
 
-`home/OpenMQTTGateway/HCSR501toMQTT {"hcsr501":"false"}`
+`home/OpenMQTTGateway/HCSR501toMQTT {"presence":"false"}`
 
 You can have another PIN mirror the value of the PIR sensor output by adding the following to config_HCSR501.h
 This can be useful if you would like to connect an LED to turn on when motion is detected.

--- a/main/ZsensorHCSR501.ino
+++ b/main/ZsensorHCSR501.ino
@@ -52,13 +52,13 @@ void MeasureHCSR501() {
     if (PresenceValue == HIGH) {
       if (pirState == LOW) {
         //turned on
-        HCSR501data.set("hcsr501", "true");
+        HCSR501data.set("presence", "true");
         pirState = HIGH;
       }
     } else {
       if (pirState == HIGH) {
         // turned off
-        HCSR501data.set("hcsr501", "false");
+        HCSR501data.set("presence", "false");
         pirState = LOW;
       }
     }


### PR DESCRIPTION
@1technophile ,
  As discussed in issue #690, I've changed the key used for the HCSR501 PIR sensor to be 'presence'. This will fix MQTTDiscovery, but will break users who manually have the sensor setup in HA.

  Please let me know if I've missed any other doc locations.