### PR TITLE
Active Receiver Switching

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -1,11 +1,9 @@
 
 # RF gateways  (433mhz/315mhz)
 
-Note that for the moment RF, RF2, RTL_433 and Pilight can not be activated on the same boards together.
+## Changing Active Receiver Modules
 
 With version 0.9.7 the ability to switch active signal receiver and decoder is supported between RF, RF2, RTL_433 and Pilight receiver modules.
-
-## Changing Active Receiver Modules
 
 ### Switching Active Receiver Module
 

--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -1,7 +1,44 @@
 
 # RF gateways  (433mhz/315mhz)
 
-Note that for the moment RF, RF2 and Pilight can not be activated on the same boards together.
+Note that for the moment RF, RF2, RTL_433 and Pilight can not be activated on the same boards together.
+
+With version 0.9.7 the ability to switch active signal receiver and decoder is supported between RF, RF2, RTL_433 and Pilight receiver modules.
+
+## Changing Active Receiver Modules
+
+### Switching Active Receiver Module
+
+Switching of the active receiver module is available between the RF, RF2, RTL_433 and Pilight Gateway modules, allowing for changing of signal decoders without redploying the openMQTTGateway package.  Sending a JSON message to the command topic of the desired receiver will change the active receiver module.
+
+To enable the RF Gateway module send a json message to the RF Gateway module command subject with the key being 'active', and any value.  The value at this time is ignored. 
+
+Example:
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTto433" -m '{"active":true}'`
+
+To enable the PiLight Gateway module send a json message to the PiLight Gateway module command subject with the key being 'active', and any value.  The value at this time is ignored. 
+
+Example:
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight" -m '{"active":true}'`
+
+To enable the RF2 Gateway module send a json message to the RF2 Gateway module command subject with the key being 'active', and any value.  The value at this time is ignored. 
+
+Example:
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoRF2" -m '{"active":true}'`
+
+To enable the RTL_433 Gateway module send a json message to the RTL_433 Gateway module command subject with the key being 'active', and any value.  The value at this time is ignored. 
+
+Example:
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoRTL_433" -m '{"active":true}'`
+
+### Status Messages
+
+The openMQTTGateway status message contains a key `actRec` which is the current active receiver module.
+
+1 - PiLight
+2 - RF
+3 - RTL_433
+4 - RF2
 
 ## RCSwitch based gateway
 
@@ -190,84 +227,81 @@ for on:
 This feature is only available on a ESP32 based device with a CC1101 transceiver connected due to the resource requirements of the rtl_433 device decoders.  At the present time only Pulse Position Modulation (OOK_PPM) and Pulse Width Modulation (OOK_PWM) based decoders are available.
 
 ```
-Registering protocol [1] "Silvercrest Remote Control"
-Registering protocol [2] "Rubicson Temperature Sensor"
-Registering protocol [3] "Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor"
-Registering protocol [4] "Waveman Switch Transmitter"
-Registering protocol [8] "LaCrosse TX Temperature / Humidity Sensor"
-Registering protocol [11] "Acurite 609TXC Temperature and Humidity Sensor"
-Registering protocol [15] "KlikAanKlikUit Wireless Switch"
-Registering protocol [16] "AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)"
-Registering protocol [17] "Cardin S466-TX2"
-Registering protocol [18] "Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor"
-Registering protocol [19] "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor"
-Registering protocol [21] "Calibeur RF-104 Sensor"
-Registering protocol [25] "Globaltronics GT-WT-02 Sensor"
-Registering protocol [29] "Chuango Security Technology"
-Registering protocol [30] "Generic Remote SC226x EV1527"
-Registering protocol [31] "TFA-Twin-Plus-30.3049, Conrad KW9010, Ea2 BL999"
-Registering protocol [32] "Fine Offset Electronics WH1080/WH3080 Weather Station"
-Registering protocol [34] "LaCrosse WS-2310 / WS-3600 Weather Station"
-Registering protocol [35] "Esperanza EWS"
-Registering protocol [38] "Generic temperature sensor 1"
-Registering protocol [39] "WG-PB12V1 Temperature Sensor"
-Registering protocol [40] "Acurite 592TXR Temp/Humidity, 5n1 Weather Station, 6045 Lightning, 3N1, Atlas"
-Registering protocol [41] "Acurite 986 Refrigerator / Freezer Thermometer"
+Registering protocol [2] "Acurite 609TXC Temperature and Humidity Sensor"
+Registering protocol [3] "Acurite 592TXR Temp/Humidity, 5n1 Weather Station, 6045 Lightning, 3N1, Atlas"
+Registering protocol [4] "Acurite 986 Refrigerator / Freezer Thermometer"
+Registering protocol [5] "Acurite 606TX Temperature Sensor"
+Registering protocol [6] "Acurite 00275rm,00276rm Temp/Humidity with optional probe"
+Registering protocol [7] "Acurite 590TX Temperature with optional Humidity"
+Registering protocol [8] "Akhan 100F14 remote keyless entry"
+Registering protocol [9] "AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)"
+Registering protocol [10] "Ambient Weather TX-8300 Temperature/Humidity Sensor"
+Registering protocol [11] "Auriol AFW2A1 temperature/humidity sensor"
+Registering protocol [12] "Auriol HG02832, HG05124A-DCF, Rubicson 48957 temperature/humidity sensor"
+Registering protocol [13] "BlueLine Power Monitor"
+Registering protocol [14] "Blyss DC5-UK-WH"
+Registering protocol [16] "Bresser Thermo-/Hygro-Sensor 3CH"
+Registering protocol [18] "Burnhard BBQ thermometer"
+Registering protocol [19] "Calibeur RF-104 Sensor"
+Registering protocol [20] "Cardin S466-TX2"
+Registering protocol [21] "Chuango Security Technology"
+Registering protocol [22] "Companion WTR001 Temperature Sensor"
+Registering protocol [25] "Ecowitt Wireless Outdoor Thermometer WH53/WH0280/WH0281A"
+Registering protocol [26] "Eurochron EFTH-800 temperature and humidity sensor"
+Registering protocol [30] "Esperanza EWS"
+Registering protocol [32] "Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor"
+Registering protocol [33] "Fine Offset Electronics, WH0530 Temperature/Rain Sensor"
+Registering protocol [34] "Fine Offset WH1050 Weather Station"
+Registering protocol [35] "Fine Offset Electronics WH1080/WH3080 Weather Station"
+Registering protocol [37] "FT-004-B Temperature Sensor"
+Registering protocol [38] "Generic wireless motion sensor"
+Registering protocol [39] "Generic Remote SC226x EV1527"
+Registering protocol [40] "Generic temperature sensor 1"
+Registering protocol [41] "Globaltronics QUIGG GT-TMBBQ-05"
+Registering protocol [42] "Globaltronics GT-WT-02 Sensor"
+Registering protocol [43] "Globaltronics GT-WT-03 Sensor"
+Registering protocol [44] "Microchip HCS200 KeeLoq Hopping Encoder based remotes"
+Registering protocol [45] "Honeywell ActivLink, Wireless Doorbell"
 Registering protocol [46] "HT680 Remote control"
-Registering protocol [47] "Conrad S3318P, FreeTec NC-5849-913 temperature humidity sensor"
-Registering protocol [48] "Akhan 100F14 remote keyless entry"
-Registering protocol [49] "Quhwa"
-Registering protocol [51] "Skylink HA-434TL motion sensor"
-Registering protocol [53] "Springfield Temperature and Soil Moisture"
-Registering protocol [54] "Oregon Scientific SL109H Remote Thermal Hygro Sensor"
-Registering protocol [55] "Acurite 606TX Temperature Sensor"
-Registering protocol [56] "TFA pool temperature sensor"
-Registering protocol [57] "Kedsum Temperature & Humidity Sensor, Pearl NC-7415"
-Registering protocol [58] "Blyss DC5-UK-WH"
-Registering protocol [68] "Kerui PIR / Contact Sensor"
-Registering protocol [69] "Fine Offset WH1050 Weather Station"
-Registering protocol [73] "LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor"
-Registering protocol [74] "Acurite 00275rm,00276rm Temp/Humidity with optional probe"
-Registering protocol [79] "Fine Offset Electronics, WH0530 Temperature/Rain Sensor"
-Registering protocol [84] "Thermopro TP11 Thermometer"
-Registering protocol [85] "Solight TE44/TE66, EMOS E0107T, NX-6876-917"
-Registering protocol [86] "Wireless Smoke and Heat Detector GS 558"
-Registering protocol [87] "Generic wireless motion sensor"
-Registering protocol [91] "inFactory, nor-tec, FreeTec NC-3982-913 temperature humidity sensor"
-Registering protocol [92] "FT-004-B Temperature Sensor"
-Registering protocol [94] "Philips outdoor temperature sensor (type AJ3650)"
-Registering protocol [96] "Nexa"
-Registering protocol [97] "Thermopro TP08/TP12/TP20 thermometer"
-Registering protocol [99] "X10 Security"
-Registering protocol [100] "Interlogix GE UTC Security Devices"
-Registering protocol [108] "Hyundai WS SENZOR Remote Temperature Sensor"
-Registering protocol [109] "WT0124 Pool Thermometer"
-Registering protocol [112] "Ambient Weather TX-8300 Temperature/Humidity Sensor"
-Registering protocol [114] "Maverick et73"
-Registering protocol [115] "Honeywell ActivLink, Wireless Doorbell"
-Registering protocol [121] "Opus/Imagintronix XT300 Soil Moisture"
-Registering protocol [124] "LaCrosse/ELV/Conrad WS7000/WS2500 weather sensors"
-Registering protocol [125] "TS-FT002 Wireless Ultrasonic Tank Liquid Level Meter With Temperature Sensor"
-Registering protocol [126] "Companion WTR001 Temperature Sensor"
-Registering protocol [127] "Ecowitt Wireless Outdoor Thermometer WH53/WH0280/WH0281A"
-Registering protocol [131] "Microchip HCS200 KeeLoq Hopping Encoder based remotes"
-Registering protocol [133] "Rubicson 48659 Thermometer"
-Registering protocol [135] "Philips outdoor temperature sensor (type AJ7010)"
-Registering protocol [137] "Globaltronics QUIGG GT-TMBBQ-05"
-Registering protocol [138] "Globaltronics GT-WT-03 Sensor"
-Registering protocol [141] "Auriol HG02832, HG05124A-DCF, Rubicson 48957 temperature/humidity sensor"
-Registering protocol [145] "WS2032 weather station"
-Registering protocol [146] "Auriol AFW2A1 temperature/humidity sensor"
-Registering protocol [147] "TFA Drop Rain Gauge 30.3233.01"
-Registering protocol [151] "Visonic powercode"
-Registering protocol [152] "Eurochron EFTH-800 temperature and humidity sensor"
-Registering protocol [157] "Missil ML0757 weather station"
-Registering protocol [163] "Acurite 590TX Temperature with optional Humidity"
-Registering protocol [164] "Burnhard BBQ thermometer"
-Registering protocol [165] "TFA Dostmann 30.3221.02 T/H Outdoor Sensor"
-Registering protocol [167] "BlueLine Power Monitor"
-Registering protocol [174] "Bresser Thermo-/Hygro-Sensor 3CH"
-Registering protocol [178] "Proove / Nexa / KlikAanKlikUit Wireless Switch"
+Registering protocol [47] "inFactory, nor-tec, FreeTec NC-3982-913 temperature humidity sensor"
+Registering protocol [49] "Interlogix GE UTC Security Devices"
+Registering protocol [51] "Kedsum Temperature & Humidity Sensor, Pearl NC-7415"
+Registering protocol [52] "Kerui PIR / Contact Sensor"
+Registering protocol [53] "LaCrosse TX Temperature / Humidity Sensor"
+Registering protocol [54] "LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor"
+Registering protocol [55] "LaCrosse/ELV/Conrad WS7000/WS2500 weather sensors"
+Registering protocol [56] "LaCrosse WS-2310 / WS-3600 Weather Station"
+Registering protocol [58] "Maverick et73"
+Registering protocol [60] "Missil ML0757 weather station"
+Registering protocol [64] "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor"
+Registering protocol [66] "Opus/Imagintronix XT300 Soil Moisture"
+Registering protocol [67] "Oregon Scientific SL109H Remote Thermal Hygro Sensor"
+Registering protocol [69] "Philips outdoor temperature sensor (type AJ3650)"
+Registering protocol [70] "Philips outdoor temperature sensor (type AJ7010)"
+Registering protocol [71] "Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor"
+Registering protocol [73] "Quhwa"
+Registering protocol [75] "Rubicson Temperature Sensor"
+Registering protocol [76] "Rubicson 48659 Thermometer"
+Registering protocol [77] "Conrad S3318P, FreeTec NC-5849-913 temperature humidity sensor"
+Registering protocol [78] "Silvercrest Remote Control"
+Registering protocol [79] "Skylink HA-434TL motion sensor"
+Registering protocol [80] "Wireless Smoke and Heat Detector GS 558"
+Registering protocol [81] "Solight TE44/TE66, EMOS E0107T, NX-6876-917"
+Registering protocol [82] "Springfield Temperature and Soil Moisture"
+Registering protocol [83] "TFA Dostmann 30.3221.02 T/H Outdoor Sensor"
+Registering protocol [84] "TFA Drop Rain Gauge 30.3233.01"
+Registering protocol [85] "TFA pool temperature sensor"
+Registering protocol [86] "TFA-Twin-Plus-30.3049, Conrad KW9010, Ea2 BL999"
+Registering protocol [87] "Thermopro TP11 Thermometer"
+Registering protocol [88] "Thermopro TP08/TP12/TP20 thermometer"
+Registering protocol [90] "TS-FT002 Wireless Ultrasonic Tank Liquid Level Meter With Temperature Sensor"
+Registering protocol [91] "Visonic powercode"
+Registering protocol [92] "Waveman Switch Transmitter"
+Registering protocol [93] "WG-PB12V1 Temperature Sensor"
+Registering protocol [94] "WS2032 weather station"
+Registering protocol [95] "Hyundai WS SENZOR Remote Temperature Sensor"
+Registering protocol [96] "WT0124 Pool Thermometer"
+Registering protocol [98] "X10 Security"
 ```
 
 ### Change receive frequency

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -327,7 +327,9 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #ifdef ZgatewaySRFB
 #  define SERIAL_BAUD 19200
 #else
-#  define SERIAL_BAUD 115200
+#  ifndef SERIAL_BAUD
+#    define SERIAL_BAUD 115200
+#  endif
 #endif
 /*--------------MQTT general topics-----------------*/
 // global MQTT subject listened by the gateway to execute commands (send RF, IR or others)

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -220,7 +220,6 @@ extern void enablePilightReceive() {
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
   rf.setCallback(pilightCallback);
-  rf.enableReceiver();
   rf.initReceiver(RF_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
 };

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -78,7 +78,6 @@ void setupPilight() {
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.setMHZ(CC1101_FREQUENCY);
   ELECHOUSE_cc1101.SetRx(CC1101_FREQUENCY);
-  // rf.enableReceiver();
 #  endif
   rf.setCallback(pilightCallback);
   rf.initReceiver(RF_RECEIVER_GPIO);

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -56,9 +56,11 @@ void RFtoMQTTdiscovery(SIGNAL_SIZE_UL_ULL MQTTvalue) { //on the fly switch creat
 #  endif
 
 void setupRF() {
-  //RF init parameters
+//RF init parameters
+#  ifndef ARDUINO_AVR_UNO // Space issues with the UNO
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
   Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
+#  endif
 #  ifdef ZradioCC1101 //receiving with CC1101
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz);
@@ -244,10 +246,12 @@ void disableRFReceive() {
 }
 
 void enableRFReceive() {
-  #  ifdef ZradioCC1101
+#  ifdef ZradioCC1101
   Log.notice(F("Switching to RF Receiver: %F" CR), receiveMhz);
 #  else
+#    ifndef ARDUINO_AVR_UNO // Space issues with the UNO
   Log.notice(F("Switching to RF Receiver" CR));
+#    endif
 #  endif
 #  ifdef ZgatewayPilight
   disablePilightReceive();

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -258,7 +258,7 @@ void enableRFReceive() {
 #    endif
 #  endif
 #  ifdef ZgatewayRF2
-  disableRF2receive();
+  disableRF2Receive();
 #  endif
 
 #  ifdef ZradioCC1101 // set Receive on and Transmitt off

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -229,17 +229,34 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
 #    endif
 }
 #  endif
-#endif
 
-#ifdef ZradioCC1101
-bool validFrequency(int mhz) {
-  //  CC1101 valid frequencies 300-348 MHZ, 387-464MHZ and 779-928MHZ.
-  if (mhz >= 300 && mhz <= 348)
-    return true;
-  if (mhz >= 387 && mhz <= 464)
-    return true;
-  if (mhz >= 779 && mhz <= 928)
-    return true;
-  return false;
+int receiveInterupt = -1;
+
+void disableRFReceive() {
+  Log.trace(F("disableRFReceive" CR));
+#  ifdef ZgatewayPilight
+// enablePilightReceive();
+#  endif
+  if (receiveInterupt != -1) {
+    receiveInterupt = -1;
+    mySwitch.disableReceive();
+  }
+}
+
+void enableRFReceive() {
+  Log.trace(F("enableRFReceive" CR));
+#  ifdef ZgatewayPilight
+  disablePilightReceive();
+#  endif
+#  ifdef ZgatewayRTL_433
+  disableRTLreceive();
+#  endif
+
+#  ifdef ZradioCC1101 // set Receive on and Transmitt off
+  ELECHOUSE_cc1101.SetRx(receiveMhz);
+  #  endif
+  mySwitch.disableTransmit();
+  receiveInterupt = RF_RECEIVER_GPIO;
+  mySwitch.enableReceive(RF_RECEIVER_GPIO);
 }
 #endif

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -57,10 +57,8 @@ void RFtoMQTTdiscovery(SIGNAL_SIZE_UL_ULL MQTTvalue) { //on the fly switch creat
 
 void setupRF() {
 //RF init parameters
-#  ifndef ARDUINO_AVR_UNO // Space issues with the UNO
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
   Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
-#  endif
 #  ifdef ZradioCC1101 //receiving with CC1101
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz);
@@ -249,18 +247,18 @@ void enableRFReceive() {
 #  ifdef ZradioCC1101
   Log.notice(F("Switching to RF Receiver: %F" CR), receiveMhz);
 #  else
-#    ifndef ARDUINO_AVR_UNO // Space issues with the UNO
   Log.notice(F("Switching to RF Receiver" CR));
+#  endif
+#  ifndef ARDUINO_AVR_UNO // Space issues with the UNO
+#    ifdef ZgatewayPilight
+  disablePilightReceive();
+#    endif
+#    ifdef ZgatewayRTL_433
+  disableRTLreceive();
 #    endif
 #  endif
-#  ifdef ZgatewayPilight
-  disablePilightReceive();
-#  endif
-#  ifdef ZgatewayRTL_433
-  disableRTLreceive();
-#  endif
-#  ifdef ZgatewayRTL_433
-  disableRTLreceive();
+#  ifdef ZgatewayRF2
+  disableRF2receive();
 #  endif
 
 #  ifdef ZradioCC1101 // set Receive on and Transmitt off

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -56,7 +56,7 @@ void RFtoMQTTdiscovery(SIGNAL_SIZE_UL_ULL MQTTvalue) { //on the fly switch creat
 #  endif
 
 void setupRF() {
-//RF init parameters
+  //RF init parameters
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
   Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
 #  ifdef ZradioCC1101 //receiving with CC1101

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -334,7 +334,7 @@ void MQTTtoRF2(char* topicOri, JsonObject& RF2data) { // json object decoding
 #  endif
 
 void disableRF2Receive() {
-  Log.trace(F("disableRF2Receive: %d" CR), NewRemoteReceiver::_interrupt);
+  Log.trace(F("disableRF2Receive" CR));
   NewRemoteReceiver::deinit();
   NewRemoteReceiver::init(-1, 2, rf2Callback); // mark _interupt with -1
   NewRemoteReceiver::deinit();

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -41,7 +41,19 @@ void rtl_433_Callback(char* message) {
   DynamicJsonBuffer jsonBuffer2(JSON_MSG_BUFFER);
   JsonObject& RFrtl_433_ESPdata = jsonBuffer2.parseObject(message);
 
-  pub(subjectRTL_433toMQTT, RFrtl_433_ESPdata);
+  String topic = String(subjectRTL_433toMQTT);
+#  ifdef valueAsASubject
+  String model = RFrtl_433_ESPdata["model"];
+  String id = RFrtl_433_ESPdata["id"];
+  if (model != 0) {
+    topic = topic + "/" + model;
+    if (id != 0) {
+      topic = topic + "/" + id;
+    }
+  }
+#  endif
+
+  pub((char*)topic.c_str(), RFrtl_433_ESPdata);
 #  ifdef MEMORY_DEBUG
   Log.trace(F("Post rtl_433_Callback: %d" CR), ESP.getFreeHeap());
 #  endif

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -27,7 +27,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "User_config.h"
-
 #ifdef ZgatewayRTL_433
 
 #  include <rtl_433_ESP.h>
@@ -51,9 +50,8 @@ void rtl_433_Callback(char* message) {
 void setupRTL_433() {
   rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
   rtl_433.setCallback(rtl_433_Callback, messageBuffer, JSON_MSG_BUFFER);
-  Log.notice(F("ZgatewayRTL_433 command topic: %s%s" CR), mqtt_topic, subjectMQTTtoRTL_433);
-  enableRTLreceive();
-  Log.trace(F("ZgatewayRTL_433 setup done " CR));
+  Log.trace(F("ZgatewayRTL_433 command topic: %s%s" CR), mqtt_topic, subjectMQTTtoRTL_433);
+  Log.notice(F("ZgatewayRTL_433 setup done " CR));
 }
 
 void RTL_433Loop() {
@@ -62,41 +60,59 @@ void RTL_433Loop() {
 
 extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
   if (cmpToMainTopic(topicOri, subjectMQTTtoRTL_433)) {
-    Log.trace(F("MQTTtoRTL_433 %s" CR), topicOri);
-    float tempMhz = RTLdata["mhz"] | 0;
-    int minimumRssi = RTLdata["rssi"] | 0;
-    int debug = RTLdata["debug"] | -1;
-    int status = RTLdata["status"] | -1;
-    if (tempMhz != 0 && validFrequency((int)tempMhz)) {
-      //  activeReceiver = RTL; // Enable RTL_433 Gateway
+    float tempMhz = RTLdata["mhz"];
+    bool success = false;
+    if (RTLdata.containsKey("mhz") && validFrequency(tempMhz)) {
       receiveMhz = tempMhz;
       Log.notice(F("RTL_433 Receive mhz: %F" CR), receiveMhz);
-      pub(subjectRTL_433toMQTT, RTLdata);
-    } else if (minimumRssi != 0) {
+      success = true;
+    }
+    if (RTLdata.containsKey("active")) {
+      Log.trace(F("RTL_433 active:" CR));
+      activeReceiver = ACTIVE_RTL; // Enable RTL_433 Gateway
+      success = true;
+    }
+    if (RTLdata.containsKey("rssi")) {
+      int minimumRssi = RTLdata["rssi"] | 0;
       Log.notice(F("RTL_433 minimum RSSI: %d" CR), minimumRssi);
       rtl_433.setMinimumRSSI(minimumRssi);
-      pub(subjectRTL_433toMQTT, RTLdata);
-    } else if (debug >= 0 && debug <= 4) {
+      success = true;
+    }
+    if (RTLdata.containsKey("debug")) {
+      int debug = RTLdata["debug"] | -1;
       Log.notice(F("RTL_433 set debug: %d" CR), debug);
       rtl_433.setDebug(debug);
       rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
-      pub(subjectRTL_433toMQTT, RTLdata);
-    } else if (status >= 0) {
-      Log.notice(F("RTL_433 get status: %d" CR), status);
-      rtl_433.getStatus(status);
+      success = true;
+    }
+    if (RTLdata.containsKey("status")) {
+      Log.notice(F("RTL_433 get status:" CR));
+      rtl_433.getStatus(1);
+      success = true;
+    }
+    if (success) {
       pub(subjectRTL_433toMQTT, RTLdata);
     } else {
       pub(subjectRTL_433toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("MQTTtoRTL_433 Fail json" CR));
     }
+    enableActiveReceiver();
   }
 }
 
 extern void enableRTLreceive() {
-  Log.trace(F("enableRTLreceive: %F" CR), receiveMhz);
+  Log.notice(F("Switching to RTL_433 Receiver: %FMhz" CR), receiveMhz);
+#  ifdef ZgatewayRF
+  disableRFReceive();
+#  endif
+#  ifdef ZgatewayRF2
+  disableRF2Receive();
+#  endif
+#  ifdef ZgatewayPilight
+  disablePilightReceive();
+#  endif
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
   rtl_433.enableReceiver(RF_RECEIVER_GPIO);
-  // rtl_433.initReceiver(RF_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
 }
 

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -198,8 +198,10 @@ void enableActiveReceiver() {
       enableRF2Receive();
       break;
 #  endif
+#  ifndef ARDUINO_AVR_UNO // Space issues with the UNO
     default:
       Log.error(F("ERROR: unsupported receiver %d" CR), activeReceiver);
+#  endif
   }
   currentReceiver = activeReceiver;
 }

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -34,6 +34,8 @@ extern void setupRF();
 extern void RFtoMQTT();
 extern void MQTTtoRF(char* topicOri, char* datacallback);
 extern void MQTTtoRF(char* topicOri, JsonObject& RFdata);
+extern void disableRFReceive();
+extern void enableRFReceive();
 #endif
 #ifdef ZgatewayRF2
 extern void setupRF2();
@@ -46,6 +48,8 @@ extern void setupPilight();
 extern void PilighttoMQTT();
 extern void MQTTtoPilight(char* topicOri, char* datacallback);
 extern void MQTTtoPilight(char* topicOri, JsonObject& RFdata);
+extern void disablePilightReceive();
+extern void enablePilightReceive();
 #endif
 #ifdef ZgatewayRTL_433
 extern void RTL_433Loop();
@@ -134,6 +138,61 @@ float receiveMhz = CC1101_FREQUENCY;
 //RF PIN definition
 #    define RF_EMITTER_GPIO 4 //4 = D4 on arduino
 #  endif
+#endif
+
+#if defined(ZgatewayRF)  || defined(ZgatewayPilight) ||  defined(ZgatewayRTL_433)
+/**
+ * Active Receiver Module
+ * 1 = ZgatewayPilight
+ * 2 = ZgatewayRF
+ * 3 = ZgatewayRTL_433
+ */
+int activeReceiver = 0;
+#  define ACTIVE_RECERROR 0
+#  define ACTIVE_PILIGHT 1
+#  define ACTIVE_RF      2
+#  define ACTIVE_RTL     3
+
+#  ifdef ZradioCC1101
+bool validFrequency(int mhz) {
+  //  CC1101 valid frequencies 300-348 MHZ, 387-464MHZ and 779-928MHZ.
+  if (mhz >= 300 && mhz <= 348)
+    return true;
+  if (mhz >= 387 && mhz <= 464)
+    return true;
+  if (mhz >= 779 && mhz <= 928)
+    return true;
+  return false;
+}
+#  endif
+
+int currentReceiver = -1;
+
+extern void stateMeasures();  // Send a status message 
+
+void enableActiveReceiver() {
+  // if (currentReceiver != activeReceiver) {
+  Log.trace(F("enableActiveReceiver: %d" CR), activeReceiver);
+  switch (activeReceiver) {
+#  ifdef ZgatewayPilight
+    case ACTIVE_PILIGHT:
+      enablePilightReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRF
+    case ACTIVE_RF:
+      enableRFReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRTL_433
+    case ACTIVE_RTL:
+      enableRTLreceive();
+      break;
+#  endif
+  }
+  stateMeasures();  // Send a status message 
+  currentReceiver = activeReceiver;
+}
 #endif
 
 #endif

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -42,6 +42,8 @@ extern void setupRF2();
 extern void RF2toMQTT();
 extern void MQTTtoRF2(char* topicOri, char* datacallback);
 extern void MQTTtoRF2(char* topicOri, JsonObject& RFdata);
+extern void disableRF2Receive();
+extern void enableRF2Receive();
 #endif
 #ifdef ZgatewayPilight
 extern void setupPilight();
@@ -140,21 +142,23 @@ float receiveMhz = CC1101_FREQUENCY;
 #  endif
 #endif
 
-#if defined(ZgatewayRF)  || defined(ZgatewayPilight) ||  defined(ZgatewayRTL_433)
+#if defined(ZgatewayRF) || defined(ZgatewayPilight) || defined(ZgatewayRTL_433) || defined(ZgatewayRF2)
 /**
  * Active Receiver Module
  * 1 = ZgatewayPilight
  * 2 = ZgatewayRF
  * 3 = ZgatewayRTL_433
+ * 4 = ZgatewayRF2
  */
 int activeReceiver = 0;
 #  define ACTIVE_RECERROR 0
-#  define ACTIVE_PILIGHT 1
-#  define ACTIVE_RF      2
-#  define ACTIVE_RTL     3
+#  define ACTIVE_PILIGHT  1
+#  define ACTIVE_RF       2
+#  define ACTIVE_RTL      3
+#  define ACTIVE_RF2      4
 
 #  ifdef ZradioCC1101
-bool validFrequency(int mhz) {
+bool validFrequency(float mhz) {
   //  CC1101 valid frequencies 300-348 MHZ, 387-464MHZ and 779-928MHZ.
   if (mhz >= 300 && mhz <= 348)
     return true;
@@ -168,7 +172,7 @@ bool validFrequency(int mhz) {
 
 int currentReceiver = -1;
 
-extern void stateMeasures();  // Send a status message 
+extern void stateMeasures(); // Send a status message
 
 void enableActiveReceiver() {
   // if (currentReceiver != activeReceiver) {
@@ -189,8 +193,14 @@ void enableActiveReceiver() {
       enableRTLreceive();
       break;
 #  endif
+#  ifdef ZgatewayRF2
+    case ACTIVE_RF2:
+      enableRF2Receive();
+      break;
+#  endif
+    default:
+      Log.error(F("ERROR: unsupported receiver %d" CR), activeReceiver);
   }
-  stateMeasures();  // Send a status message 
   currentReceiver = activeReceiver;
 }
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -660,7 +660,7 @@ void setup() {
 #ifdef ZgatewayRF2
   setupRF2();
   modules.add(ZgatewayRF2);
-  #  ifdef ACTIVE_RECEIVER
+#  ifdef ACTIVE_RECEIVER
 #    undef ACTIVE_RECEIVER
 #  endif
 #  define ACTIVE_RECEIVER ACTIVE_RF2
@@ -668,6 +668,7 @@ void setup() {
 #ifdef ZgatewayPilight
   setupPilight();
   modules.add(ZgatewayPilight);
+  disablePilightReceive();
 #  ifdef ACTIVE_RECEIVER
 #    undef ACTIVE_RECEIVER
 #  endif
@@ -752,7 +753,7 @@ void setup() {
 #  endif
 #  define ACTIVE_RECEIVER ACTIVE_RTL
 #endif
-#if defined(ZgatewayRTL_433) || defined(ZgatewayRF) || defined(ZgatewayPilight)
+#if defined(ZgatewayRTL_433) || defined(ZgatewayRF) || defined(ZgatewayPilight) || defined(ZgatewayRF2)
 #  ifdef DEFAULT_RECEIVER // Allow defining of default receiver as a compiler directive
   activeReceiver = DEFAULT_RECEIVER;
 #  else
@@ -762,9 +763,11 @@ void setup() {
 #endif
   Log.trace(F("mqtt_max_packet_size: %d" CR), mqtt_max_packet_size);
 
+#ifndef ARDUINO_AVR_UNO // Space issues with the UNO
   char jsonChar[100];
   modules.printTo((char*)jsonChar, modules.measureLength() + 1);
   Log.notice(F("OpenMQTTGateway modules: %s" CR), jsonChar);
+#endif
   Log.notice(F("************** Setup OpenMQTTGateway end **************" CR));
 }
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -654,6 +654,7 @@ void setup() {
 #ifdef ZgatewayRF
   setupRF();
   modules.add(ZgatewayRF);
+  activeReceiver = ACTIVE_RF;
 #endif
 #ifdef ZgatewayRF2
   setupRF2();
@@ -662,6 +663,7 @@ void setup() {
 #ifdef ZgatewayPilight
   setupPilight();
   modules.add(ZgatewayPilight);
+  activeReceiver = ACTIVE_PILIGHT;
 #endif
 #ifdef ZgatewayWeatherStation
   setupWeatherStation();
@@ -737,6 +739,10 @@ void setup() {
 #ifdef ZgatewayRTL_433
   setupRTL_433();
   modules.add(ZgatewayRTL_433);
+  activeReceiver = ACTIVE_RTL;
+#endif
+#if defined(ZgatewayRTL_433) || defined(ZgatewayRF) || defined(ZgatewayPilight)
+  enableActiveReceiver();
 #endif
   Log.trace(F("mqtt_max_packet_size: %d" CR), mqtt_max_packet_size);
   Log.notice(F("Setup OpenMQTTGateway end" CR));
@@ -1409,6 +1415,9 @@ void stateMeasures() {
   SYSdata["m5batpower"] = (float)M5.Axp.GetBatPower();
   SYSdata["m5batchargecurrent"] = (float)M5.Axp.GetBatChargeCurrent();
   SYSdata["m5apsvoltage"] = (float)M5.Axp.GetAPSVoltage();
+#  endif
+#  if defined(ZgatewayRF) || defined(ZgatewayPilight) || defined(ZgatewayRTL_433)
+  SYSdata["actRec"] = (int)activeReceiver;
 #  endif
 #  ifdef ZradioCC1101
   SYSdata["mhz"] = (int)receiveMhz;

--- a/platformio.ini
+++ b/platformio.ini
@@ -652,8 +652,8 @@ lib_deps =
   ${libraries.irremoteesp}
   ${libraries.rfm69}
   ${libraries.rfm69spi}
-  ${libraries.rc-switch}
-  ${libraries.newremoteswitch}
+;  ${libraries.rc-switch}
+;  ${libraries.newremoteswitch}
   ${libraries.bme280}
   ${libraries.bmp180}
   ${libraries.htu21}
@@ -670,11 +670,11 @@ lib_deps =
   ${libraries.rfWeatherStation}
 build_flags =
   ${com-esp.build_flags}
-  '-DZgatewayRF="RF"'
-  '-DZgatewayRF2="RF2"'
+;  '-DZgatewayRF="RF"'
+;  '-DZgatewayRF2="RF2"'
   '-DZgatewayIR="IR"'
   '-DZgatewayBT="BT"'
-  '-DZgatewayPilight="Pilight"'
+;  '-DZgatewayPilight="Pilight"'
   '-DZactuatorONOFF="ONOFF"'
   '-DZactuatorFASTLED="FASTLED"'
   ;'-DZactuatorPWM="PWM"'

--- a/platformio.ini
+++ b/platformio.ini
@@ -564,6 +564,29 @@ build_flags =
   '-DRF_RECEIVER_GPIO=4'
 ;  '-DRTL_DEBUG=4'        ; enable rtl_433 verbose device decode
 
+[env:esp32dev-multi_receiver]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.rc-switch}
+  ${libraries.smartrc-cc1101-driver-lib}
+  ${libraries.rtl_433_ESP}
+  ${libraries.esppilight}
+  ${libraries.newremoteswitch}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayRF="RF"'
+  '-DZgatewayRF2="RF2"'
+  '-DZgatewayRTL_433="RTL_433"'
+  '-DZgatewayPilight="Pilight"'
+  '-DZradioCC1101="CC1101"'
+  '-DGateway_Name="OpenMQTTGateway_multi_receiver"'
+  '-DRF_RECEIVER_GPIO=4'  ; CC1101 - GDO2
+  '-DRF_EMITTER_GPIO=2'   ; CC1101 - GDO0
+;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
+
 [env:ttgo-lora32-v1]
 platform = ${com.esp32_platform}
 board = ttgo-lora32-v1


### PR DESCRIPTION
Switching of the active receiver module is available between the RF, RF2, RTL_433 and Pilight Gateway modules, allowing for changing of signal decoders without redploying the openMQTTGateway package. Sending a JSON message to the command topic of the desired receiver will change the active receiver module.  This will resolve issue #848

Other minor adjustments/improvements

1 - Improved startup serial logging that includes
- OpenMQTTGateway Version
- OpenMQTTGateway Modules

2 - Trace logging of full Gateway module command topic to assist in determining command topic
 - Enabled in RF, RF2, PiLight and RTL_433

3 - Updated RTL_433 Documentation to only include enabled ASK/OOK ( an oops from the original release )
device decoders

4 - Trace logging of MQTT Callback topic

Regression testing was completed with an ESP32 connected to a CC1101 transceiver and with a ESP32 connected to a RXB6 Receiver module.  And RF, PiLight and RTL_433 were confirmed to be able to receive signals.  I could not confirm RF2 was able to receive as I do not have an appropriate device to test with.  Will need to watch this during the development phase in case it does not work correctly.

My Current Backlog

[x] Active switching between signal receivers ( RF, PiLight and RTL_433 ) and a bonus RF2
[ ] Home Assistant Discovery for RTL_433, including Black/White listing devices
[ ] [FSK Modulation](https://github.com/NorthernMan54/rtl_433_ESP/issues/5) support for rtl_433_ESP ( waiting for feedback on the feature )
[ ] RTL_433 support for the [RX127X Transceiver Chipset](https://github.com/NorthernMan54/rtl_433_ESP/issues/11)