### PR TITLE
Fix/update to Qingping Cleargrass CGD1 detection

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -980,7 +980,7 @@ JsonObject& process_bledata(JsonObject& BLEdata) {
         return process_cleargrass(BLEdata, false);
       }
       Log.trace(F("Is it a CGD1?" CR));
-      if ((strstr(service_data, "080caf") != NULL || strstr(service_data, "080c09") != NULL) && (strlen(service_data) > ServicedataMinLength)) {
+      if (((strstr(service_data, "080caf") != NULL || strstr(service_data, "080c09") != NULL) && (strlen(service_data) > ServicedataMinLength)) || (strstr(service_data, "080cd0") != NULL && (strlen(service_data) > ServicedataMinLength - 6))) {
         Log.trace(F("CGD1 data reading" CR));
         BLEdata.set("model", "CGD1");
         if (device->sensorModel == -1)


### PR DESCRIPTION
Before the fix:
{"id":"58:2D:34:50:A0:D0","name":"Qingping Alarm Clock","rssi":-82,"distance":11.4949,"servicedata":"080cd0a050342d580104c0007c02"}
The servicedata string does not match any pattern so is not parsed

After the fix:
{"id":"58:2D:34:50:A0:D0","name":"Qingping Alarm Clock","rssi":-83,"distance":12.61001,"model":"CGD1","tem":19.2,"tempc":19.2,"tempf":66.56,"hum":63.5}
The parser is invoked and the data is output as expected.

There are probably too many brackets (I'm not a C dev) and I can't test on whatever version of CGD1 broadcasts 080caf or 080c09 servicedata strings. First tested on 0.9.4 with ESP32 (ran for months without issue). Now updating all my gateways to 0.9.5 and remembered to create the pull request.