### PR TITLE
Add rf2 autodiscovery

### DIFF
--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -71,19 +71,19 @@ void setupRF2() {
   digitalWrite(RF_EMITTER_GPIO, LOW);
 }
 
-#  ifdef ZmqttDiscovery 
-//Regsiter for autodiscover in Home Assistant
+#  ifdef ZmqttDiscovery
+//Register for autodiscover in Home Assistant
 void RF2toMQTTdiscovery(JsonObject& data) {
   Log.trace(F("switchRF2Discovery" CR));
   String payloadonstr;
   String payloadoffstr;
 
-  int org_switchtype = data["switchType"];  // Store original switchvalue
-  data.set("switchType", 1);                // switchtype = 1 turns switch on.
+  int org_switchtype = data["switchType"]; // Store original switchvalue
+  data.set("switchType", 1); // switchtype = 1 turns switch on.
   data.printTo(payloadonstr);
-  data.set("switchType", 0);  // switchtype = 0 turns switch off.
+  data.set("switchType", 0); // switchtype = 0 turns switch off.
   data.printTo(payloadoffstr);
-  data.set("switchType", org_switchtype);  // Restore original switchvalue
+  data.set("switchType", org_switchtype); // Restore original switchvalue
 
   String switchname;
   switchname = "RF2_" + String((int)data["unit"]) + "_" +

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -77,31 +77,41 @@ void RF2toMQTTdiscovery(JsonObject& data) {
   Log.trace(F("switchRF2Discovery" CR));
   String payloadonstr;
   String payloadoffstr;
-  
-  int org_switchtype = data["switchType"]; //Store original switchvalue 
-  data.set("switchType", 1);  //switchtype = 1 turns switch on.
+
+  int org_switchtype = data["switchType"];  // Store original switchvalue
+  data.set("switchType", 1);                // switchtype = 1 turns switch on.
   data.printTo(payloadonstr);
-  data.set("switchType", 0);  //switchtype = 0 turns switch off.
+  data.set("switchType", 0);  // switchtype = 0 turns switch off.
   data.printTo(payloadoffstr);
-  data.set("switchType", org_switchtype);  //Restore original switchvalue
+  data.set("switchType", org_switchtype);  // Restore original switchvalue
 
   String switchname;
-  switchname = "RF2_"+String((int)data["unit"]) + "_" + String((int)data["groupbit"]) + "_" + String((unsigned long)data["address"]);
-  
-  char* switchRF[8] = {"switch", (char*)switchname.c_str() , "", "", "", (char*)payloadonstr.c_str(), (char*)payloadoffstr.c_str(), ""};
-  //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
+  switchname = "RF2_" + String((int)data["unit"]) + "_" +
+               String((int)data["groupbit"]) + "_" +
+               String((unsigned long)data["address"]);
+
+  char* switchRF[8] = {"switch",
+                       (char*)switchname.c_str(),
+                       "",
+                       "",
+                       "",
+                       (char*)payloadonstr.c_str(),
+                       (char*)payloadoffstr.c_str(),
+                       ""};
+  // component type,name,availability topic,device class,value template,payload
+  // on, payload off, unit of measurement
 
   Log.trace(F("CreateDiscoverySwitch: %s" CR), switchRF[1]);
-  
-  //As RF2 433Mhz switches do not render their state, no state topic should be provided in the discovery. 
-  //This will cause the switch to be in optimistic mode in HA with separate on and off icons.
-  // The two separate on/off icons allow for subsequent on commands to support the dimming feature of KAKU switches like ACM-300.
-  createDiscovery(switchRF[0],
-                  "", switchRF[1], (char*)getUniqueId(switchRF[1], "").c_str(),
-                  will_Topic, switchRF[3], switchRF[4],
-                  switchRF[5], switchRF[6], switchRF[7],
-                  0, "", "", true, subjectMQTTtoRF2);
 
+  // As RF2 433Mhz switches do not render their state, no state topic should be
+  // provided in the discovery. This will cause the switch to be in optimistic
+  // mode in HA with separate on and off icons.
+  // The two separate on/off icons allow for subsequent on commands to support
+  // the dimming feature of KAKU switches like ACM-300.
+  createDiscovery(switchRF[0], "", switchRF[1],
+                  (char*)getUniqueId(switchRF[1], "").c_str(), will_Topic,
+                  switchRF[3], switchRF[4], switchRF[5], switchRF[6],
+                  switchRF[7], 0, "", "", true, subjectMQTTtoRF2);
 }
 #  endif
 

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -71,6 +71,40 @@ void setupRF2() {
   digitalWrite(RF_EMITTER_GPIO, LOW);
 }
 
+#  ifdef ZmqttDiscovery 
+//Regsiter for autodiscover in Home Assistant
+void RF2toMQTTdiscovery(JsonObject& data) {
+  Log.trace(F("switchRF2Discovery" CR));
+  String payloadonstr;
+  String payloadoffstr;
+  
+  int org_switchtype = data["switchType"]; //Store original switchvalue 
+  data.set("switchType", 1);  //switchtype = 1 turns switch on.
+  data.printTo(payloadonstr);
+  data.set("switchType", 0);  //switchtype = 0 turns switch off.
+  data.printTo(payloadoffstr);
+  data.set("switchType", org_switchtype);  //Restore original switchvalue
+
+  String switchname;
+  switchname = "RF2_"+String((int)data["unit"]) + "_" + String((int)data["groupbit"]) + "_" + String((unsigned long)data["address"]);
+  
+  char* switchRF[8] = {"switch", (char*)switchname.c_str() , "", "", "", (char*)payloadonstr.c_str(), (char*)payloadoffstr.c_str(), ""};
+  //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
+
+  Log.trace(F("CreateDiscoverySwitch: %s" CR), switchRF[1]);
+  
+  //As RF2 433Mhz switches do not render their state, no state topic should be provided in the discovery. 
+  //This will cause the switch to be in optimistic mode in HA with separate on and off icons.
+  // The two separate on/off icons allow for subsequent on commands to support the dimming feature of KAKU switches like ACM-300.
+  createDiscovery(switchRF[0],
+                  "", switchRF[1], (char*)getUniqueId(switchRF[1], "").c_str(),
+                  will_Topic, switchRF[3], switchRF[4],
+                  switchRF[5], switchRF[6], switchRF[7],
+                  0, "", "", true, subjectMQTTtoRF2);
+
+}
+#  endif
+
 void RF2toMQTT() {
   if (rf2rd.hasNewData) {
     Log.trace(F("Creating RF2 buffer" CR));
@@ -86,6 +120,9 @@ void RF2toMQTT() {
     RF2data.set("period", (int)rf2rd.period);
     RF2data.set("address", (unsigned long)rf2rd.address);
     RF2data.set("switchType", (int)rf2rd.switchType);
+#  ifdef ZmqttDiscovery //component creation for HA
+    RF2toMQTTdiscovery(RF2data);
+#  endif
 
     pub(subjectRF2toMQTT, RF2data);
   }

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -72,15 +72,17 @@ void createDiscovery(char* sensor_type,
   StaticJsonBuffer<JSON_MSG_CALC_BUFFER> jsonBuffer;
   JsonObject& sensor = jsonBuffer.createObject();
 
-  //If a component cannot render it's state (f.i. KAKU relays) no state topic should be added.
-  //Without a state topic HA will use optimistic mode for the component by default.
-  //The Home Assistant UI for optimistic switches (separate on and off icons) allows for multiple 
-  // subsequent on commands. This is required for dimming on KAKU relays like the ACM-300.
-  if (st_topic[0]) { 
+  // If a component cannot render it's state (f.i. KAKU relays) no state topic
+  // should be added. Without a state topic HA will use optimistic mode for the
+  // component by default. The Home Assistant UI for optimistic switches
+  // (separate on and off icons) allows for multiple
+  // subsequent on commands. This is required for dimming on KAKU relays like
+  // the ACM-300.
+  if (st_topic[0]) {
     char state_topic[mqtt_topic_max_size];
     strcpy(state_topic, mqtt_topic);
     strcat(state_topic, st_topic);
-    sensor.set("stat_t", state_topic); //state_topic
+    sensor.set("stat_t", state_topic);  // state_topic
   }
 
   sensor.set("name", s_name); //name

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -72,10 +72,16 @@ void createDiscovery(char* sensor_type,
   StaticJsonBuffer<JSON_MSG_CALC_BUFFER> jsonBuffer;
   JsonObject& sensor = jsonBuffer.createObject();
 
-  char state_topic[mqtt_topic_max_size];
-  strcpy(state_topic, mqtt_topic);
-  strcat(state_topic, st_topic);
-  sensor.set("stat_t", state_topic); //state_topic
+  //If a component cannot render it's state (f.i. KAKU relays) no state topic should be added.
+  //Without a state topic HA will use optimistic mode for the component by default.
+  //The Home Assistant UI for optimistic switches (separate on and off icons) allows for multiple 
+  // subsequent on commands. This is required for dimming on KAKU relays like the ACM-300.
+  if (st_topic[0]) { 
+    char state_topic[mqtt_topic_max_size];
+    strcpy(state_topic, mqtt_topic);
+    strcat(state_topic, st_topic);
+    sensor.set("stat_t", state_topic); //state_topic
+  }
 
   sensor.set("name", s_name); //name
   sensor.set("uniq_id", unique_id); //unique_id

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -82,7 +82,7 @@ void createDiscovery(char* sensor_type,
     char state_topic[mqtt_topic_max_size];
     strcpy(state_topic, mqtt_topic);
     strcat(state_topic, st_topic);
-    sensor.set("stat_t", state_topic);  // state_topic
+    sensor.set("stat_t", state_topic); // state_topic
   }
 
   sensor.set("name", s_name); //name


### PR DESCRIPTION
Added Home Assistant discovery to RF2.

For each unique combination of unit, groupbit and address a switch will be added to Home Assistant called:  "RF2_[unit]_[groupbit])_[address].
As RF2 433Mhz switches do not render their state, no state topic will be provided in the discovery. 
This will cause the switch to be in optimistic mode in HA with separate on and off icons.  
The two separate on/off icons allow for subsequent on commands to support the dimming feature of KAKU switches like ACM-300.