### PR TITLE
Add LYWSD03MMC from ATC

### DIFF
--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -23,6 +23,7 @@ OpenMQTTGateway is able to scan all the BLE devices that advertise their data so
 | XIAOMI Mi Flora |HHCCJCY01HHCC|temperature/moisture/luminance/fertility|
 | XIAOMI Mi Jia |LYWSDCGO|temperature/humidity/battery|
 | XIAOMI Mi Jia 2 *|LYWSD03MMC|temperature/humidity/battery/volt|
+| XIAOMI Mi Jia 2 custom firmware **|LYWSD03MMC ATC|temperature/humidity/battery/volt|
 | XIAOMI MHO-C401 *|MHO-C401|temperature/humidity/battery/volt|
 | XIAOMI Mi Lamp |MUE4094RT|presence|
 | HONEYWELL |JQJCY01YM|formaldehyde/temperature/humidity/battery|
@@ -38,7 +39,8 @@ OpenMQTTGateway is able to scan all the BLE devices that advertise their data so
 Exhaustive list [here](https://compatible.openmqttgateway.com/index.php/devices/ble-devices/)
 
 ::: INFO
-(*)Not supported with HM10.
+(*) Not supported with HM10.
+(**) See https://github.com/atc1441/ATC_MiThermometer
 :::
 
 ![devices](../img/OpenMQTTGateway_devices_ble.png ':size=250%')

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -101,6 +101,7 @@ enum ble_sensor_model {
   INKBIRD,
   LYWSD03MMC,
   MHO_C401,
+  LYWSD03MMC_ATC,
 };
 
 /*-------------------PIN DEFINITIONS----------------------*/


### PR DESCRIPTION
https://github.com/atc1441/ATC_MiThermometer

https://www.youtube.com/watch?v=NXKzFG61lNs

With this custom firmware, the LYWSD03MMC advertises its data without encryption, so no need to connect to the sensor when using this custom firmware. The data are read every `BLEinterval` like all the other devices that advertise data.

Note that the flashing process takes less than 5minutes and is done over the air (impressive :-)).