### PR TITLE
Usability Improvements for esp32 platform

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -327,9 +327,9 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #ifdef ZgatewaySRFB
 #  define SERIAL_BAUD 19200
 #else
-#ifndef SERIAL_BAUD
-#  define SERIAL_BAUD 115200
-#endif
+#  ifndef SERIAL_BAUD
+#    define SERIAL_BAUD 115200
+#  endif
 #endif
 /*--------------MQTT general topics-----------------*/
 // global MQTT subject listened by the gateway to execute commands (send RF, IR or others)

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -327,7 +327,9 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #ifdef ZgatewaySRFB
 #  define SERIAL_BAUD 19200
 #else
+#ifndef SERIAL_BAUD
 #  define SERIAL_BAUD 115200
+#endif
 #endif
 /*--------------MQTT general topics-----------------*/
 // global MQTT subject listened by the gateway to execute commands (send RF, IR or others)

--- a/main/main.ino
+++ b/main/main.ino
@@ -831,7 +831,6 @@ void setupTLS() {
 #if defined(ESPWifiManualSetup)
 void setup_wifi() {
   WiFi.mode(WIFI_STA);
-  Serial.setDebugOutput(true);
   wifiMulti.addAP(wifi_ssid, wifi_password);
   Log.trace(F("Connecting to %s" CR), wifi_ssid);
 #  ifdef wifi_ssid1


### PR DESCRIPTION
I had been using these for a while with my devices, and wanted to share these usability improvements for others

1 - Ability to set **SERIAL_BAUD** via a compiler directive and platformio ini file, to allow using the higher serial speeds available with the ESP platform.

2 - In **ESPWifiManualSetup** add the ability to define a second SSID/Password via compiler directive wifi_ssid1/wifi_password1 and have the unit select the available one on startup.  For both ESP8266 and ESP32 platforms.

3 - Add support for MDNS_SD for lookup of mqtt service address on ESP32 platform.

4 - Resolve issue with MDNS_SD not working on esp8266 platform.  Arduino OTA was initializing MDNS and causing MDNS.begin to fail.  As this feature may not be widely used I'm not sure if this issue was reported.