### PR TITLE
Add default include_dir to platformio section

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 src_dir = main
+include_dir = main
 
 extra_configs =
   tests/*_env.ini


### PR DESCRIPTION
#748
point to main as we are not using default include folder