### PR TITLE
[breaking] Refactor the BLE devices identification

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -60,17 +60,17 @@ OpenMQTTGateway publish the servicedata field of your BLE devices, with HM10 thi
 ## Setting a white or black list
 A black list is a list of mac adresses that will never be published by OMG
 to set black list
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"black-list":["012314551615","4C6577889C79","4C65A6663C79"]}'`
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"black-list":["01:23:14:55:16:15","4C:65:77:88:9C:79","4C:65:A6:66:3C:79"]}'`
 
 A white list is a list of mac adresses permitted to be published by OMG
 to set white list
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["012314551615","4C65A5553C79","4C65A6663C79"]}'`
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["01:23:14:55:16:15","4C:65:77:88:9C:79","4C:65:A6:66:3C:79"]}'`
 
 Note: if you want to filter (white or black list) on BLE sensors that are auto discovered, you need to wait for the discovery before applying the white or black list
 
 ::: tip
 So as to keep your white/black list persistent you can publish it with the retain option of MQTT (-r with mosquitto_pub or retain check box of MQTT Explorer)
-`mosquitto_pub -r -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["012314551615","4C65A5553C79","4C65A6663C79"]}'`
+`mosquitto_pub -r -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["01:23:14:55:16:15","4C:65:77:88:9C:79","4C:65:A6:66:3C:79"]}'`
 :::
 
 ## Setting the time between scans and force a scan

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -45,6 +45,9 @@ extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
 #  define TimeBtw_Read 55555 //define default time between 2 scans
 #endif
 
+unsigned int BLEinterval = TimeBtw_Read; //time between 2 scans
+int Minrssi = MinimumRSSI; //minimum rssi value
+
 #ifndef pubKnownBLEServiceData
 #  define pubKnownBLEServiceData false // define true if you want to publish service data belonging to recognised sensors
 #endif
@@ -64,28 +67,6 @@ extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/
 // if not commented Home presence integration with HOME ASSISTANT is activated
 #define subjectHomePresence "home_presence/" // will send Home Assistant room presence message to this topic (first part is same for all rooms, second is room name)
-
-unsigned int BLEinterval = TimeBtw_Read; //time between 2 scans
-int Minrssi = MinimumRSSI; //minimum rssi value
-
-struct BLEdevice {
-  char macAdr[13];
-  bool isDisc;
-  bool isWhtL;
-  bool isBlkL;
-};
-
-#define device_flags_isDisc   1 << 0
-#define device_flags_isWhiteL 1 << 1
-#define device_flags_isBlackL 1 << 2
-
-struct decompose {
-  char subject[4];
-  int start;
-  int len;
-  bool reverse;
-  char extract[60];
-};
 
 /*-------------------PIN DEFINITIONS----------------------*/
 #if !defined(BT_RX) || !defined(BT_TX)

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -46,7 +46,6 @@ extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
 #endif
 
 unsigned int BLEinterval = TimeBtw_Read; //time between 2 scans
-int Minrssi = MinimumRSSI; //minimum rssi value
 
 #ifndef pubKnownBLEServiceData
 #  define pubKnownBLEServiceData false // define true if you want to publish service data belonging to recognised sensors


### PR DESCRIPTION
generalize the use of the mac address with : for the lists, white, black and internal identification
Move structures from config_BT.h to ZgatewayBT.ino
update doc

The goal is to align the vector array ids format with the one extracted from BLEscan