### PR TITLE
 Autoreset option in case of not connection with the broker

### DIFF
--- a/docs/upload/portal.md
+++ b/docs/upload/portal.md
@@ -5,28 +5,33 @@ From your smartphone search for your OpenMQTTGateway wifi network and connect to
 
 ![Wifi manager menu](../img/OpenMQTTGateway_Wifi_Manager_menu.png)
 
-* Click on Configure WiFi
+- Click on Configure WiFi
 
 ![Wifi manager parameters](../img/OpenMQTTGateway_Wifi_Manager_enter_parameters.png)
 
-* Select your wifi
-* Set your wifi password
-* Set your MQTT Server IP
-* Set your MQTT Server username (facultative)
-* Set your MQTT Server password (facultative)
-* Set your MQTT base topic if you need to change it (you must keep the / at the end)
-* Set your gateway name if you need to change it
+- Select your wifi
+- Set your wifi password
+- Set your MQTT Server IP
+- Set your MQTT Server username (facultative)
+- Set your MQTT Server password (facultative)
+- Set your MQTT base topic if you need to change it (you must keep the / at the end)
+- Set your gateway name if you need to change it
 
-* Click on save
+- Click on save
 
 ![Wifi manager save](../img/OpenMQTTGateway_Wifi_Manager_save.png)
 
 The ESP restart and connect to your network. Note that your credentials are saved into the ESP memory, if you want to redo the configuration you have to erase the ESP memory with the flash download tool.
 
 Once done the gateway should connect to your network and your broker, you should see it into the broker in the form of the following messages:
+
 ```
-home/OpenMQTTGateway/LWT Online 
+home/OpenMQTTGateway/LWT Online
 home/OpenMQTTGateway/version
 ```
 
-Note that the web portal appears only on first boot, if you want to configure again the setting you can do a long press on TRIGGER_GPIO or [erase the settings](../use/gateway.md#erase-the-esp-settings).
+Note that the web portal appears only on first boot, if you want to configure again the setting you can:
+
+- [Erase the settings](../use/gateway.md#erase-the-esp-settings) if the device is already connected to the broker mqtt
+- Long press on TRIGGER_GPIO (please note that if you have ESP32 or ESP8266 you can configure it into `User_config.h` )
+- Wait the auto reset ( if it has been activated inside `User_config.h`, by default it is deactivated )

--- a/docs/use/boards.md
+++ b/docs/use/boards.md
@@ -6,14 +6,17 @@
 
 So as to erase the flash memory on ESP boards you may do a long press to TRIGGER_GPIO button or connect the pin to the ground.
 
+One more option is enable the autoreset option (check inside `User_config.h`). If this feature is enabled (as default is disabled) the board try to connect the mqtt broker as usual but in case of ripetute failure, the reset of configuration is performed and it return on the initial state.
+
 ### Low power mode for ESP32
+
 OpenMQTTGateway support a low power mode for ESP32, this mode can be set by MQTT on a barebone ESP32:
 
-* Normal mode (per default)
+- Normal mode (per default)
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoBT/config" -m '{"low_power_mode":0}'`
 
-* Low Power mode
+- Low Power mode
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoBT/config" -m '{"low_power_mode":2}'`
 
@@ -50,17 +53,18 @@ you can also revert it to the serial monitor:
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoM5/config -m '{"log-display":false}'`
 
 ### Low power mode for M5 boards
+
 OpenMQTTGateway support a low power mode for ESP32, this mode can be set by MQTT or a button on M5 boards:
 
-* Normal mode (per default), screen ON
+- Normal mode (per default), screen ON
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoBT/config" -m '{"low_power_mode":0}'`
 
-* Low Power mode, screen ON when processing only
+- Low Power mode, screen ON when processing only
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoBT/config" -m '{"low_power_mode":1}'`
 
-* Low Power mode, screen OFF, LED ON when processing on M5StickC
+- Low Power mode, screen OFF, LED ON when processing on M5StickC
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoBT/config" -m '{"low_power_mode":2}'`
 
@@ -69,6 +73,7 @@ The low power mode can be changed also with a push to button B when the board is
 ### Erasing the flash
 
 So as to erase the flash memory on M5Stack boards you may do a long press to TRIGGER_GPIO button:
-* Button B on M5StickC (GPIO 37)
-* Button C on M5Stack (GPIO 37)
-* Button lateral on M5stick (GPIO 35)
+
+- Button B on M5StickC (GPIO 37)
+- Button C on M5Stack (GPIO 37)
+- Button lateral on M5stick (GPIO 35)

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -327,7 +327,7 @@ uint8_t wifiProtocol = 0; // default mode, automatic selection
  * Remove the comment to this parameter if you want to enable the auto-reset 
  * of configurations that have exceeded the number of connection attempts
  */
-#  define AUTO_ERASING_ESP_CONFIG true
+//#  define AUTO_ERASING_ESP_CONFIG true
 #endif
 
 //      VCC   ------------D|-----------/\/\/\/\ -----------------  Arduino PIN

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -322,6 +322,14 @@ uint8_t wifiProtocol = 0; // default mode, automatic selection
 //#  define TRIGGER_GPIO 0 // boot button as full reset button (long press >10s)
 #endif
 
+#ifndef AUTO_ERASING_ESP_CONFIG
+/*
+ * Remove the comment to this parameter if you want to enable the auto-reset 
+ * of configurations that have exceeded the number of connection attempts
+ */
+#  define AUTO_ERASING_ESP_CONFIG true
+#endif
+
 //      VCC   ------------D|-----------/\/\/\/\ -----------------  Arduino PIN
 //                        LED       Resistor 270-510R
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -681,7 +681,20 @@ void disconnection_handling(int failure_number) {
   Log.warning(F("disconnection_handling, failed %d times" CR), failure_number);
   if ((failure_number > maxConnectionRetry) && !connectedOnce) {
 #  ifndef ESPWifiManualSetup
-    Log.error(F("Failed connecting 1st time to mqtt, you should put TRIGGER_GPIO to LOW or erase the flash" CR));
+#    if TRIGGER_GPIO
+    Log.error(F("Failed connecting mqtt broker, you should put TRIGGER_GPIO to LOW or erase the flash" CR));
+#    else
+#      if AUTO_ERASING_ESP_CONFIG
+    if (failure_number > (maxConnectionRetry + ATTEMPTS_BEFORE_BG + ATTEMPTS_BEFORE_B)) {
+      Log.error(F("Failed connecting mqtt broker, try to erase config and restart" CR));
+      eraseAndRestart();
+    } else {
+      Log.warning(F("Failed connecting mqtt broker, wait for %d more attempts before the autoreset" CR), (maxConnectionRetry + ATTEMPTS_BEFORE_BG + ATTEMPTS_BEFORE_B - failure_number));
+    }
+#      else
+    Log.error(F("Failed connecting mqtt broker, you should erase the flash" CR));
+#      endif
+#    endif
 #  endif
   }
   if (failure_number <= (maxConnectionRetry + ATTEMPTS_BEFORE_BG)) {


### PR DESCRIPTION
This is an proposal of improvement: auto reset of configuration if no broker is available.

The details:
- Autoreset in case of not connection with the mqtt broker
- Improved the information on terminal in order to provide information about the TRIGGER_GPIO or if it's configured or not the autoreset
- Provide the options to enable or disable this feature, as default is disabled.
- Updated the documentation

Tested on my device: ESP32 Development Board with CP2102
