### PR TITLE
Add ability to invert the PIR Notify LED

### DIFF
--- a/docs/use/sensors.md
+++ b/docs/use/sensors.md
@@ -53,3 +53,6 @@ You can have another PIN mirror the value of the PIR sensor output by adding the
 This can be useful if you would like to connect an LED to turn on when motion is detected.
 
 `#define HCSR501_LED_NOTIFY_GPIO 4`
+
+This notification pin can be inverted if driving directly or through a transistor/mosfet.
+`#define INVERT_LED_NOTIFY true`

--- a/main/ZsensorHCSR501.ino
+++ b/main/ZsensorHCSR501.ino
@@ -63,7 +63,7 @@ void MeasureHCSR501() {
       }
     }
 #  ifdef HCSR501_LED_NOTIFY_GPIO
-    digitalWrite(HCSR501_LED_NOTIFY_GPIO, pirState);
+    digitalWrite(HCSR501_LED_NOTIFY_GPIO, pirState == HCSR501_LED_ON);
 #  endif
     if (HCSR501data.size() > 0)
       pub(subjectHCSR501toMQTT, HCSR501data);

--- a/main/config_HCSR501.h
+++ b/main/config_HCSR501.h
@@ -33,6 +33,10 @@ extern void HCSR501toMQTT();
 #define subjectHCSR501toMQTT "/HCSR501toMQTT"
 //#define HCSR501_LED_NOTIFY_GPIO 4 //Uncomment this line to mirror the state of the PIR sensor to the specified GPIO
 
+#if defined(HCSR501_LED_NOTIFY_GPIO) && !defined(HCSR501_LED_ON)
+#  define HCSR501_LED_ON HIGH
+#endif
+
 #ifndef TimeBeforeStartHCSR501
 #  define TimeBeforeStartHCSR501 60000 //define the time necessary for HC SR501 init
 #endif


### PR DESCRIPTION
I've added the option to invert the PIR notification LED at build time. It's default value is set to drive an LED through a Mosfet. If the LED is driven directly from the AVR/ESP's pin, `INVERT_LED_NOTIFY` should be set to `true`.