### PR TITLE
Add publish only BLE sensors function

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -98,7 +98,15 @@ If you want to change the number of BLE scans that are done before a BLE connect
 
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"scanbcnct":30}'`
 
-The BLE connect will be done every 30 * (`TimeBtwRead` + `Scan_duration`), 30 * (55000 + 10000) = 1950000ms :
+The BLE connect will be done every 30 * (`TimeBtwRead` + `Scan_duration`), 30 * (55000 + 10000) = 1950000ms
+
+## Setting if the gateway publish all the BLE devices scanned or only the detected sensors
+
+If you want to change this characteristic:
+
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"onlysensors":true}'`
+
+The gateway will publish only the detected sensors like Mi Flora, Mi jia, LYWSD03MMC... and not the other BLE devices. This is usefull if you don't use the gateway for presence detection but only to retrieve sensors data.
 
 ## Setting the minimum RSSI accepted to publish device data
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -44,6 +44,9 @@ extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
 #ifndef TimeBtwRead
 #  define TimeBtwRead 55555 //define default time between 2 scans
 #endif
+#ifndef PublishOnlySensors
+#  define PublishOnlySensors false //true if we publish all BLE devices discovered or false only the identified sensors (like temperature sensors)
+#endif
 
 #define HMSerialSpeed 9600 // Communication speed with the HM module, softwareserial doesn't support 115200
 //#define HM_BLUE_LED_STOP true //uncomment to stop the blue led light of HM1X
@@ -58,6 +61,7 @@ extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
 
 unsigned int BLEinterval = TimeBtwRead; //time between 2 scans
 unsigned int BLEscanBeforeConnect = ScanBeforeConnect; //Number of BLE scans between connection cycles
+bool publishOnlySensors = PublishOnlySensors;
 
 #ifndef pubKnownBLEServiceData
 #  define pubKnownBLEServiceData false // define true if you want to publish service data belonging to recognised sensors


### PR DESCRIPTION
don't publish the non identified BLE devices when requested (at build or by MQTT setting)