### PR TITLE
BLE Optimizations and buffer overflow fix

### DIFF
--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -39,6 +39,10 @@ extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
 //#define HM-11 // uncomment this line if you use HM-11 and comment the line above
 //#define HM_BLUE_LED_STOP true //uncomment to stop the blue led light of HM1X
 #define BLEdelimiter         "4f4b2b444953413a" // OK+DISA:
+#define BLEEndOfDiscovery    "4f4b2b4449534345" // OK+DISCE
+#define BLEdelimiterLength   16
+#define CRLR                 "0d0a"
+#define CRLR_Length          4
 #define ServicedataMinLength 29
 
 #ifndef TimeBtw_Read

--- a/main/main.ino
+++ b/main/main.ino
@@ -193,7 +193,7 @@ PubSubClient client(eClient);
 //MQTT last attemps reconnection date
 unsigned long lastMQTTReconnectAttempt = 0;
 
-void revert_hex_data(char* in, char* out, int l) {
+void revert_hex_data(const char* in, char* out, int l) {
   //reverting array 2 by 2 to get the data in good order
   int i = l - 2, j = 0;
   while (i != -2) {
@@ -207,24 +207,17 @@ void revert_hex_data(char* in, char* out, int l) {
   out[l - 1] = '\0';
 }
 
-void extract_char(char* token_char, char* subset, int start, int l, bool reverse, bool isNumber) {
-  char tmp_subset[l + 1];
-  memcpy(tmp_subset, &token_char[start], l);
-  tmp_subset[l] = '\0';
+void extract_char(const char* token_char, char* subset, int start, int l, bool reverse, bool isNumber) {
   if (isNumber) {
-    char tmp_subset2[l + 1];
     if (reverse)
-      revert_hex_data(tmp_subset, tmp_subset2, l + 1);
-    else
-      strncpy(tmp_subset2, tmp_subset, l + 1);
-    long long_value = strtoul(tmp_subset2, NULL, 16);
-    sprintf(tmp_subset2, "%ld", long_value);
-    strncpy(subset, tmp_subset2, l + 1);
+      revert_hex_data(token_char + start, subset, l + 1);
+    long long_value = strtoul(subset, NULL, 16);
+    sprintf(subset, "%ld", long_value);
   } else {
     if (reverse)
-      revert_hex_data(tmp_subset, subset, l + 1);
+      revert_hex_data(token_char + start, subset, l + 1);
     else
-      strncpy(subset, tmp_subset, l + 1);
+      strncpy(subset, token_char + start, l + 1);
   }
   subset[l] = '\0';
 }


### PR DESCRIPTION
For the past two weeks I have been investigating random crashes and sometime my OMG losing it's Gateway_Name after a random length of time. (Sometimes 5 minutes, others 3 hours.)
My first thoughts was that I was running out of RAM on my ESP8266 due to running BLE, RF, IR, BME280, PIR, and Analog. Long story short for all my testing, the heap and stack seem to be fine.

However, in the `BTtoMQTT()` method for ESP8266's, the length of the 'Rest Data' is never checked to be less than the decompose.extract[60] buffer. 
https://github.com/1technophile/OpenMQTTGateway/blob/519eb73deee87ae74ffcc48d31cccbf8eb36c83c/main/ZgatewayBT.ino#L607-L611

I believe that this buffer was being overflowed in the main.ino:`extract_char` function when 
https://github.com/1technophile/OpenMQTTGateway/blob/519eb73deee87ae74ffcc48d31cccbf8eb36c83c/main/main.ino#L227

I have been running two OMG's (both ESP8266) for 24hrs now without any resets, but would appreciate if someone else could test that I haven't messed up the MAC or Service Data parsing of the packets. (I don't have any Mi Flora or other devices that can be read by the HM-10.)

### Changes

- Instead of just adding a verification for the `rest data length`, I've updated the `BTtoMQTT` function to parse BLE devices as they are received by the HM-10 module, instead of waiting for the entire reply from the HM-10 discovery. This reduces the size of the `returnedString` String (from >800 to <300 on my tests).
This is accomplished by checking the received `returnString` for both the `BLEdelimiter` as the start of a BLE device and a `CR LR` ("0d0a") as the [end of a packet.](https://1technophile.blogspot.com/2017/11/mi-flora-integration-to-openmqttgateway.html)
The `returnedString` is cleared after every `TimeBtw_Read`.

- As I'm also reserving space for the `returnedString` (512 length) at setup, it should reduce HEAP fragmentation as the `returnedString` isn't being reallocated as it grows. (Unless it goes over 512.)

- Even though I rewrote the `extract_char` function to use pointer arithmetic instead of creating temporary arrays, I've removed calls to the `extract_char` function from the BLE gateway. Instead I'm sectioning the BLE packet using strings. This should reduce the HEAP by not needing the decompose.extract[60] for each section.

- I shifted the `decompose` start values by -16 as I'm removing the `BLEdelimiter` from the inspected BLE packet.

- Changed String concatenations to use `+=` as [I've read that it's more efficient](https://cpp4arduino.com/2018/11/21/eight-tips-to-use-the-string-class-efficiently.html#tip-5-mutate-a-string-instead-of-creating-temporaries).