### PR TITLE
Declare sendIdentifiedPRotocol so MQTTtoIR finds it

### DIFF
--- a/main/ZgatewayIR.ino
+++ b/main/ZgatewayIR.ino
@@ -179,7 +179,7 @@ void IRtoMQTT() {
   }
 }
 
-bool sendIdentifiedProtocol(const char* protocol_name, SIGNAL_SIZE_UL_ULL data, const char* hex, unsigned int valueBITS, uint16_t valueRPT);  
+bool sendIdentifiedProtocol(const char* protocol_name, SIGNAL_SIZE_UL_ULL data, const char* hex, unsigned int valueBITS, uint16_t valueRPT);
 
 #  ifdef jsonReceiving
 void MQTTtoIR(char* topicOri, JsonObject& IRdata) {

--- a/main/ZgatewayIR.ino
+++ b/main/ZgatewayIR.ino
@@ -179,6 +179,8 @@ void IRtoMQTT() {
   }
 }
 
+bool sendIdentifiedProtocol(const char* protocol_name, SIGNAL_SIZE_UL_ULL data, const char* hex, unsigned int valueBITS, uint16_t valueRPT);  
+
 #  ifdef jsonReceiving
 void MQTTtoIR(char* topicOri, JsonObject& IRdata) {
   if (cmpToMainTopic(topicOri, subjectMQTTtoIR)) {


### PR DESCRIPTION
When building v0.9.5 on Arduino IDE 1.8.13, in either macOS 10.15.17 (Catalina) or 11.1 (Big Sur), I got this error:

```c
ZgatewayIR:258:90: error: 'sendIdentifiedProtocol' was not declared in this scope
         signalSent = sendIdentifiedProtocol(protocol_name, data, hex, valueBITS, valueRPT);
                                                                                          ^
```

This fix declares the `sendIdentifiedPRotocol` function, so the `MQTTtoIR` one compiles it.

I could also just swap the order, or try to simplify the declaration (if possible; wasn't sure about style/side effects), just let me know!

Thanks again for maintaining this amazing application.

<details>
<summary>Full error log</summary>

```
Arduino: 1.8.13 (Mac OS X), Board: "NodeMCU 1.0 (ESP-12E Module), 80 MHz, Flash, Legacy (new can return nullptr), All SSL ciphers (most compatible), 4MB (FS:2MB OTA:~1019KB), 2, v2 Lower Memory, Disabled, None, Only Sketch, 115200"











/Users/chesterbr/chesterbr/private-OpenMQTTGateway/main/ZgatewayIR.ino: In function 'void MQTTtoIR(char*, ArduinoJson::JsonObject&)':
ZgatewayIR:258:90: error: 'sendIdentifiedProtocol' was not declared in this scope
         signalSent = sendIdentifiedProtocol(protocol_name, data, hex, valueBITS, valueRPT);
                                                                                          ^
exit status 1
'sendIdentifiedProtocol' was not declared in this scope


This report would have more information with
"Show verbose output during compilation"
option enabled in File -> Preferences.
```
</details>