### PR TITLE
BLE low power mode and settings optimization

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -617,9 +617,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
  * BLEscan used to retrieve BLE advertized data from devices without connection
  */
 void BLEscan() {
-  TIMERG0.wdt_wprotect = TIMG_WDT_WKEY_VALUE;
-  TIMERG0.wdt_feed = 1;
-  TIMERG0.wdt_wprotect = 0;
+  disableCore0WDT();
   Log.notice(F("Scan begin" CR));
   BLEDevice::init("");
   BLEScan* pBLEScan = BLEDevice::getScan();
@@ -632,6 +630,7 @@ void BLEscan() {
   scanCount++;
   Log.notice(F("Found %d devices, scan number %d end deinit controller" CR), foundDevices.getCount(), scanCount);
   BLEDevice::deinit(true);
+  enableCore0WDT();
 }
 
 /** 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -622,10 +622,12 @@ void BLEscan() {
   TIMERG0.wdt_wprotect = 0;
   Log.notice(F("Scan begin" CR));
   BLEDevice::init("");
-  BLEScan* pBLEScan = BLEDevice::getScan(); //create new scan
+  BLEScan* pBLEScan = BLEDevice::getScan();
   MyAdvertisedDeviceCallbacks myCallbacks;
   pBLEScan->setAdvertisedDeviceCallbacks(&myCallbacks);
-  pBLEScan->setActiveScan(true); //active scan uses more power, but get results faster
+  pBLEScan->setActiveScan(ActiveBLEScan);
+  pBLEScan->setInterval(BLEScanInterval);
+  pBLEScan->setWindow(BLEScanWindow);
   BLEScanResults foundDevices = pBLEScan->start(Scan_duration / 1000, false);
   scanCount++;
   Log.notice(F("Found %d devices, scan number %d end deinit controller" CR), foundDevices.getCount(), scanCount);

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -48,7 +48,16 @@ bool bleConnect = AttemptBLECOnnect;
 #define MinimumRSSI        -100 //default minimum rssi value, all the devices below -90 will not be reported
 
 #ifndef Scan_duration
-#  define Scan_duration 10000 //define the time for a scan --WARNING-- changing this value can lead to instability on ESP32
+#  define Scan_duration 10000 //define the time for a scan
+#endif
+#ifndef BLEScanInterval
+#  define BLEScanInterval 52 // How often the scan occurs / switches channels; in milliseconds,
+#endif
+#ifndef BLEScanWindow
+#  define BLEScanWindow 30 // How long to scan during the interval; in milliseconds.
+#endif
+#ifndef ActiveBLEScan
+#  define ActiveBLEScan true // Set active scanning, this will get more data from the advertiser.
 #endif
 #ifndef ScanBeforeConnect
 #  define ScanBeforeConnect 10 //define number of scans before connecting to BLE devices (ESP32 only, minimum 1)

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,7 @@ extra_configs =
 ;default_envs = esp32dev-weatherstation
 ;default_envs = esp32dev-ir
 ;default_envs = esp32dev-ble
+;default_envs = esp32dev-ble-cont
 ;default_envs = esp32feather-ble
 ;default_envs = esp32-lolin32lite-ble
 ;default_envs = esp32-olimex-gtw-ble-eth
@@ -338,6 +339,23 @@ build_flags =
   '-DLED_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 
+[env:esp32dev-ble-cont]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.ble}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayBT="BT"'
+  '-DLED_RECEIVE=2'
+  '-DLED_RECEIVE_ON=0'
+  '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_C"'
+  '-DTimeBtwRead=0'
+  '-DScan_duration=1000'
+  '-DAttemptBLECOnnect=false'
+
 [env:esp32feather-ble]
 platform = ${com.esp32_platform}
 board = featheresp32
@@ -365,6 +383,17 @@ build_flags =
   '-DLED_RECEIVE=22'
   '-DLED_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_LOLIN32LITE_BLE"'
+;; Low power parameters, uncomment and fill credentials
+;  '-DDEFAULT_LOW_POWER_MODE=0'
+;  '-DTimeBtwRead=550000'
+;  '-DAttemptBLECOnnect=false'
+;  '-DActiveBLEScan=false'
+;  '-DESPWifiManualSetup=true'
+;  '-DMQTT_USER="lolin-esp32"'
+;  '-DMQTT_PASS="your_password"'
+;  '-DMQTT_SERVER="192.168.1.17"'
+;  '-Dwifi_ssid="WIFI_SSID"'
+;  '-Dwifi_password="WIFI_PASSWORD"'
 
 [env:esp32-olimex-gtw-ble-eth]
 platform = ${com.esp32_platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,7 +113,7 @@ fastled = FastLED@3.3.2
 onewire = OneWire
 dallastemperature = DallasTemperature
 m5stickc = M5StickC@0.2.0
-m5stickcp = M5StickC-Plus@0.0.1
+m5stickcp = https://github.com/m5stack/M5StickC-Plus.git
 m5stack = M5Stack@0.3.0
 smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.5
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
@@ -564,6 +564,7 @@ build_flags =
 # https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436
 platform = ${com.esp32_platform}
 board = ttgo-t-beam
+board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.ble}

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,7 +113,7 @@ fastled = FastLED@3.3.2
 onewire = OneWire
 dallastemperature = DallasTemperature
 m5stickc = M5StickC@0.2.0
-m5stickcp = https://github.com/m5stack/M5StickC-Plus.git
+m5stickcp = M5StickC-Plus@0.0.1
 m5stack = M5Stack@0.3.0
 smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.5
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
@@ -136,7 +136,7 @@ monitor_speed = 115200
 
 [com]
 esp8266_platform = espressif8266@2.6.3
-esp32_platform = espressif32@3.0.0
+esp32_platform = espressif32@3.1.1
 atmelavr_platform = atmelavr@3.2.0
 
 [com-esp]


### PR DESCRIPTION
-low power mode settings example
-take into account parameters following #891
-add esp32dev-ble-cont for door/window sensor listening