### PR TITLE
Typo fix

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -290,7 +290,7 @@ This function does not work when all available decoders are enabled and triggers
 
 ### Retrieve current status of receiver
 
-`home/OpenMQTTGateway/commands/MQTTtoRTL_433 {"status":-1}`
+`home/OpenMQTTGateway/commands/MQTTtoRTL_433 {"status":1}`
 
 ```
 {"model":"status",


### PR DESCRIPTION
Typo in sending status command to MQTTtoRTL_433. "-1" should be "1" as it produces an error otherwise.