### PR TITLE
Fix ESPiLight transmission error reporting

### DIFF
--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -1,18 +1,18 @@
-/*  
-  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+/*
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation
 
-   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
    Send and receiving command by MQTT
- 
+
   This gateway enables to:
  - receive MQTT data from a topic and send RF 433Mhz signal corresponding to the received MQTT data based on ESPilight library
  - publish MQTT data to a different topic related to received 433Mhz signal based on ESPilight library
 
     Copyright: (c)Florian ROBERT
     Pilight Gateway made by steadramon, improvments with the help of puuu
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -101,26 +101,21 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
   ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
   rf.disableReceiver();
 #  endif
-  int result = 0;
-
   if (cmpToMainTopic(topicOri, subjectMQTTtoPilight)) {
     Log.trace(F("MQTTtoPilight json data analysis" CR));
     const char* message = Pilightdata["message"];
     const char* protocol = Pilightdata["protocol"];
     const char* raw = Pilightdata["raw"];
     if (raw) {
-      int msgLength = 0;
       uint16_t codes[MAXPULSESTREAMLENGTH];
-      msgLength = rf.stringToPulseTrain(
-          raw,
-          codes, MAXPULSESTREAMLENGTH);
+      int msgLength = rf.stringToPulseTrain(
+          raw, codes, MAXPULSESTREAMLENGTH);
       if (msgLength > 0) {
         rf.sendPulseTrain(codes, msgLength);
         Log.notice(F("MQTTtoPilight raw ok" CR));
-        result = msgLength;
       } else {
         Log.trace(F("MQTTtoPilight raw KO" CR));
-        switch (result) {
+        switch (msgLength) {
           case ESPiLight::ERROR_INVALID_PULSETRAIN_MSG_C:
             Log.trace(F("'c' not found in string, or has no data" CR));
             break;
@@ -134,35 +129,34 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
             Log.trace(F("pulse type not defined" CR));
             break;
         }
+        Log.error(F("Invalid JSON: raw data malformed" CR));
       }
     } else if (message && protocol) {
       Log.trace(F("MQTTtoPilight msg & protocol ok" CR));
-      result = rf.send(protocol, message);
+      int msgLength = rf.send(protocol, message);
+      if (msgLength > 0) {
+        Log.trace(F("Adv data MQTTtoPilight push state via PilighttoMQTT" CR));
+        pub(subjectGTWPilighttoMQTT, Pilightdata);
+      } else {
+        switch (msgLength) {
+          case ESPiLight::ERROR_UNAVAILABLE_PROTOCOL:
+            Log.error(F("protocol is not available" CR));
+            break;
+          case ESPiLight::ERROR_INVALID_PILIGHT_MSG:
+            Log.error(F("message is invalid" CR));
+            break;
+          case ESPiLight::ERROR_INVALID_JSON:
+            Log.error(F("message is not a proper json object" CR));
+            break;
+          case ESPiLight::ERROR_NO_OUTPUT_PIN:
+            Log.error(F("no transmitter pin" CR));
+            break;
+          default:
+            Log.error(F("Invalid JSON: can't read message/protocol" CR));
+        }
+      }
     } else {
       Log.error(F("MQTTtoPilight failed json read" CR));
-    }
-
-    if (result > 0) {
-      Log.trace(F("Adv data MQTTtoPilight push state via PilighttoMQTT" CR));
-      pub(subjectGTWPilighttoMQTT, Pilightdata);
-    } else {
-      switch (result) {
-        case ESPiLight::ERROR_UNAVAILABLE_PROTOCOL:
-          Log.error(F("protocol is not available" CR));
-          break;
-        case ESPiLight::ERROR_INVALID_PILIGHT_MSG:
-          Log.error(F("message is invalid" CR));
-          break;
-        case ESPiLight::ERROR_INVALID_JSON:
-          Log.error(F("message is not a proper json object" CR));
-          break;
-        case ESPiLight::ERROR_NO_OUTPUT_PIN:
-          Log.error(F("no transmitter pin" CR));
-          break;
-        default:
-          Log.error(F("invalid json data, can't read raw or message/protocol" CR));
-          break;
-      }
     }
   }
 #  ifdef ZradioCC1101


### PR DESCRIPTION
The `MQTTtoPilight` function's logic prevented the correct parsing of the error codes returned by ESPiLight. This fixes that and somewhat restructures the if/else logic therein for more efficiency.