### PR TITLE
Fix pilight value as subject

### DIFF
--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -47,6 +47,7 @@ void pilightCallback(const String& protocol, const String& message, int status,
     RFPiLightdata.set("message", msg);
     RFPiLightdata.set("protocol", (char*)protocol.c_str());
     RFPiLightdata.set("length", (char*)deviceID.c_str());
+    RFPiLightdata.set("value", (char*)deviceID.c_str());
     RFPiLightdata.set("repeats", (int)repeats);
     RFPiLightdata.set("status", (int)status);
     pub(subjectPilighttoMQTT, RFPiLightdata);

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -52,7 +52,7 @@ void pilightCallback(const String& protocol, const String& message, int status,
     if (!strlen(device_id)) {
       // deviceID returned from Pilight is only extracted from id field
       // but some device may use another name as unique identifier
-      char * choices[] = {"key", "unit", "systemcode", "unitcode", "programcode"};
+      char* choices[] = {"key", "unit", "systemcode", "unitcode", "programcode"};
 
       for (uint8_t i = 0; i < 5; i++) {
         if (msg[choices[i]]) {

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -47,7 +47,22 @@ void pilightCallback(const String& protocol, const String& message, int status,
     RFPiLightdata.set("message", msg);
     RFPiLightdata.set("protocol", (char*)protocol.c_str());
     RFPiLightdata.set("length", (char*)deviceID.c_str());
-    RFPiLightdata.set("value", (char*)deviceID.c_str());
+
+    const char* device_id = deviceID.c_str();
+    if (!strlen(device_id)) {
+      // deviceID returned from Pilight is only extracted from id field
+      // but some device may use another name as unique identifier
+      char * choices[] = {"key", "unit", "systemcode", "unitcode", "programcode"};
+
+      for (uint8_t i = 0; i < 5; i++) {
+        if (msg[choices[i]]) {
+          device_id = (const char*)msg[choices[i]];
+          break;
+        }
+      }
+    }
+
+    RFPiLightdata.set("value", device_id);
     RFPiLightdata.set("repeats", (int)repeats);
     RFPiLightdata.set("status", (int)status);
     pub(subjectPilighttoMQTT, RFPiLightdata);

--- a/main/main.ino
+++ b/main/main.ino
@@ -253,17 +253,17 @@ void pub(char* topicori, JsonObject& data) {
   if (client.connected()) {
     String topic = String(mqtt_topic) + String(topicori);
 #ifdef valueAsASubject
-#ifdef ZgatewayPilight
+#  ifdef ZgatewayPilight
     String value = data["value"];
     if (value != 0) {
       topic = topic + "/" + value;
     }
-#else
+#  else
     SIGNAL_SIZE_UL_ULL value = data["value"];
     if (value != 0) {
       topic = topic + "/" + String(value);
     }
-#endif
+#  endif
 #endif
 
 #ifdef jsonPublishing

--- a/main/main.ino
+++ b/main/main.ino
@@ -253,10 +253,17 @@ void pub(char* topicori, JsonObject& data) {
   if (client.connected()) {
     String topic = String(mqtt_topic) + String(topicori);
 #ifdef valueAsASubject
+#ifdef ZgatewayPilight
+    String value = data["value"];
+    if (value != 0) {
+      topic = topic + "/" + value;
+    }
+#else
     SIGNAL_SIZE_UL_ULL value = data["value"];
     if (value != 0) {
       topic = topic + "/" + String(value);
     }
+#endif
 #endif
 
 #ifdef jsonPublishing


### PR DESCRIPTION
Thank you for this project ;)

The Pilight gateway with the valueAsASubject parameter does not work (compilation problem).

This PR fixes this problem and closes the #408 ticket.

I also added a patch that allows to find a correct ID (in order to have a non null topic) because PiLight only reads ID and ignores the others fields.

One question, in the ZgatewayPilight.ino file, there are this line: `RFPiLightdata.set("length", (char*)deviceID.c_str());` is it normal to set the length value from the deviceID value?

Thank you.