### PR TITLE
Automate setting OMG_VERSION

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -136,6 +136,7 @@ build_flags =
   '-DjsonReceiving=true'
 ;  '-DLOG_LEVEL=LOG_LEVEL_TRACE'  ; Enable trace level logging
 monitor_speed = 115200
+extra_scripts = pre:scripts/omg_firmware_version.py
 
 [com]
 esp8266_platform = espressif8266@2.6.3

--- a/scripts/omg_firmware_version.py
+++ b/scripts/omg_firmware_version.py
@@ -1,0 +1,16 @@
+import subprocess
+
+Import("env")
+
+def get_firmware_specifier_build_flag():
+    #ret = subprocess.run(["git", "describe"], stdout=subprocess.PIPE, text=True) #Uses only annotated tags
+    ret = subprocess.run(["git", "describe", "--tags"], stdout=subprocess.PIPE, text=True) #Uses any tags
+    branch = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], stdout=subprocess.PIPE, text=True)
+    build_version = env['PIOENV'] + "-" + ret.stdout.strip() + "[" + branch.stdout.strip() + "]"
+    build_flag = "-D OMG_VERSION=\\\"" + build_version + "\\\""
+    print ("OpenMQTTGateway Build Version: " + build_version)
+    return (build_flag)
+
+env.Append(
+    BUILD_FLAGS=[get_firmware_specifier_build_flag()]
+)


### PR DESCRIPTION
This script will set the OMG_VERSION to a string containing the build
env name, OMG Release number, gihthub release tag and git branch.  And
to invoke it needs to be added as an extra script in the env section of
platform.ini

extra_scripts = pre:scripts/omg_firmware_version.py

I.e.

esp32dev_cccccc-v0.9.6-12-gdea42b3[development-switching]

Tested with MacOS, will need validation with a windows environment.  If
it fails validation on windows am thinking to just comment it out in
platformio.ini and add a comment indicating the feature and optionally
enable.