### PR TITLE
Enable deactivation of BLE connect

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -93,6 +93,12 @@ Once the forced scan has completed, the previous scan interval value will be res
 
 The default value `TimeBtwRead` is set into config_BT.h or into your .ini file for platformio users.
 
+If you want to scan continuously for BLE devices, for example for beacon location you can set the interval to 1ms:
+
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"interval":1}'`
+
+In this case you should deactivate the BLE connection mechanism to avoid concurrency between scan and connections (see chapter below, bleconnect).
+
 ::: tip
 For certain devices like LYWSD03MMC OpenMQTTGateway use a connection (due to the fact that the advertized data are encrypted), this connection mechanism is launched after every `ScanBeforeConnect` per default, you can modify it by following the procedure below.
 :::
@@ -105,7 +111,7 @@ If you want to change the number of BLE scans that are done before a BLE connect
 
 The BLE connect will be done every 30 * (`TimeBtwRead` + `Scan_duration`), 30 * (55000 + 10000) = 1950000ms
 
-## Setting if the gateway publish all the BLE devices scanned or only the detected sensors
+## Setting if the gateway publishes all the BLE devices scanned or only the detected sensors
 
 If you want to change this characteristic:
 
@@ -116,6 +122,16 @@ With Home Assistant, this command is directly avalaible through MQTT auto discov
 :::
 
 The gateway will publish only the detected sensors like Mi Flora, Mi jia, LYWSD03MMC... and not the other BLE devices. This is usefull if you don't use the gateway for presence detection but only to retrieve sensors data.
+
+## Setting if the gateway connects to BLE devices eligibles on ESP32
+
+If you want to change this characteristic:
+
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"bleconnect":false}'`
+
+::: tip
+With Home Assistant, this command is directly avalaible through MQTT auto discovery as a switch into the HASS OpenMQTTGateway device entities list.
+:::
 
 ## Setting the minimum RSSI accepted to publish device data
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -744,7 +744,7 @@ void coreTask(void* pvParameters) {
       } else if (!ProcessLock) {
         BLEscan();
         // Launching a connect every BLEscanBeforeConnect
-        if (!(scanCount % BLEscanBeforeConnect) || scanCount == 1)
+        if ((!(scanCount % BLEscanBeforeConnect) || scanCount == 1) && bleConnect)
           BLEconnect();
         dumpDevices();
       }
@@ -1462,7 +1462,8 @@ void BTforceScan() {
     BTtoMQTT();
     Log.trace(F("Scan done" CR));
 #  ifdef ESP32
-    BLEconnect();
+    if (bleConnect)
+      BLEconnect();
 #  endif
   } else {
     Log.trace(F("Cannot launch scan due to other process running" CR));
@@ -1519,6 +1520,15 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
       publishOnlySensors = (bool)BTdata["onlysensors"];
       Log.notice(F("New value onlysensors: %T" CR), publishOnlySensors);
     }
+#  ifdef ESP32
+    // Attempts to connect to elligible devices or not
+    if (BTdata.containsKey("bleconnect")) {
+      Log.trace(F("Do we initiate a connection to retrieve data" CR));
+      Log.trace(F("Previous value: %T" CR), bleConnect);
+      bleConnect = (bool)BTdata["bleconnect"];
+      Log.notice(F("New value bleConnect: %T" CR), bleConnect);
+    }
+#  endif
     // MinRSSI set
     if (BTdata.containsKey("minrssi")) {
       // storing Min RSSI for further use if needed

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -709,6 +709,14 @@ void pubMqttDiscovery() {
                   "", "", true, subjectMQTTtoBTset, //set,payload_avalaible,payload_not avalaible,is a gateway entity, command topic
                   "", "", "", "", true // device name, device manufacturer, device model, device mac, retain
   );
+  createDiscovery("switch", //set Type
+                  "", "BT: Connect to devices", (char*)getUniqueId("bleconnect", "").c_str(), //set state_topic,name,uniqueId
+                  "", "", "", //set availability_topic,device_class,value_template,
+                  "{\"bleconnect\":true}", "{\"bleconnect\":false}", "", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoBTset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
+                  "", "", "", "", true // device name, device manufacturer, device model, device mac, retain
+  );
 #    endif
 #  endif
 }

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -36,6 +36,10 @@ extern void launchBTDiscovery();
 extern int btQueueBlocked;
 extern int btQueueLengthSum;
 extern int btQueueLengthCount;
+#  ifndef AttemptBLECOnnect
+#    define AttemptBLECOnnect true //do we by default attempt a BLE connection to sensors with ESP32
+#  endif
+bool bleConnect = AttemptBLECOnnect;
 #endif
 
 /*----------------------BT topics & parameters-------------------------*/


### PR DESCRIPTION
Useful if you want to scan continuously for BLE devices, in this case, you should deactivate the BLE connect to avoid concurrency between scan and connect callback