### PR TITLE
The reset button function does not work if TRIGGER_GPIO = 0

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -859,7 +859,7 @@ void saveConfigCallback() {
   shouldSaveConfig = true;
 }
 
-#  if TRIGGER_GPIO
+#  ifdef TRIGGER_GPIO
 void checkButton() { // code from tzapu/wifimanager examples
   // check for button press
   if (digitalRead(TRIGGER_GPIO) == LOW) {
@@ -900,7 +900,7 @@ void eraseAndRestart() {
 }
 
 void setup_wifimanager(bool reset_settings) {
-#  if TRIGGER_GPIO
+#  ifdef TRIGGER_GPIO
   pinMode(TRIGGER_GPIO, INPUT_PULLUP);
 #  endif
   delay(10);


### PR DESCRIPTION
After a bit of a challenge getting the config correct, determined that the reset button option doesn't work on a ESP32 due to the definition logic