### PR TITLE
feat: add protocol into topic

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -255,8 +255,9 @@ void pub(char* topicori, JsonObject& data) {
 #ifdef valueAsASubject
 #  ifdef ZgatewayPilight
     String value = data["value"];
+    String protocol = data["protocol"];
     if (value != 0) {
-      topic = topic + "/" + value;
+      topic = topic + "/" + protocol + "/" + value;
     }
 #  else
     SIGNAL_SIZE_UL_ULL value = data["value"];


### PR DESCRIPTION
Currently, the implementation of Pilight in OMG is not really usable because Pilight can return several protocols that match a single received radio signal.

The topic created when a message is received includes only the ID of the received message, this means that only the last protocol will appear on the MQTT server, the others will have been overwritten.

By simply adding the protocol to the topic, this problem is solved.