### PR TITLE
Wifi reconnection improvements

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -837,7 +837,7 @@ void setup_wifi() {
     Log.trace(F("." CR));
     failure_number_ntwk++;
 #  if defined(ESP32) && defined(ZgatewayBT)
-    if (failure_number_ntwk > maxConnectionRetryWifi)
+    if (failure_number_ntwk > maxConnectionRetryWifi && lowpowermode)
       lowPowerESP32();
 #  endif
   }
@@ -1304,7 +1304,9 @@ void loop() {
     digitalWrite(LED_INFO, !LED_INFO_ON);
     delay(5000);
 #if defined(ESP8266) || defined(ESP32) && !defined(ESP32_ETHERNET)
+#  ifdef ESP32 // If used with ESP8266 this method prevent the reconnection
     WiFi.reconnect();
+#  endif
     Log.warning(F("wifi" CR));
 #else
     Log.warning(F("ethernet" CR));


### PR DESCRIPTION
Deep sleep should be activated only when failing connect on low power mode.
Correct reconnection on esp8266. Unfortunately WiFi.reconnect(); prevent the esp8266 from reconnecting, so we reduce its scope to ESP32