### PR TITLE
Remove Secure Connection macro and add the config to wifimanager.

### DIFF
--- a/docs/upload/advanced-configuration.md
+++ b/docs/upload/advanced-configuration.md
@@ -13,7 +13,7 @@ The MQTT broker is configured for TLS and you have access to the CA certificate 
 You are using ESP8266 or ESP32, for other boards TLS is not supported.
 
 ### Configure secure connection in the gateway
-To enable the secure connection and use TLS uncomment `//#define SECURE_CONNECTION` in `User_config.h`.
+To enable the secure connection and use TLS set the `#define MQTT_DEFAULT_SECURE` to true.
 Set `MQTT_SERVER` to the Common Name (CN) of the certificate of the broker.
 This can be the hostname or the ip of the broker.
 
@@ -27,9 +27,6 @@ const char* certificate CERT_ATTRIBUTE = R"EOF("
 -----END CERTIFICATE-----
 ")EOF";
 ```
-
-If you have no ntp server in your local network (included in the router) or not using dhcp, you should uncomment `//#    define NTP_SERVER "pool.ntp.org"` to use a ntp server for time synchronization.
-This is related to the `W: failed, ssl error code=54` error message, which indicate that the time of the esp is not correct.
 
 You can know compile and upload to your board and the gateway should connect with TLS to your broker.
 

--- a/docs/upload/portal.md
+++ b/docs/upload/portal.md
@@ -14,6 +14,9 @@ From your smartphone search for your OpenMQTTGateway wifi network and connect to
 * Select your wifi
 * Set your wifi password
 * Set your MQTT Server IP
+* Set your MQTT Server Port
+* Set the MQTT secure connection box to select whether or not the connection should be secure
+* Copy/paste the MQTT server certificate in the MQTT server cert box (only required if using a secure connection), be sure to include the `-----BEGIN CERIFICATE-----` and `-----END CERTIFICATE-----` markers  
 * Set your MQTT Server username (facultative)
 * Set your MQTT Server password (facultative)
 * Set your MQTT base topic if you need to change it (you must keep the / at the end)

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -80,6 +80,10 @@ const byte ip[] = {192, 168, 1, 99};
 const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield mac adress
 #endif
 
+#ifndef NTP_SERVER
+#  define NTP_SERVER "pool.ntp.org"
+#endif
+
 #ifdef MQTT_HTTPS_FW_UPDATE
 #  if defined(ESP8266) || defined(ESP32)
 //If used, this should be set to the root CA certificate of the server hosting the firmware.
@@ -89,7 +93,6 @@ const char* https_fw_server_cert PROGMEM = R"EOF("
 ...
 -----END CERTIFICATE-----
 ")EOF";
-#    define NTP_SERVER "pool.ntp.org"
 #    ifndef MQTT_HTTPS_FW_UPDATE_USE_PASSWORD
 #      define MQTT_HTTPS_FW_UPDATE_USE_PASSWORD 1 // Set this to 0 if not using TLS connection to MQTT broker to prevent clear text passwords being sent.
 #    endif
@@ -142,16 +145,6 @@ const char* https_fw_server_cert PROGMEM = R"EOF("
 #  define mqtt_max_packet_size 128
 #endif
 
-// activate the use of TLS for secure connection to the MQTT broker
-// MQTT_SERVER must be set to the Common Name (CN) of the broker's certificate
-//#define SECURE_CONNECTION
-
-#ifdef SECURE_CONNECTION
-#  define MQTT_DEFAULT_PORT "8883"
-#else
-#  define MQTT_DEFAULT_PORT "1883"
-#endif
-
 #ifndef MQTT_USER
 #  define MQTT_USER "your_username"
 #endif
@@ -162,11 +155,13 @@ const char* https_fw_server_cert PROGMEM = R"EOF("
 #  define MQTT_SERVER "192.168.1.17"
 #endif
 #ifndef MQTT_PORT
-#  define MQTT_PORT MQTT_DEFAULT_PORT
+#  define MQTT_PORT "1883"
+#endif
+#ifndef MQTT_SECURE_DEFAULT
+#  define MQTT_SECURE_DEFAULT false
 #endif
 
-#ifdef SECURE_CONNECTION
-#  if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266) || defined(ESP32)
 // The root ca certificate used for validating the MQTT broker
 // The certificate must be in PEM ascii format
 const char* certificate PROGMEM = R"EOF("
@@ -175,16 +170,6 @@ const char* certificate PROGMEM = R"EOF("
 -----END CERTIFICATE-----
 ")EOF";
 
-// specify a NTP server here or else the NTP server from DHCP is used
-#    ifndef NTP_SERVER
-//#    define NTP_SERVER "pool.ntp.org"
-#    endif
-#  else
-#    error "only ESP8266 and ESP32 support SECURE_CONNECTION with TLS"
-#  endif
-#endif
-
-#if defined(ESP8266) || defined(ESP32)
 #  define ATTEMPTS_BEFORE_BG 10 // Number of wifi connection attempts before going to BG protocol
 #  define ATTEMPTS_BEFORE_B  20 // Number of wifi connection attempts before going to B protocol
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -71,8 +71,8 @@ extra_configs =
 ;default_envs = uno-fastled
 ;default_envs = atmega-all-test
 ;default_envs = manual-wifi-test
-;default_envs = esp32dev-tls-test
-;default_envs = nodemcuv2-tls-test
+;default_envs = esp32dev-mqtt-fw-test
+;default_envs = nodemcuv2-mqtt-fw-test
 ;default_envs = nodemcuv2-rs232
 ;default_envs = sonoff-rfbridge-direct
 
@@ -105,7 +105,7 @@ bmp180 = BMP180#efac46bd8d
 htu21 = SparkFun HTU21D Humidity and Temperature Sensor Breakout@1.1.3
 ahtx0 = Adafruit AHTX0
 ina226 = https://github.com/jarzebski/Arduino-INA226.git#968a684
-a6lib = https://github.com/1technophile/A6lib.git
+a6lib = https://github.com/h2zero/A6lib
 wifimanager = https://github.com/tzapu/WiFiManager.git#c3ff582
 ethernet = Ethernet
 esp8266_mdns = esp8266_mdns
@@ -826,29 +826,27 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_TEST_MANUAL_WIFI"'
 board_build.flash_mode = dout
 
-[env:esp32dev-tls-test]
+[env:esp32dev-mqtt-fw-test]
 platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
 build_flags =
   ${com-esp.build_flags}
-  '-DSECURE_CONNECTION'
   '-DMQTT_HTTPS_FW_UPDATE'
-  '-DGateway_Name="OpenMQTTGateway_TEST_TLS"'
+  '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
 board_build.flash_mode = dout
 
 
-[env:nodemcuv2-tls-test]
+[env:nodemcuv2-mqtt-fw-test]
 platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
 build_flags =
   ${com-esp.build_flags}
-  '-DSECURE_CONNECTION'
   '-DMQTT_HTTPS_FW_UPDATE'
-  '-DGateway_Name="OpenMQTTGateway_TEST_TLS"'
+  '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
 board_build.flash_mode = dout
 
 [env:rf-wifi-gateway]


### PR DESCRIPTION
This adds the ability to specify if the MQTT broker connection is secure via a checkbox on the config page of WiFiManager.
Also added to the WiFiManager config page is a text box to enter the brokers TLS certificate.

In the case of using manual configuration a new macro is created `MQTT_SECURE_DEFAULT`; when defined as `true` a secure connection will be requested and the certificate defined in user_config.h will be used.