### PR TITLE
Enable BT use for Arduino Mega

### DIFF
--- a/docs/prerequisites/board.md
+++ b/docs/prerequisites/board.md
@@ -29,12 +29,16 @@ The boards below doesn't need hardware modification (or a lite one).
 The boards below need hardware modifications and electronic/hardware competencies. You have more possibilities of gateways combination compared to off the shelves ones.
 |DIY boards|RF|IR|BLE|LORA|GSM|Button|Relay|
 |-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-|Arduino UNO|X|X(limited compared to ESP)|X|-|X|X|
+|Arduino UNO|X|X(limited compared to ESP)|-|-|X|X|
 |Arduino MEGA|X|X(limited compared to ESP)|X|-|-|X|X|
 |ESP32|X|X|X|X|not tested|X|X|
 |ESP8266|X|X|X|not tested|X|X|X|
 
-*Note that Pilight is only supported on ESP and Arduino UNO handle only 32bits values in our context.*
+::: INFO
+Pilight is only supported on ESP, Arduino UNO handle only 32bits values in our context.
+Setup based on HM10 doesn't support some BLE [devices](devices.md#for-ble-devices).
+:::
+*Note that *
 
 ![boards](../img/OpenMQTTGateway_boards.png)
 

--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -21,15 +21,18 @@ OpenMQTTGateway is able to scan all the BLE devices that advertise their data so
 | XIAOMI Mi Flora |HHCCJCY01HHCC|temperature/moisture/luminance/fertility|
 | XIAOMI Mi Jia |LYWSDCGO|temperature/humidity/battery|
 | XIAOMI Mi Lamp |MUE4094RT|presence|
-| INKBIRD |IBS-TH1|temperature/humidity/battery|
+| INKBIRD *|IBS-TH1|temperature/humidity/battery|
 | ClearGrass |CGG1|temperature/humidity/battery|
 | ClearGrass alarm clock|CGD1|temperature/humidity|
 | ClearGrass with atmospheric pressure |CGP1W|temperature/humidity/air pressure|
 | Clock |LYWDS02|temperature/humidity|
-| XIAOMI Mi Scale v1|XMTZC04HM|weight|
-| XIAOMI Mi Scale v2|XMTZC05HM|weight|
-| XIAOMI Mi band ||steps|
+| XIAOMI Mi Scale v1 *|XMTZC04HM|weight|
+| XIAOMI Mi Scale v2 *|XMTZC05HM|weight|
+| XIAOMI Mi band * ||steps|
 
+::: INFO
+(*)Not supported with HM10.
+:::
 
 ![boards](../img/OpenMQTTGateway_devices_ble.png ':size=250%')
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -42,6 +42,10 @@ FreeRTOS::Semaphore semaphoreCreateOrUpdateDevice = FreeRTOS::Semaphore("createO
 #    include <esp_wifi.h>
 #  endif
 
+#  if !defined(ESP32) && !defined(ESP8266)
+#    include <ArduinoSTL.h>
+#  endif
+
 #  include <vector>
 using namespace std;
 vector<BLEdevice> devices;

--- a/platformio.ini
+++ b/platformio.ini
@@ -99,6 +99,7 @@ dallastemperature = DallasTemperature
 m5stickc = M5StickC@0.2.0
 m5stack = M5Stack@0.3.0
 smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.3.5
+stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
 
 [env]
 framework = arduino
@@ -654,13 +655,14 @@ lib_deps =
   ${libraries.onewire}
   ${libraries.dallastemperature}
   ${libraries.rfWeatherStation}
+  ${libraries.stl}
 build_flags =
   ${com-arduino.build_flags}
   '-DZgatewayRF="RF"'
   '-DZgatewayRF="RF315"'
   '-DZgatewayRF2="RF2"'
   '-DZgatewayIR="IR"'
-  ;'-DZgatewayBT="BT"'
+  '-DZgatewayBT="BT"'
   '-DZactuatorONOFF="ONOFF"'
   '-DZactuatorFASTLED="FASTLED"'
   '-DZsensorINA226="INA226"'


### PR DESCRIPTION
by adding a ArduinoSTL library,
currently the vector function is missing for Arduino AVR boards.