### PR TITLE
[Breaking] Publish state to same channel as received signals

### DIFF
--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -66,7 +66,7 @@ extern void MQTTtoPilight(char* topicOri, JsonObject& RFdata);
 //433Mhz newremoteswitch MQTT Subjects and keys
 #define subjectMQTTtoRF2    "/commands/MQTTtoRF2"
 #define subjectRF2toMQTT    "/RF2toMQTT"
-#define subjectGTWRF2toMQTT "/433toMQTT"
+#define subjectGTWRF2toMQTT "/RF2toMQTT"
 #define RF2codeKey          "ADDRESS_" // code will be defined if a subject contains RF2codeKey followed by a value of 7 digits
 #define RF2periodKey        "PERIOD_" // period  will be defined if a subject contains RF2periodKey followed by a value of 3 digits
 #define RF2unitKey          "UNIT_" // number of your unit value  will be defined if a subject contains RF2unitKey followed by a value of 1-2 digits


### PR DESCRIPTION
Received signals are published to the subjectRF2toMQTT topic (/RF2toMQTT). However, echos of mqtt messages are published to the topic subjectGTWRF2toMQTT (/433toMQTT).

That seems quite inconsistent and breaks functionality in Home Assistant that expects confirming messages, like this echo, on the same topic as receive messages.

This PR fixes this.

**Breaking change**
This PR changes the topic of echo messages. Configurations expecting the previous topic `433toMQTT`, will break.

Alternatively it might be an option to publish echos to both topics or make the topic configurable. Please let me know if such changes are preferred.