### PR TITLE
{Breaking] Add M5 SYS parameters to auto discovery

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -181,6 +181,59 @@ void pubMqttDiscovery() {
                   0, //set  off_delay
                   "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
   );
+#    if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP)
+  createDiscovery("sensor", //set Type
+                  subjectSYStoMQTT, "SYS: Bat voltage", (char*)getUniqueId("m5batvoltage", "").c_str(), //set state_topic,name,uniqueId
+                  "", "", "{{ value_json.m5batvoltage }}", //set availability_topic,device_class,value_template,
+                  "", "", "V", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
+  );
+  createDiscovery("sensor", //set Type
+                  subjectSYStoMQTT, "SYS: Bat current", (char*)getUniqueId("m5batcurrent", "").c_str(), //set state_topic,name,uniqueId
+                  "", "", "{{ value_json.m5batcurrent }}", //set availability_topic,device_class,value_template,
+                  "", "", "A", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
+  );
+  createDiscovery("sensor", //set Type
+                  subjectSYStoMQTT, "SYS: Vin voltage", (char*)getUniqueId("m5vinvoltage", "").c_str(), //set state_topic,name,uniqueId
+                  "", "", "{{ value_json.m5vinvoltage }}", //set availability_topic,device_class,value_template,
+                  "", "", "V", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
+  );
+  createDiscovery("sensor", //set Type
+                  subjectSYStoMQTT, "SYS: Vin current", (char*)getUniqueId("m5vincurrent", "").c_str(), //set state_topic,name,uniqueId
+                  "", "", "{{ value_json.m5vincurrent }}", //set availability_topic,device_class,value_template,
+                  "", "", "A", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
+  );
+#    endif
+#    ifdef ZboardM5STACK
+  createDiscovery("sensor", //set Type
+                  subjectSYStoMQTT, "SYS: Batt level", (char*)getUniqueId("m5battlevel", "").c_str(), //set state_topic,name,uniqueId
+                  "", "", "{{ value_json.m5battlevel }}", //set availability_topic,device_class,value_template,
+                  "", "", "%", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
+  );
+  createDiscovery("binary_sensor", //set Type
+                  subjectSYStoMQTT, "SYS: Is Charging", (char*)getUniqueId("m5ischarging", "").c_str(), //set state_topic,name,uniqueId
+                  "", "{{ value_json.m5ischarging }}", "", //set availability_topic,device_class,value_template,
+                  "", "", "%", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
+  );
+  createDiscovery("binary_sensor", //set Type
+                  subjectSYStoMQTT, "SYS: Is Charge Full", (char*)getUniqueId("m5ischargefull", "").c_str(), //set state_topic,name,uniqueId
+                  "", "{{ value_json.m5ischargefull }}", "", //set availability_topic,device_class,value_template,
+                  "", "", "%", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  "", "", true, "" //set,payload_avalaible,payload_not avalaible   ,is a child device, command topic
+  );
+#    endif
 #  endif
   createDiscovery("switch", //set Type
                   will_Topic, "SYS: Restart gateway", (char*)getUniqueId("restart", "").c_str(), //set state_topic,name,uniqueId

--- a/main/main.ino
+++ b/main/main.ino
@@ -1388,22 +1388,22 @@ void stateMeasures() {
 #  endif
 #  ifdef ZboardM5STACK
   M5.Power.begin();
-  SYSdata["m5-batt-level"] = (int8_t)M5.Power.getBatteryLevel();
-  SYSdata["m5-is-charging"] = (bool)M5.Power.isCharging();
-  SYSdata["m5-is-chargefull"] = (bool)M5.Power.isChargeFull();
+  SYSdata["m5battlevel"] = (int8_t)M5.Power.getBatteryLevel();
+  SYSdata["m5ischarging"] = (bool)M5.Power.isCharging();
+  SYSdata["m5ischargefull"] = (bool)M5.Power.isChargeFull();
 #  endif
 #  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP)
   M5.Axp.EnableCoulombcounter();
-  SYSdata["m5-bat-voltage"] = (float)M5.Axp.GetBatVoltage();
-  SYSdata["m5-bat-current"] = (float)M5.Axp.GetBatCurrent();
-  SYSdata["m5-vin-voltage"] = (float)M5.Axp.GetVinVoltage();
-  SYSdata["m5-vin-current"] = (float)M5.Axp.GetVinCurrent();
-  SYSdata["m5-vbus-voltage"] = (float)M5.Axp.GetVBusVoltage();
-  SYSdata["m5-vbus-current"] = (float)M5.Axp.GetVBusCurrent();
-  SYSdata["m5-temp-axp"] = (float)M5.Axp.GetTempInAXP192();
-  SYSdata["m5-bat-power"] = (float)M5.Axp.GetBatPower();
-  SYSdata["m5-bat-chargecurrent"] = (float)M5.Axp.GetBatChargeCurrent();
-  SYSdata["m5-aps-voltage"] = (float)M5.Axp.GetAPSVoltage();
+  SYSdata["m5batvoltage"] = (float)M5.Axp.GetBatVoltage();
+  SYSdata["m5batcurrent"] = (float)M5.Axp.GetBatCurrent();
+  SYSdata["m5vinvoltage"] = (float)M5.Axp.GetVinVoltage();
+  SYSdata["m5vincurrent"] = (float)M5.Axp.GetVinCurrent();
+  SYSdata["m5vbusvoltage"] = (float)M5.Axp.GetVBusVoltage();
+  SYSdata["m5vbuscurrent"] = (float)M5.Axp.GetVBusCurrent();
+  SYSdata["m5tempaxp"] = (float)M5.Axp.GetTempInAXP192();
+  SYSdata["m5batpower"] = (float)M5.Axp.GetBatPower();
+  SYSdata["m5batchargecurrent"] = (float)M5.Axp.GetBatChargeCurrent();
+  SYSdata["m5apsvoltage"] = (float)M5.Axp.GetAPSVoltage();
 #  endif
   SYSdata.set("modules", modules);
   pub(subjectSYStoMQTT, SYSdata);


### PR DESCRIPTION
Parameters like battery/Vin voltage, the current will now be autodiscovered on M5Stick C, C plus.
![image](https://user-images.githubusercontent.com/12672732/101288438-2475a080-37bc-11eb-8b8b-63e1b8fcd70c.png)
M5Stack advertise Battery level, full and if charging.

Note that these parameters can be useful to detect a power outage.

[BREAKING] the key of the parameters are changed, the previous ones containing "-" were not autodiscovered