### PR TITLE
Dont make HADiscovery switch if RF is receive only

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -37,7 +37,7 @@
 
 RCSwitch mySwitch = RCSwitch();
 
-#  ifdef ZmqttDiscovery
+#  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT)
 void RFtoMQTTdiscovery(SIGNAL_SIZE_UL_ULL MQTTvalue) { //on the fly switch creation from received RF values
   char val[11];
   sprintf(val, "%lu", MQTTvalue);
@@ -90,7 +90,7 @@ void RFtoMQTT() {
     mySwitch.resetAvailable();
 
     if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of RF -->MQTT
-#  ifdef ZmqttDiscovery //component creation for HA
+#  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT) //component creation for HA
       RFtoMQTTdiscovery(MQTTvalue);
 #  endif
       pub(subjectRFtoMQTT, RFdata);


### PR DESCRIPTION
@1technophile, thought of this while minor tweak while testing the HADiscovery from the previous PR.

If the RFGateway is only used to receive and not to transmit, via `RF_DISABLE_TRANSMIT`, is there a reason to create a switch in Home Assistant for the received code?

This PR disables creating a HADiscovery switch when the `RF_DISABLE_TRANSMIT` define is set.
Let me know if you want me to make a note of this in the docs and I'll push an update.