### PR TITLE
Basic whitelisting/blacklisting support for ZgatewayRF

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -101,7 +101,7 @@ Empty the blacklist (also disables blacklisting):
 
 * The json message size is limited! This means that for each list (black/white) there's a limit and the **JSON_MSG_BUFFER** size must be adjusted in `User_config.h` accordingly for the corresponding platform **if and only if** it has enough **RAM** resources. One can evaluate the buffer size using the [ArduinoJson assistant](https://arduinojson.org/v5/assistant).
 * Only `ESP32/ESP8266/ATMEGA1280/ATMEGA2560` MCUs are supported by this feature
-* Only `ZgatewayRF` is supported for now by this feature for now (`-DZgatewayRF="RF"` build flag)
+* Only `ZgatewayRF` is supported by this feature for now (`-DZgatewayRF="RF"` build flag)
 
 ## Pilight gateway
 

--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -97,9 +97,11 @@ Empty the blacklist (also disables blacklisting):
 
 `home/OpenMQTTGateway_ESP32_RF/commands/MQTTto433/config {"black-list": []}`
 
-**Attention**:
+**Notes**:
 
-The json message size is limited! This means that for each list (black/white) there's a limit and the **JSON_MSG_BUFFER** size must be adjusted in `User_config.h` accordingly for the corresponding platform **if and only if** it has enough **RAM** resources. One can evaluate the buffer size using the [ArduinoJson assistant](https://arduinojson.org/v5/assistant).
+* The json message size is limited! This means that for each list (black/white) there's a limit and the **JSON_MSG_BUFFER** size must be adjusted in `User_config.h` accordingly for the corresponding platform **if and only if** it has enough **RAM** resources. One can evaluate the buffer size using the [ArduinoJson assistant](https://arduinojson.org/v5/assistant).
+* Only `ESP32/ESP8266/ATMEGA1280/ATMEGA2560` MCUs are supported by this feature
+* Only `ZgatewayRF` is supported for now by this feature for now (`-DZgatewayRF="RF"` build flag)
 
 ## Pilight gateway
 

--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -75,6 +75,28 @@ Messages received will include the frequency, and when transmitting on a differe
 
 `{"value":4534142,"protocol":6,"length":26,"delay":356,"mhz":315.026}`
 
+### Whitelisting/Blacklisting devices
+
+This happens based on the unique numeric id that is sent by each RF device. To configure whitelisting one has to write a specific json message on the designated MQTT config topic (a list of numeric id's):
+
+Whitelisting example:
+
+`home/OpenMQTTGateway_ESP32_RF/commands/MQTTto433/config {"white-list": ["110355","110361","110365"]}`
+
+Blacklisting example:
+
+`home/OpenMQTTGateway_ESP32_RF/commands/MQTTto433/config {"black-list": ["931859","931865"]}`
+
+If one needs to disable whitelisting and/or blacklisting just send an empty list like this for each in turn:
+
+Empty the whitelist (also disables whitelisting):
+
+`home/OpenMQTTGateway_ESP32_RF/commands/MQTTto433/config {"white-list": []}`
+
+Empty the blacklist (also disables blacklisting):
+
+`home/OpenMQTTGateway_ESP32_RF/commands/MQTTto433/config {"black-list": []}`
+
 ## Pilight gateway
 
 ### Receiving data from RF signal

--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -97,6 +97,10 @@ Empty the blacklist (also disables blacklisting):
 
 `home/OpenMQTTGateway_ESP32_RF/commands/MQTTto433/config {"black-list": []}`
 
+**Attention**:
+
+The json message size is limited! This means that for each list (black/white) there's a limit and the **JSON_MSG_BUFFER** size must be adjusted in `User_config.h` accordingly for the corresponding platform **if and only if** it has enough **RAM** resources. One can evaluate the buffer size using the [ArduinoJson assistant](https://arduinojson.org/v5/assistant).
+
 ## Pilight gateway
 
 ### Receiving data from RF signal

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -30,18 +30,18 @@
 #ifdef ZgatewayRF
 
 #  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
-#  include <vector>
+#    include <vector>
 using namespace std;
 
 static vector<SIGNAL_SIZE_UL_ULL> whitelisted_devices;
 static vector<SIGNAL_SIZE_UL_ULL> blacklisted_devices;
 
-#define isWhitelistedDevice(id) checkIfDevicePresentInList(id, whitelisted_devices)
-#define isBlacklistedDevice(id) checkIfDevicePresentInList(id, blacklisted_devices)
+#    define isWhitelistedDevice(id) checkIfDevicePresentInList(id, whitelisted_devices)
+#    define isBlacklistedDevice(id) checkIfDevicePresentInList(id, blacklisted_devices)
 #  endif
 
 #  ifdef ZradioCC1101
-#  include <ELECHOUSE_CC1101_SRC_DRV.h>
+#    include <ELECHOUSE_CC1101_SRC_DRV.h>
 #  endif
 
 #  include <RCSwitch.h> // library for controling Radio frequency switch
@@ -156,11 +156,11 @@ void RFtoMQTT() {
 
 #  ifdef simpleReceiving
 void MQTTtoRF(char* topicOri, char* datacallback) {
-#  ifdef ZradioCC1101 // set Receive off and Transmitt on
+#    ifdef ZradioCC1101 // set Receive off and Transmitt on
   ELECHOUSE_cc1101.SetTx(receiveMhz);
   mySwitch.disableReceive();
   mySwitch.enableTransmit(RF_EMITTER_GPIO);
-#  endif
+#    endif
   SIGNAL_SIZE_UL_ULL data = STRTO_UL_ULL(datacallback, NULL, 10); // we will not be able to pass values > 4294967295 on Arduino boards
 
   // RF DATA ANALYSIS
@@ -208,17 +208,17 @@ void MQTTtoRF(char* topicOri, char* datacallback) {
     // Acknowledgement to the GTWRF topic
     pub(subjectGTWRFtoMQTT, datacallback); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
   }
-#  ifdef ZradioCC1101 // set Receive on and Transmitt off
+#    ifdef ZradioCC1101 // set Receive on and Transmitt off
   ELECHOUSE_cc1101.SetRx(receiveMhz);
   mySwitch.disableTransmit();
   mySwitch.enableReceive(RF_RECEIVER_GPIO);
-#  endif
+#    endif
 }
 #  endif
 
 #  ifdef jsonReceiving
 void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
-#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#    ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
   if (cmpToMainTopic(topicOri, subjectMQTTtoRFset)) {
     const char* whiteListJsonKey = "white-list";
     const char* blackListJsonKey = "black-list";
@@ -230,9 +230,9 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
     } else {
       pub(subjectGTWRFtoMQTT, "{\"Status\": \"config error\"}"); // Fail feedback
     }
-  } else 
-#  endif
-  if (cmpToMainTopic(topicOri, subjectMQTTtoRF)) {
+  } else
+#    endif
+      if (cmpToMainTopic(topicOri, subjectMQTTtoRF)) {
     Log.trace(F("MQTTtoRF json" CR));
     SIGNAL_SIZE_UL_ULL data = RFdata["value"];
     if (data != 0) {
@@ -243,7 +243,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       Log.notice(F("RF Protocol:%d" CR), valuePRT);
       Log.notice(F("RF Pulse Lgth: %d" CR), valuePLSL);
       Log.notice(F("Bits nb: %d" CR), valueBITS);
-#  ifdef ZradioCC1101 // set Receive off and Transmitt on
+#    ifdef ZradioCC1101 // set Receive off and Transmitt on
       float trMhz = RFdata["mhz"] | CC1101_FREQUENCY;
       if (validFrequency((int)trMhz)) {
         ELECHOUSE_cc1101.SetTx(trMhz);
@@ -251,7 +251,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
         mySwitch.disableReceive();
         mySwitch.enableTransmit(RF_EMITTER_GPIO);
       }
-#  endif
+#    endif
       mySwitch.setRepeatTransmit(valueRPT);
       mySwitch.setProtocol(valuePRT, valuePLSL);
       mySwitch.send(data, valueBITS);
@@ -259,7 +259,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       pub(subjectGTWRFtoMQTT, RFdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
       mySwitch.setRepeatTransmit(RF_EMITTER_REPEAT); // Restore the default value
     } else {
-#  ifdef ZradioCC1101 // set Receive on and Transmitt off
+#    ifdef ZradioCC1101 // set Receive on and Transmitt off
       float tempMhz = RFdata["mhz"];
       if (tempMhz != 0 && validFrequency((int)tempMhz)) {
         receiveMhz = tempMhz;
@@ -274,17 +274,17 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       pub(subjectGTWRFtoMQTT, "{\"Status\": \"error\"}"); // Fail feedback
 #      endif
       Log.error(F("MQTTtoRF Fail json" CR));
-#  endif
+#    endif
     }
   }
-#  ifdef ZradioCC1101 // set Receive on and Transmitt off
+#    ifdef ZradioCC1101 // set Receive on and Transmitt off
   ELECHOUSE_cc1101.SetRx(receiveMhz);
   mySwitch.disableTransmit();
   mySwitch.enableReceive(RF_RECEIVER_GPIO);
-#  endif
+#    endif
 }
 #  endif
-#  endif
+#endif
 
 #ifdef ZradioCC1101
 bool validFrequency(int mhz) {
@@ -297,4 +297,4 @@ bool validFrequency(int mhz) {
     return true;
   return false;
 }
-#  endif
+#endif

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -29,7 +29,7 @@
 
 #ifdef ZgatewayRF
 
-#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
 #    include <vector>
 using namespace std;
 
@@ -48,7 +48,7 @@ static vector<SIGNAL_SIZE_UL_ULL> blacklisted_devices;
 
 RCSwitch mySwitch = RCSwitch();
 
-#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
 bool checkIfDevicePresentInList(SIGNAL_SIZE_UL_ULL id, vector<SIGNAL_SIZE_UL_ULL>& list) {
   for (size_t i = 0; i < list.size(); i++) {
     if (list[i] == id) {
@@ -126,7 +126,7 @@ void RFtoMQTT() {
     RFdata.set("mhz", receiveMhz);
 #  endif
     mySwitch.resetAvailable();
-#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
     // if there are no whitelisted devices then proceed as usual
     if (!whitelisted_devices.empty() && !isWhitelistedDevice(MQTTvalue)) {
       return;
@@ -218,7 +218,7 @@ void MQTTtoRF(char* topicOri, char* datacallback) {
 
 #  ifdef jsonReceiving
 void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
-#    ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#    if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
   if (cmpToMainTopic(topicOri, subjectMQTTtoRFset)) {
     const char* whiteListJsonKey = "white-list";
     const char* blackListJsonKey = "black-list";
@@ -270,7 +270,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
         Log.error(F("MQTTtoRF Fail json" CR));
       }
 #    else
-#      ifndef ARDUINO_AVR_UNO // Space issues with the UNO
+#      if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // Space issues with the UNO
       pub(subjectGTWRFtoMQTT, "{\"Status\": \"error\"}"); // Fail feedback
 #      endif
       Log.error(F("MQTTtoRF Fail json" CR));

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -29,7 +29,7 @@
 
 #ifdef ZgatewayRF
 
-#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
 #    include <vector>
 using namespace std;
 
@@ -48,7 +48,7 @@ static vector<SIGNAL_SIZE_UL_ULL> blacklisted_devices;
 
 RCSwitch mySwitch = RCSwitch();
 
-#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
 bool checkIfDevicePresentInList(SIGNAL_SIZE_UL_ULL id, vector<SIGNAL_SIZE_UL_ULL>& list) {
   for (size_t i = 0; i < list.size(); i++) {
     if (list[i] == id) {
@@ -126,7 +126,7 @@ void RFtoMQTT() {
     RFdata.set("mhz", receiveMhz);
 #  endif
     mySwitch.resetAvailable();
-#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#  if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
     // if there are no whitelisted devices then proceed as usual
     if (!whitelisted_devices.empty() && !isWhitelistedDevice(MQTTvalue)) {
       return;
@@ -218,7 +218,7 @@ void MQTTtoRF(char* topicOri, char* datacallback) {
 
 #  ifdef jsonReceiving
 void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
-#    if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#    if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
   if (cmpToMainTopic(topicOri, subjectMQTTtoRFset)) {
     const char* whiteListJsonKey = "white-list";
     const char* blackListJsonKey = "black-list";
@@ -270,7 +270,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
         Log.error(F("MQTTtoRF Fail json" CR));
       }
 #    else
-#      if defined(ESP32) || defined(ESP8266) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) // Space issues with the UNO
+#      ifndef ARDUINO_AVR_UNO // Space issues with the UNO
       pub(subjectGTWRFtoMQTT, "{\"Status\": \"error\"}"); // Fail feedback
 #      endif
       Log.error(F("MQTTtoRF Fail json" CR));

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -30,18 +30,18 @@
 #ifdef ZgatewayRF
 
 #  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
-#    include <vector>
+#  include <vector>
 using namespace std;
 
 static vector<SIGNAL_SIZE_UL_ULL> whitelisted_devices;
 static vector<SIGNAL_SIZE_UL_ULL> blacklisted_devices;
 
-#    define isWhitelistedDevice(id) checkIfDevicePresentInList(id, whitelisted_devices)
-#    define isBlacklistedDevice(id) checkIfDevicePresentInList(id, blacklisted_devices)
+#define isWhitelistedDevice(id) checkIfDevicePresentInList(id, whitelisted_devices)
+#define isBlacklistedDevice(id) checkIfDevicePresentInList(id, blacklisted_devices)
 #  endif
 
 #  ifdef ZradioCC1101
-#    include <ELECHOUSE_CC1101_SRC_DRV.h>
+#  include <ELECHOUSE_CC1101_SRC_DRV.h>
 #  endif
 
 #  include <RCSwitch.h> // library for controling Radio frequency switch
@@ -156,11 +156,11 @@ void RFtoMQTT() {
 
 #  ifdef simpleReceiving
 void MQTTtoRF(char* topicOri, char* datacallback) {
-#    ifdef ZradioCC1101 // set Receive off and Transmitt on
+#  ifdef ZradioCC1101 // set Receive off and Transmitt on
   ELECHOUSE_cc1101.SetTx(receiveMhz);
   mySwitch.disableReceive();
   mySwitch.enableTransmit(RF_EMITTER_GPIO);
-#    endif
+#  endif
   SIGNAL_SIZE_UL_ULL data = STRTO_UL_ULL(datacallback, NULL, 10); // we will not be able to pass values > 4294967295 on Arduino boards
 
   // RF DATA ANALYSIS
@@ -208,17 +208,17 @@ void MQTTtoRF(char* topicOri, char* datacallback) {
     // Acknowledgement to the GTWRF topic
     pub(subjectGTWRFtoMQTT, datacallback); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
   }
-#    ifdef ZradioCC1101 // set Receive on and Transmitt off
+#  ifdef ZradioCC1101 // set Receive on and Transmitt off
   ELECHOUSE_cc1101.SetRx(receiveMhz);
   mySwitch.disableTransmit();
   mySwitch.enableReceive(RF_RECEIVER_GPIO);
-#    endif
+#  endif
 }
 #  endif
 
 #  ifdef jsonReceiving
 void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
-#    ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
   if (cmpToMainTopic(topicOri, subjectMQTTtoRFset)) {
     const char* whiteListJsonKey = "white-list";
     const char* blackListJsonKey = "black-list";
@@ -231,7 +231,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       pub(subjectGTWRFtoMQTT, "{\"Status\": \"config error\"}"); // Fail feedback
     }
   } else 
-#    endif
+#  endif
   if (cmpToMainTopic(topicOri, subjectMQTTtoRF)) {
     Log.trace(F("MQTTtoRF json" CR));
     SIGNAL_SIZE_UL_ULL data = RFdata["value"];
@@ -243,7 +243,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       Log.notice(F("RF Protocol:%d" CR), valuePRT);
       Log.notice(F("RF Pulse Lgth: %d" CR), valuePLSL);
       Log.notice(F("Bits nb: %d" CR), valueBITS);
-#    ifdef ZradioCC1101 // set Receive off and Transmitt on
+#  ifdef ZradioCC1101 // set Receive off and Transmitt on
       float trMhz = RFdata["mhz"] | CC1101_FREQUENCY;
       if (validFrequency((int)trMhz)) {
         ELECHOUSE_cc1101.SetTx(trMhz);
@@ -251,7 +251,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
         mySwitch.disableReceive();
         mySwitch.enableTransmit(RF_EMITTER_GPIO);
       }
-#    endif
+#  endif
       mySwitch.setRepeatTransmit(valueRPT);
       mySwitch.setProtocol(valuePRT, valuePLSL);
       mySwitch.send(data, valueBITS);
@@ -259,7 +259,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       pub(subjectGTWRFtoMQTT, RFdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
       mySwitch.setRepeatTransmit(RF_EMITTER_REPEAT); // Restore the default value
     } else {
-#    ifdef ZradioCC1101 // set Receive on and Transmitt off
+#  ifdef ZradioCC1101 // set Receive on and Transmitt off
       float tempMhz = RFdata["mhz"];
       if (tempMhz != 0 && validFrequency((int)tempMhz)) {
         receiveMhz = tempMhz;
@@ -274,14 +274,14 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       pub(subjectGTWRFtoMQTT, "{\"Status\": \"error\"}"); // Fail feedback
 #      endif
       Log.error(F("MQTTtoRF Fail json" CR));
-#    endif
+#  endif
     }
   }
-#    ifdef ZradioCC1101 // set Receive on and Transmitt off
+#  ifdef ZradioCC1101 // set Receive on and Transmitt off
   ELECHOUSE_cc1101.SetRx(receiveMhz);
   mySwitch.disableTransmit();
   mySwitch.enableReceive(RF_RECEIVER_GPIO);
-#    endif
+#  endif
 }
 #  endif
 #  endif

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -29,6 +29,17 @@
 
 #ifdef ZgatewayRF
 
+#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+#    include <vector>
+using namespace std;
+
+static vector<SIGNAL_SIZE_UL_ULL> whitelisted_devices;
+static vector<SIGNAL_SIZE_UL_ULL> blacklisted_devices;
+
+#    define isWhitelistedDevice(id) checkIfDevicePresentInList(id, whitelisted_devices)
+#    define isBlacklistedDevice(id) checkIfDevicePresentInList(id, blacklisted_devices)
+#  endif
+
 #  ifdef ZradioCC1101
 #    include <ELECHOUSE_CC1101_SRC_DRV.h>
 #  endif
@@ -36,6 +47,26 @@
 #  include <RCSwitch.h> // library for controling Radio frequency switch
 
 RCSwitch mySwitch = RCSwitch();
+
+#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+bool checkIfDevicePresentInList(SIGNAL_SIZE_UL_ULL id, vector<SIGNAL_SIZE_UL_ULL>& list) {
+  for (size_t i = 0; i < list.size(); i++) {
+    if (list[i] == id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void refreshDevicesList(vector<SIGNAL_SIZE_UL_ULL>& dev_list, const char* key, JsonObject& data) {
+  dev_list.clear();
+
+  for (int i = 0; i < data[key].size(); i++) {
+    const char* id = data[key][i];
+    dev_list.push_back(STRTO_UL_ULL(id, NULL, 10));
+  }
+}
+#  endif
 
 #  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT)
 void RFtoMQTTdiscovery(SIGNAL_SIZE_UL_ULL MQTTvalue) { //on the fly switch creation from received RF values
@@ -95,7 +126,17 @@ void RFtoMQTT() {
     RFdata.set("mhz", receiveMhz);
 #  endif
     mySwitch.resetAvailable();
+#  ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+    // if there are no whitelisted devices then proceed as usual
+    if (!whitelisted_devices.empty() && !isWhitelistedDevice(MQTTvalue)) {
+      return;
+    }
 
+    // if there are no blacklisted devices then proceed as usual
+    if (!blacklisted_devices.empty() && isBlacklistedDevice(MQTTvalue)) {
+      return;
+    }
+#  endif
     if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of RF -->MQTT
 #  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT) //component creation for HA
       if (disc)
@@ -177,6 +218,20 @@ void MQTTtoRF(char* topicOri, char* datacallback) {
 
 #  ifdef jsonReceiving
 void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
+#    ifndef ARDUINO_AVR_UNO // no whitelist/blacklist support for Arduino UNO - doesn't fit
+  if (cmpToMainTopic(topicOri, subjectMQTTtoRFset)) {
+    const char* whiteListJsonKey = "white-list";
+    const char* blackListJsonKey = "black-list";
+
+    if (RFdata.containsKey(whiteListJsonKey)) {
+      refreshDevicesList(whitelisted_devices, whiteListJsonKey, RFdata);
+    } else if (RFdata.containsKey(blackListJsonKey)) {
+      refreshDevicesList(blacklisted_devices, blackListJsonKey, RFdata);
+    } else {
+      pub(subjectGTWRFtoMQTT, "{\"Status\": \"config error\"}"); // Fail feedback
+    }
+  } else 
+#    endif
   if (cmpToMainTopic(topicOri, subjectMQTTtoRF)) {
     Log.trace(F("MQTTtoRF json" CR));
     SIGNAL_SIZE_UL_ULL data = RFdata["value"];
@@ -229,7 +284,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
 #    endif
 }
 #  endif
-#endif
+#  endif
 
 #ifdef ZradioCC1101
 bool validFrequency(int mhz) {
@@ -242,4 +297,4 @@ bool validFrequency(int mhz) {
     return true;
   return false;
 }
-#endif
+#  endif

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -64,6 +64,7 @@ int minimumRssi = 0;
 /*-------------------RF topics & parameters----------------------*/
 //433Mhz MQTT Subjects and keys
 #define subjectMQTTtoRF    "/commands/MQTTto433"
+#define subjectMQTTtoRFset "/commands/MQTTto433/config"
 #define subjectRFtoMQTT    "/433toMQTT"
 #define subjectGTWRFtoMQTT "/433toMQTT"
 #define RFprotocolKey      "433_" // protocol will be defined if a subject contains RFprotocolKey followed by a value of 1 digit

--- a/platformio.ini
+++ b/platformio.ini
@@ -82,6 +82,7 @@ extra_configs =
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [libraries]
+arduino_stl = ciband/avr_stl @ ^1.2.3
 arduinojson = ArduinoJson@5.13.4
 arduinolog = https://github.com/1technophile/Arduino-Log.git#d13cd80
 pubsubclient = PubSubClient@2.8
@@ -154,6 +155,7 @@ build_flags =
 lib_deps =
   ${env.lib_deps}
   ${libraries.ethernet}
+  ${libraries.arduino_stl}
 build_flags =
   ${env.build_flags}
   '-DsimpleReceiving=true'


### PR DESCRIPTION
Basic whitelisting/blacklisting support for the ZGatewayRF. Nothing fancy or complicated just a simple filtering based on the unique RC switch code being sent. This avoids creating in Home Assistant for example redundant entities because the RF receiver "catches signals" from other devices around the house or neighbors.

I tested both whitelisting/blacklisting and seems to work as expected. Disabling whitelisting/blacklisting is also supported.

Hope it helps.