### PR TITLE
Initial pull request for rtl_433 support

### DIFF
--- a/docs/use/gateway.md
+++ b/docs/use/gateway.md
@@ -15,6 +15,10 @@ With Home Assistant, this command is directly avalaible through MQTT auto discov
 With Home Assistant, this command is directly avalaible through MQTT auto discovery as a switch into the HASS OpenMQTTGateway device entities list.
 :::
 
+## Retrieve current status of the ESP
+
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"cmd":"status"}'`
+
 ## Auto discovery
 You can deactivate the MQTT auto discovery function, this function enable to create automaticaly devices/entities with Home Assistant convention.
 ### Deactivate

--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -184,3 +184,128 @@ Once you get the infos publish the parameters with mqtt like that for off:
 for on:
 
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoRF2 -m "{"unit":0,"groupBit":0,"period":273,"adress":8233228,"switchType":1}"`
+
+## rtl_433 device decoders
+
+This feature is only available on a ESP32 based device with a CC1101 transceiver connected due to the resource requirements of the rtl_433 device decoders.  At the present time only Pulse Position Modulation (OOK_PPM) and Pulse Width Modulation (OOK_PWM) based decoders are available.
+
+```
+Registering protocol [1] "Silvercrest Remote Control"
+Registering protocol [2] "Rubicson Temperature Sensor"
+Registering protocol [3] "Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor"
+Registering protocol [4] "Waveman Switch Transmitter"
+Registering protocol [8] "LaCrosse TX Temperature / Humidity Sensor"
+Registering protocol [11] "Acurite 609TXC Temperature and Humidity Sensor"
+Registering protocol [15] "KlikAanKlikUit Wireless Switch"
+Registering protocol [16] "AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)"
+Registering protocol [17] "Cardin S466-TX2"
+Registering protocol [18] "Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor"
+Registering protocol [19] "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor"
+Registering protocol [21] "Calibeur RF-104 Sensor"
+Registering protocol [25] "Globaltronics GT-WT-02 Sensor"
+Registering protocol [29] "Chuango Security Technology"
+Registering protocol [30] "Generic Remote SC226x EV1527"
+Registering protocol [31] "TFA-Twin-Plus-30.3049, Conrad KW9010, Ea2 BL999"
+Registering protocol [32] "Fine Offset Electronics WH1080/WH3080 Weather Station"
+Registering protocol [34] "LaCrosse WS-2310 / WS-3600 Weather Station"
+Registering protocol [35] "Esperanza EWS"
+Registering protocol [38] "Generic temperature sensor 1"
+Registering protocol [39] "WG-PB12V1 Temperature Sensor"
+Registering protocol [40] "Acurite 592TXR Temp/Humidity, 5n1 Weather Station, 6045 Lightning, 3N1, Atlas"
+Registering protocol [41] "Acurite 986 Refrigerator / Freezer Thermometer"
+Registering protocol [46] "HT680 Remote control"
+Registering protocol [47] "Conrad S3318P, FreeTec NC-5849-913 temperature humidity sensor"
+Registering protocol [48] "Akhan 100F14 remote keyless entry"
+Registering protocol [49] "Quhwa"
+Registering protocol [51] "Skylink HA-434TL motion sensor"
+Registering protocol [53] "Springfield Temperature and Soil Moisture"
+Registering protocol [54] "Oregon Scientific SL109H Remote Thermal Hygro Sensor"
+Registering protocol [55] "Acurite 606TX Temperature Sensor"
+Registering protocol [56] "TFA pool temperature sensor"
+Registering protocol [57] "Kedsum Temperature & Humidity Sensor, Pearl NC-7415"
+Registering protocol [58] "Blyss DC5-UK-WH"
+Registering protocol [68] "Kerui PIR / Contact Sensor"
+Registering protocol [69] "Fine Offset WH1050 Weather Station"
+Registering protocol [73] "LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor"
+Registering protocol [74] "Acurite 00275rm,00276rm Temp/Humidity with optional probe"
+Registering protocol [79] "Fine Offset Electronics, WH0530 Temperature/Rain Sensor"
+Registering protocol [84] "Thermopro TP11 Thermometer"
+Registering protocol [85] "Solight TE44/TE66, EMOS E0107T, NX-6876-917"
+Registering protocol [86] "Wireless Smoke and Heat Detector GS 558"
+Registering protocol [87] "Generic wireless motion sensor"
+Registering protocol [91] "inFactory, nor-tec, FreeTec NC-3982-913 temperature humidity sensor"
+Registering protocol [92] "FT-004-B Temperature Sensor"
+Registering protocol [94] "Philips outdoor temperature sensor (type AJ3650)"
+Registering protocol [96] "Nexa"
+Registering protocol [97] "Thermopro TP08/TP12/TP20 thermometer"
+Registering protocol [99] "X10 Security"
+Registering protocol [100] "Interlogix GE UTC Security Devices"
+Registering protocol [108] "Hyundai WS SENZOR Remote Temperature Sensor"
+Registering protocol [109] "WT0124 Pool Thermometer"
+Registering protocol [112] "Ambient Weather TX-8300 Temperature/Humidity Sensor"
+Registering protocol [114] "Maverick et73"
+Registering protocol [115] "Honeywell ActivLink, Wireless Doorbell"
+Registering protocol [121] "Opus/Imagintronix XT300 Soil Moisture"
+Registering protocol [124] "LaCrosse/ELV/Conrad WS7000/WS2500 weather sensors"
+Registering protocol [125] "TS-FT002 Wireless Ultrasonic Tank Liquid Level Meter With Temperature Sensor"
+Registering protocol [126] "Companion WTR001 Temperature Sensor"
+Registering protocol [127] "Ecowitt Wireless Outdoor Thermometer WH53/WH0280/WH0281A"
+Registering protocol [131] "Microchip HCS200 KeeLoq Hopping Encoder based remotes"
+Registering protocol [133] "Rubicson 48659 Thermometer"
+Registering protocol [135] "Philips outdoor temperature sensor (type AJ7010)"
+Registering protocol [137] "Globaltronics QUIGG GT-TMBBQ-05"
+Registering protocol [138] "Globaltronics GT-WT-03 Sensor"
+Registering protocol [141] "Auriol HG02832, HG05124A-DCF, Rubicson 48957 temperature/humidity sensor"
+Registering protocol [145] "WS2032 weather station"
+Registering protocol [146] "Auriol AFW2A1 temperature/humidity sensor"
+Registering protocol [147] "TFA Drop Rain Gauge 30.3233.01"
+Registering protocol [151] "Visonic powercode"
+Registering protocol [152] "Eurochron EFTH-800 temperature and humidity sensor"
+Registering protocol [157] "Missil ML0757 weather station"
+Registering protocol [163] "Acurite 590TX Temperature with optional Humidity"
+Registering protocol [164] "Burnhard BBQ thermometer"
+Registering protocol [165] "TFA Dostmann 30.3221.02 T/H Outdoor Sensor"
+Registering protocol [167] "BlueLine Power Monitor"
+Registering protocol [174] "Bresser Thermo-/Hygro-Sensor 3CH"
+Registering protocol [178] "Proove / Nexa / KlikAanKlikUit Wireless Switch"
+```
+
+### Change receive frequency
+
+Default receive frequency of the CC1101 module is 433.92 Mhz, and this can be can changed by sending a message with the frequency.  Parameter is `mhz` and valid values are 300-348 Mhz, 387-464Mhz and 779-928Mhz.  Actual frequency support will depend on your CC1101 board
+
+`home/OpenMQTTGateway/commands/MQTTtoRTL_433 {"mhz":315.026}`
+
+### Minimum Signal Strength
+
+Default minimum signal strength to enable the receiver is -82, and this setting can be changed with the following command.
+
+`home/OpenMQTTGateway/commands/MQTTtoRTL_433 {"rssi":-75}`
+
+### Enable rtl_433 device decoder verbose debug
+
+This function does not work when all available decoders are enabled and triggers an out of memory restart.
+
+`home/OpenMQTTGateway/commands/MQTTtoRTL_433 {"debug":4}`
+
+### Retrieve current status of receiver
+
+`home/OpenMQTTGateway/commands/MQTTtoRTL_433 {"status":-1}`
+
+```
+{"model":"status",
+"protocol":"debug",
+"debug":0,                  - rtl_433 verbose setting
+"duration":11799327,        - duration of current signal
+"Gap length":-943575,       - duration of gap between current signal
+"signalRssi":-38,           - most recent received signal strength
+"train":1,                  - signal processing train #
+"messageCount":3,           - total number of signals received
+"_enabledReceiver":1,       - which recevier is enabled
+"receiveMode":0,            - is the receiver currently receiving a signal
+"currentRssi":-89,          - current rssi level
+"minimumRssi":-82,          - minimum rssi level to start signal processing
+"pulses":0,                 - how many pulses have been recieved in the current signal
+"StackHighWaterMark":5528,  - ESP32 Stack
+"freeMem":112880}           - ESP32 memory available
+```

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -352,6 +352,7 @@ uint8_t wifiProtocol = 0; // default mode, automatic selection
 // key used for launching commands to the gateway
 #define restartCmd "restart"
 #define eraseCmd   "erase"
+#define statusCmd  "status"
 
 // uncomment the line below to integrate msg value into the subject when receiving
 //#define valueAsASubject true

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -33,7 +33,6 @@
 #  include <rtl_433_ESP.h>
 
 #  define CC1101_FREQUENCY 433.92
-#  define JSON_MSG_BUFFER  512
 #  define ONBOARD_LED      2
 
 char messageBuffer[JSON_MSG_BUFFER];
@@ -52,7 +51,7 @@ void rtl_433_Callback(char* message) {
 #  endif
 }
 
-void rtl_433setup() {
+void setupRTL_433() {
   rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
   rtl_433.setCallback(rtl_433_Callback, messageBuffer, JSON_MSG_BUFFER);
   Log.notice(F("ZgatewayRTL_433 command topic: %s%s" CR), mqtt_topic, subjectMQTTtoRTL_433);
@@ -60,14 +59,14 @@ void rtl_433setup() {
   Log.trace(F("ZgatewayRTL_433 setup done " CR));
 }
 
-void rtl_433loop() {
+void RTL_433Loop() {
   rtl_433.loop();
 }
 
 extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
   if (cmpToMainTopic(topicOri, subjectMQTTtoRTL_433)) {
     Log.trace(F("MQTTtoRTL_433 %s" CR), topicOri);
-    float tempMhz = RTLdata["mhz"];
+    float tempMhz = RTLdata["mhz"] | 0;
     int minimumRssi = RTLdata["rssi"] | 0;
     int debug = RTLdata["debug"] | -1;
     int status = RTLdata["status"] | -1;
@@ -93,22 +92,12 @@ extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
       pub(subjectRTL_433toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("MQTTtoRTL_433 Fail json" CR));
     }
-    // enableActiveReceiver();
   }
 }
 
 extern void enableRTLreceive() {
   Log.trace(F("enableRTLreceive: %F" CR), receiveMhz);
-#  ifdef ZgatewayRF
-  disableRFReceive();
-#  endif
-#  ifdef ZgatewayPilight
-  disablePilightReceive();
-#  endif
-
-#  ifdef ZradioCC1101
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
-#  endif
   rtl_433.enableReceiver(RF_RECEIVER_GPIO);
   // rtl_433.initReceiver(RF_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
@@ -120,15 +109,15 @@ extern void disableRTLreceive() {
   rtl_433.disableReceiver();
 }
 
-extern int getMinimumRSSI() {
+extern int getRTLMinimumRSSI() {
   return rtl_433.minimumRssi;
 }
 
-extern int getCurrentRSSI() {
+extern int getRTLCurrentRSSI() {
   return rtl_433.currentRssi;
 }
 
-extern int getMessageCount() {
+extern int getRTLMessageCount() {
   return rtl_433.messageCount;
 }
 

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -1,0 +1,135 @@
+/*  
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Send and receiving command by MQTT
+ 
+  This gateway enables to:
+ - receive MQTT data from a topic and send RF 433Mhz signal corresponding to the received MQTT data
+ - publish MQTT data to a different topic related to received 433Mhz signal
+ - leverage the rtl_433 device decoders on a ESP32 device
+
+    Copyright: (c)Florian ROBERT
+  
+    This file is part of OpenMQTTGateway.
+    
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "User_config.h"
+
+#ifdef ZgatewayRTL_433
+
+#  include <rtl_433_ESP.h>
+
+#  define CC1101_FREQUENCY 433.92
+#  define JSON_MSG_BUFFER  512
+#  define ONBOARD_LED      2
+
+char messageBuffer[JSON_MSG_BUFFER];
+
+rtl_433_ESP rtl_433(-1); // use -1 to disable transmitter
+
+#  include <ELECHOUSE_CC1101_SRC_DRV.h>
+
+void rtl_433_Callback(char* message) {
+  DynamicJsonBuffer jsonBuffer2(JSON_MSG_BUFFER);
+  JsonObject& RFrtl_433_ESPdata = jsonBuffer2.parseObject(message);
+
+  pub(subjectRTL_433toMQTT, RFrtl_433_ESPdata);
+#  ifdef MEMORY_DEBUG
+    Log.trace(F("Post rtl_433_Callback: %d" CR), ESP.getFreeHeap());
+#  endif
+}
+
+void rtl_433setup() {
+  rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
+  rtl_433.setCallback(rtl_433_Callback, messageBuffer, JSON_MSG_BUFFER);
+  Log.notice(F("ZgatewayRTL_433 command topic: %s%s" CR), mqtt_topic, subjectMQTTtoRTL_433);
+  enableRTLreceive();
+  Log.trace(F("ZgatewayRTL_433 setup done " CR));
+}
+
+void rtl_433loop() {
+  rtl_433.loop();
+}
+
+extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
+  if (cmpToMainTopic(topicOri, subjectMQTTtoRTL_433)) {
+    Log.trace(F("MQTTtoRTL_433 %s" CR), topicOri);
+    float tempMhz = RTLdata["mhz"];
+    int minimumRssi = RTLdata["rssi"] | 0;
+    int debug = RTLdata["debug"] | -1;
+    int status = RTLdata["status"] | -1;
+    if (tempMhz != 0 && validFrequency((int)tempMhz)) {
+    //  activeReceiver = RTL; // Enable RTL_433 Gateway
+      receiveMhz = tempMhz;
+      Log.notice(F("RTL_433 Receive mhz: %F" CR), receiveMhz);
+      pub(subjectRTL_433toMQTT, RTLdata); 
+    } else if (minimumRssi != 0) {      
+      Log.notice(F("RTL_433 minimum RSSI: %d" CR), minimumRssi);
+      rtl_433.setMinimumRSSI(minimumRssi);
+      pub(subjectRTL_433toMQTT, RTLdata); 
+    } else if (debug >= 0 && debug <= 4) {      
+      Log.notice(F("RTL_433 set debug: %d" CR), debug);
+      rtl_433.setDebug(debug);
+      rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
+      pub(subjectRTL_433toMQTT, RTLdata); 
+    } else if (status >= 0 ) {      
+      Log.notice(F("RTL_433 get status: %d" CR), status);
+      rtl_433.getStatus(status);
+      pub(subjectRTL_433toMQTT, RTLdata); 
+    } else {
+      pub(subjectRTL_433toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
+      Log.error(F("MQTTtoRTL_433 Fail json" CR));
+    }
+    // enableActiveReceiver();
+  }
+}
+
+extern void enableRTLreceive() {
+  Log.trace(F("enableRTLreceive: %F" CR), receiveMhz);
+#  ifdef ZgatewayRF
+  disableRFReceive();
+#  endif
+#  ifdef ZgatewayPilight
+  disablePilightReceive();
+#  endif
+
+#  ifdef ZradioCC1101
+  ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
+#  endif
+  rtl_433.enableReceiver(RF_RECEIVER_GPIO);
+  // rtl_433.initReceiver(RF_RECEIVER_GPIO);
+  pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
+}
+
+extern void disableRTLreceive() {
+  Log.trace(F("disableRTLreceive" CR));
+  rtl_433.enableReceiver(-1);
+  rtl_433.disableReceiver();
+}
+
+extern int getMinimumRSSI() {
+  return rtl_433.minimumRssi;
+}
+
+extern int getCurrentRSSI() {
+  return rtl_433.currentRssi;
+}
+
+extern int getMessageCount() {
+  return rtl_433.messageCount;
+}
+
+#endif

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -48,7 +48,7 @@ void rtl_433_Callback(char* message) {
 
   pub(subjectRTL_433toMQTT, RFrtl_433_ESPdata);
 #  ifdef MEMORY_DEBUG
-    Log.trace(F("Post rtl_433_Callback: %d" CR), ESP.getFreeHeap());
+  Log.trace(F("Post rtl_433_Callback: %d" CR), ESP.getFreeHeap());
 #  endif
 }
 
@@ -72,23 +72,23 @@ extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
     int debug = RTLdata["debug"] | -1;
     int status = RTLdata["status"] | -1;
     if (tempMhz != 0 && validFrequency((int)tempMhz)) {
-    //  activeReceiver = RTL; // Enable RTL_433 Gateway
+      //  activeReceiver = RTL; // Enable RTL_433 Gateway
       receiveMhz = tempMhz;
       Log.notice(F("RTL_433 Receive mhz: %F" CR), receiveMhz);
-      pub(subjectRTL_433toMQTT, RTLdata); 
-    } else if (minimumRssi != 0) {      
+      pub(subjectRTL_433toMQTT, RTLdata);
+    } else if (minimumRssi != 0) {
       Log.notice(F("RTL_433 minimum RSSI: %d" CR), minimumRssi);
       rtl_433.setMinimumRSSI(minimumRssi);
-      pub(subjectRTL_433toMQTT, RTLdata); 
-    } else if (debug >= 0 && debug <= 4) {      
+      pub(subjectRTL_433toMQTT, RTLdata);
+    } else if (debug >= 0 && debug <= 4) {
       Log.notice(F("RTL_433 set debug: %d" CR), debug);
       rtl_433.setDebug(debug);
       rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
-      pub(subjectRTL_433toMQTT, RTLdata); 
-    } else if (status >= 0 ) {      
+      pub(subjectRTL_433toMQTT, RTLdata);
+    } else if (status >= 0) {
       Log.notice(F("RTL_433 get status: %d" CR), status);
       rtl_433.getStatus(status);
-      pub(subjectRTL_433toMQTT, RTLdata); 
+      pub(subjectRTL_433toMQTT, RTLdata);
     } else {
       pub(subjectRTL_433toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("MQTTtoRTL_433 Fail json" CR));

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -96,8 +96,8 @@ int minimumRssi = 0;
 
 /*-------------------RTL_433 topics & parameters----------------------*/
 //433Mhz RTL_433 MQTT Subjects and keys
-#define subjectMQTTtoRTL_433    "/commands/MQTTtoRTL_433"
-#define subjectRTL_433toMQTT    "/RTL_433toMQTT"
+#define subjectMQTTtoRTL_433 "/commands/MQTTtoRTL_433"
+#define subjectRTL_433toMQTT "/RTL_433toMQTT"
 
 /*-------------------CC1101 frequency----------------------*/
 //Match frequency to the hardware version of the radio if ZradioCC1101 is used.

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -47,6 +47,20 @@ extern void PilighttoMQTT();
 extern void MQTTtoPilight(char* topicOri, char* datacallback);
 extern void MQTTtoPilight(char* topicOri, JsonObject& RFdata);
 #endif
+#ifdef ZgatewayRTL_433
+extern void rtl_433loop();
+extern void rtl_433setup();
+extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata);
+extern void enableRTLreceive();
+extern void disableRTLreceive();
+extern int getMinimumRSSI();
+extern int getCurrentRSSI();
+extern int getMessageCount();
+/**
+ * minimumRssi minimum RSSI value to enable receiver
+ */
+int minimumRssi = 0;
+#endif
 /*-------------------RF topics & parameters----------------------*/
 //433Mhz MQTT Subjects and keys
 #define subjectMQTTtoRF    "/commands/MQTTto433"
@@ -79,6 +93,11 @@ extern void MQTTtoPilight(char* topicOri, JsonObject& RFdata);
 #define subjectPilighttoMQTT    "/PilighttoMQTT"
 #define subjectGTWPilighttoMQTT "/PilighttoMQTT"
 #define repeatPilightwMQTT      false // do we repeat a received signal by using mqtt with Pilight gateway
+
+/*-------------------RTL_433 topics & parameters----------------------*/
+//433Mhz RTL_433 MQTT Subjects and keys
+#define subjectMQTTtoRTL_433    "/commands/MQTTtoRTL_433"
+#define subjectRTL_433toMQTT    "/RTL_433toMQTT"
 
 /*-------------------CC1101 frequency----------------------*/
 //Match frequency to the hardware version of the radio if ZradioCC1101 is used.

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -48,14 +48,14 @@ extern void MQTTtoPilight(char* topicOri, char* datacallback);
 extern void MQTTtoPilight(char* topicOri, JsonObject& RFdata);
 #endif
 #ifdef ZgatewayRTL_433
-extern void rtl_433loop();
-extern void rtl_433setup();
+extern void RTL_433Loop();
+extern void setupRTL_433();
 extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata);
 extern void enableRTLreceive();
 extern void disableRTLreceive();
-extern int getMinimumRSSI();
-extern int getCurrentRSSI();
-extern int getMessageCount();
+extern int getRTLMinimumRSSI();
+extern int getRTLCurrentRSSI();
+extern int getRTLMessageCount();
 /**
  * minimumRssi minimum RSSI value to enable receiver
  */

--- a/main/main.ino
+++ b/main/main.ino
@@ -161,8 +161,6 @@ int failure_number_ntwk = 0; // number of failure connecting to network
 int failure_number_mqtt = 0; // number of failure connecting to MQTT
 #ifdef ZmqttDiscovery
 bool disc = true; // Auto discovery with Home Assistant convention
-#else
-bool disc = false; // Auto discovery with Home Assistant convention
 #endif
 unsigned long timer_led_measures = 0;
 
@@ -724,7 +722,7 @@ void setup() {
   setupSHTC3();
 #endif
 #ifdef ZgatewayRTL_433
-  rtl_433setup();
+  setupRTL_433();
   modules.add(ZgatewayRTL_433);
 #endif
   Log.trace(F("mqtt_max_packet_size: %d" CR), mqtt_max_packet_size);
@@ -1360,7 +1358,7 @@ void loop() {
       PWMLoop();
 #endif
 #ifdef ZgatewayRTL_433
-      rtl_433loop();
+      RTL_433Loop();
 #endif
     } else {
       connectMQTT();
@@ -1450,9 +1448,9 @@ void stateMeasures() {
   SYSdata["mhz"] = (int)receiveMhz;
 #  endif
 #  if defined(ZgatewayRTL_433)
-  SYSdata["minimumRssi"] = (int)getMinimumRSSI();
-  SYSdata["currentRssi"] = (int)getCurrentRSSI();
-  SYSdata["messageCount"] = (int)getMessageCount();
+  SYSdata["RTLminRssi"] = (int)getRTLMinimumRSSI();
+  SYSdata["RTLRssi"] = (int)getRTLCurrentRSSI();
+  SYSdata["RTLCnt"] = (int)getRTLMessageCount();
 #  endif
   SYSdata.set("modules", modules);
   pub(subjectSYStoMQTT, SYSdata);

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,7 +118,7 @@ smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.5
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
 shtc3 = https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library
 somfy_remote=Somfy_Remote_Lib@0.2.0
-rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP
+rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP#858cd26
 
 [env]
 framework = arduino
@@ -130,6 +130,7 @@ build_flags =
   -w ; supress all warnings
   '-DjsonPublishing=true'
   '-DjsonReceiving=true'
+;  '-DLOG_LEVEL=LOG_LEVEL_TRACE'  ; Enable trace level logging
 monitor_speed = 115200
 
 [com]
@@ -516,10 +517,7 @@ build_flags =
   '-DZradioCC1101="CC1101"'
   '-DZgatewayRTL_433="rtl_433"'
   '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
-;  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
-;  '-DRTL_DEBUG=4'        // enable rtl_433 verbose device decode
-upload_port = /dev/cu.SLAB_USBtoUART
-upload_speed = 921600
+;  '-DRTL_DEBUG=4'        ; enable rtl_433 verbose device decode
 
 [env:ttgo-lora32-v1]
 platform = ${com.esp32_platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -114,10 +114,11 @@ dallastemperature = DallasTemperature
 m5stickc = M5StickC@0.2.0
 m5stickcp = https://github.com/m5stack/M5StickC-Plus.git
 m5stack = M5Stack@0.3.0
-smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.4
+smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.5
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
 shtc3 = https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library
-somfy_remote=Somfy_Remote_Lib@0.2.0 
+somfy_remote=Somfy_Remote_Lib@0.2.0
+rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP
 
 [env]
 framework = arduino
@@ -502,6 +503,23 @@ build_flags =
   '-DIR_EMITTER_GPIO=12'
   '-DGateway_Name="OpenMQTTGateway_ESP32_ATOM_BLE_IR"'
 board_upload.speed = 1500000
+
+[env:esp32dev-rtl_433]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.rtl_433_ESP}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZradioCC1101="CC1101"'
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
+;  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
+;  '-DRTL_DEBUG=4'        // enable rtl_433 verbose device decode
+upload_port = /dev/cu.SLAB_USBtoUART
+upload_speed = 921600
 
 [env:ttgo-lora32-v1]
 platform = ${com.esp32_platform}


### PR DESCRIPTION
This is my pull request with initial support for using the rtf_433 device decoders on a ESP32 board with a CC1101 Transceiver attached.  Please note that this initial port of the rtf_433 device decoders were brute forced over, to determine the usability of the decoders on in this form factor.

Due to memory and other resource constraints of the rtf_433 device decoders I did not include this in esp32dev-all-test environment, but created a new environment esp32dev-rtl_433.

PS I added a new cmd to the base set to trigger a status message from openMQTTGateway
PSS and fixed a defect when mqttdiscovery is not enabled