### PR TITLE
LoRa packets lost - BME280 sensor fix

### DIFF
--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -42,7 +42,12 @@ void setupLORA() {
     while (1)
       ;
   }
+
+  LoRa.setSpreadingFactor(LORA_SPREADING_FACTOR);
+  LoRa.setSyncWord(LORA_SYNC_WORD);
+
   LoRa.receive();
+
   Log.notice(F("LORA_SCK: %d" CR), LORA_SCK);
   Log.notice(F("LORA_MISO: %d" CR), LORA_MISO);
   Log.notice(F("LORA_MOSI: %d" CR), LORA_MOSI);

--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -78,10 +78,28 @@ void LORAtoMQTT() {
     LORAdata.set("pferror", (float)LoRa.packetFrequencyError());
     LORAdata.set("packetSize", (int)packetSize);
     LORAdata.set("message", (char*)packet.c_str());
-    pub(subjectLORAtoMQTT, LORAdata);
+
+    // convert string to char array
+    // Length (with one extra character for the null terminator)
+    int str_len = packet.length() + 1;
+    // Prepare the character array (the buffer)
+    char packetchar[str_len];
+    // Copy it over
+    packet.toCharArray(packetchar, str_len);
+    
+    // Get the sensor name.
+    // I suppose this message format, where the first field is the sensor name.
+    // example: "message":"ttgo,124,21,20,0,36.0", here the sensor is "ttgo"
+    String sensorName = strtok(packetchar, ",");
+    
+    char topicWithSensorName[20];
+    sprintf(topicWithSensorName, "%s/%s", subjectLORAtoMQTT, sensorName);
+
+    pub(topicWithSensorName, LORAdata);
+
     if (repeatLORAwMQTT) {
       Log.trace(F("Pub LORA for rpt" CR));
-      pub(subjectMQTTtoLORA, LORAdata);
+      pub(topicWithSensorName, LORAdata);
     }
   }
 }

--- a/main/ZsensorBME280.ino
+++ b/main/ZsensorBME280.ino
@@ -51,7 +51,7 @@ BME280 mySensor;
 void setupZsensorBME280() {
   mySensor.settings.commInterface = I2C_MODE;
   mySensor.settings.I2CAddress = BME280_i2c_addr;
-  Log.notice(F("Setup BME280 on adress: %H" CR), BME280_i2c_addr);
+  Log.notice(F("Setup BME280 on address: 0x%x" CR), BME280_i2c_addr);
   //***Operation settings*****************************//
 
   // runMode Setting - Values:
@@ -101,7 +101,15 @@ void setupZsensorBME280() {
   mySensor.settings.humidOverSample = 1;
 
   delay(10); // Gives the Sensor enough time to turn on (The BME280 requires 2ms to start up)
-  Log.notice(F("Bosch BME280 Initialized - Result of .begin(): 0x %h" CR), mySensor.begin());
+
+#  ifdef I2CPIN1
+#    ifdef I2CPIN2
+  Log.notice(F("Set I2C pins for BME280 sensor" CR));
+  Wire.begin(I2CPIN1, I2CPIN2);
+#    endif
+#  endif
+
+  Log.notice(F("Bosch BME280 Initialized - Result of .begin(): 0x%x (Should return 0x60)" CR), mySensor.begin());
 }
 
 void MeasureTempHumAndPressure() {

--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -44,6 +44,11 @@ extern void BME280toMQTT();
 #define bme280_always            true // if false when the current value of the parameter is the same as previous one don't send it by MQTT
 #define TimeBetweenReadingbme280 30000
 
+//If you need custom I2C Pins for BME280 you can change it here
+// https://community.openmqttgateway.com/t/feature-suggest-customizeable-pins-e-g-for-bme280/652
+#define I2CPIN1 21
+#define I2CPIN2 13
+
 /*----------------------------USER PARAMETERS-----------------------------*/
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 #define BMETOPIC "/CLIMAtoMQTT/bme"
@@ -51,5 +56,7 @@ extern void BME280toMQTT();
 //Time used to wait for an interval before resending measured values
 unsigned long timebme280 = 0;
 int BME280_i2c_addr = 0x76; // Bosch BME280 I2C Address
+
+
 
 #endif


### PR DESCRIPTION
Set syncword and spreadfactor on receiving to avoid lost packets. 
Used with TTGO LORA v1.

Add custom I2C pins for settings BME280 sensor connection.