### PR TITLE
Prevent storing duplicate RF/IT signals

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -94,7 +94,8 @@ void RFtoMQTT() {
       RFtoMQTTdiscovery(MQTTvalue);
 #  endif
       pub(subjectRFtoMQTT, RFdata);
-      Log.trace(F("Store val: %lu" CR), MQTTvalue);
+      // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's 
+      Log.trace(F("Store val: %u" CR), (unsigned long)MQTTvalue);
       storeSignalValue(MQTTvalue);
       if (repeatRFwMQTT) {
         Log.trace(F("Pub RF for rpt" CR));

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -94,7 +94,7 @@ void RFtoMQTT() {
       RFtoMQTTdiscovery(MQTTvalue);
 #  endif
       pub(subjectRFtoMQTT, RFdata);
-      // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's 
+      // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's
       Log.trace(F("Store val: %u" CR), (unsigned long)MQTTvalue);
       storeSignalValue(MQTTvalue);
       if (repeatRFwMQTT) {

--- a/main/main.ino
+++ b/main/main.ino
@@ -1413,7 +1413,7 @@ void receivingMQTT(char* topicOri, char* datacallback) {
   JsonObject& jsondata = jsonBuffer.parseObject(datacallback);
 
 #if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
-  if (strstr(topicOri, subjectMultiGTWKey) != NULL) { // storing received value so as to avoid publishing this value if it has been already sent by this or another OpenMQTTGateway 
+  if (strstr(topicOri, subjectMultiGTWKey) != NULL) { // storing received value so as to avoid publishing this value if it has been already sent by this or another OpenMQTTGateway
     SIGNAL_SIZE_UL_ULL data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
     if (data != 0 && !isAduplicateSignal(data)) {
       storeSignalValue(data);

--- a/main/main.ino
+++ b/main/main.ino
@@ -1413,9 +1413,11 @@ void receivingMQTT(char* topicOri, char* datacallback) {
   JsonObject& jsondata = jsonBuffer.parseObject(datacallback);
 
 #if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
-  SIGNAL_SIZE_UL_ULL data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
-  if (data != 0 && !isAduplicateSignal(data)) {
-    storeSignalValue(data);
+  if (strstr(topicOri, subjectMultiGTWKey) != NULL) { // storing received value so as to avoid publishing this value if it has been already sent by this or another OpenMQTTGateway 
+    SIGNAL_SIZE_UL_ULL data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
+    if (data != 0 && !isAduplicateSignal(data)) {
+      storeSignalValue(data);
+    }
   }
 #endif
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -1366,10 +1366,12 @@ void storeSignalValue(SIGNAL_SIZE_UL_ULL MQTTvalue) {
   // replace it by the new one
   receivedSignal[o].value = MQTTvalue;
   receivedSignal[o].time = now;
-  Log.trace(F("store code : %u / %u" CR), receivedSignal[o].value, receivedSignal[o].time);
+  
+  // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's 
+  Log.trace(F("store code : %u / %u" CR), (unsigned long)receivedSignal[o].value, receivedSignal[o].time);
   Log.trace(F("Col: val/timestamp" CR));
   for (int i = 0; i < struct_size; i++) {
-    Log.trace(F("mem code : %u / %u" CR), receivedSignal[i].value, receivedSignal[i].time);
+    Log.trace(F("mem code : %u / %u" CR), (unsigned long)receivedSignal[i].value, receivedSignal[i].time);
   }
 }
 
@@ -1379,7 +1381,7 @@ void storeSignalValue(SIGNAL_SIZE_UL_ULL MQTTvalue) {
 int getMin() {
   unsigned int minimum = receivedSignal[0].time;
   int minindex = 0;
-  for (int i = 0; i < struct_size; i++) {
+  for (int i = 1; i < struct_size; i++) {
     if (receivedSignal[i].time < minimum) {
       minimum = receivedSignal[i].time;
       minindex = i;
@@ -1411,8 +1413,7 @@ void receivingMQTT(char* topicOri, char* datacallback) {
   JsonObject& jsondata = jsonBuffer.parseObject(datacallback);
 
 #if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
-    SIGNAL_SIZE_UL_ULL data = 0;
-    data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
+    SIGNAL_SIZE_UL_ULL data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
     if (data != 0 && !isAduplicateSignal(data)) {
       storeSignalValue(data);
     }

--- a/main/main.ino
+++ b/main/main.ino
@@ -1410,16 +1410,13 @@ void receivingMQTT(char* topicOri, char* datacallback) {
   StaticJsonBuffer<JSON_MSG_BUFFER> jsonBuffer;
   JsonObject& jsondata = jsonBuffer.parseObject(datacallback);
 
-  if (strstr(topicOri, subjectMultiGTWKey) != NULL) // storing received value so as to avoid publishing this value if it has been already sent by this or another OpenMQTTGateway
-  {
 #if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
     SIGNAL_SIZE_UL_ULL data = 0;
     data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
-    if (data != 0) {
+    if (data != 0 && !isAduplicateSignal(data)) {
       storeSignalValue(data);
     }
 #endif
-  }
 
   if (jsondata.success()) { // json object ok -> json decoding
     // log the received json

--- a/main/main.ino
+++ b/main/main.ino
@@ -1366,8 +1366,8 @@ void storeSignalValue(SIGNAL_SIZE_UL_ULL MQTTvalue) {
   // replace it by the new one
   receivedSignal[o].value = MQTTvalue;
   receivedSignal[o].time = now;
-  
-  // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's 
+
+  // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's
   Log.trace(F("store code : %u / %u" CR), (unsigned long)receivedSignal[o].value, receivedSignal[o].time);
   Log.trace(F("Col: val/timestamp" CR));
   for (int i = 0; i < struct_size; i++) {
@@ -1413,10 +1413,10 @@ void receivingMQTT(char* topicOri, char* datacallback) {
   JsonObject& jsondata = jsonBuffer.parseObject(datacallback);
 
 #if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
-    SIGNAL_SIZE_UL_ULL data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
-    if (data != 0 && !isAduplicateSignal(data)) {
-      storeSignalValue(data);
-    }
+  SIGNAL_SIZE_UL_ULL data = jsondata.success() ? jsondata["value"] : STRTO_UL_ULL(datacallback, NULL, 10);
+  if (data != 0 && !isAduplicateSignal(data)) {
+    storeSignalValue(data);
+  }
 #endif
 
   if (jsondata.success()) { // json object ok -> json decoding


### PR DESCRIPTION
As discussed in issue #715, this will check for duplicate RF/IR signals before storing them in the `receivedSignal` array. This will have a slight performance impact, but should be unnoticeable.


I've also:
- removed a redundant `if` statement from the `receivingMQTT` function
- in the `getMin` function, started the loop on index 1 as index 0 is always the first minimum (no need to check against itself)
- cast the SIGNAL_SIZE_UL_ULL values to a (unsigned long) for Log.trace functions in some functions (uint64_t values aren't supported by the ArduinoLog library)