### PR TITLE
Resolve incorrect wiring instructions

### DIFF
--- a/docs/setitup/rf.md
+++ b/docs/setitup/rf.md
@@ -25,10 +25,10 @@ Connect the Emitter and Receiver to a 5V (**3.3V** for CC1101) supply source, an
 |Board|Receiver Pin(GDO2)|Emitter Pin(GDO0)|SCK|VCC|MOSI|MISO|CSN|GND
 |-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 |ESP8266|D2/**D3**/D1/D8|**RX**/D2|D5|**3V3**|D7|D6|D8|GND
-|ESP32|**27**/26|12|D18|**3V3**|D23|D19|D5|GND
+|ESP32|**D27**|D12|D18|**3V3**|D23|D19|D5|GND
 
 To use the CC1101 module, `ZradioCC1101` must be uncomment in the `User_config.h` or added to the `build_flags`.
-More information about the [CC1101 wiring](https://github.com/LSatan/SmartRC-CC1101-Driver-Lib#wiring).
+More information about the [CC1101 wiring](https://github.com/LSatan/SmartRC-CC1101-Driver-Lib#wiring). ( Please note that with OMG we are recommending CC1101 GDO2 to be connected to ESP32 D27 and GDO0 to be connected to D12, this is different than the LSatan diagram. This is due to the ESP32 using D2 as part of the boot process. )
 
 
 ## Arduino Hardware setup

--- a/platformio.ini
+++ b/platformio.ini
@@ -561,8 +561,6 @@ build_flags =
   '-DZradioCC1101="CC1101"'
   '-DZgatewayRTL_433="rtl_433"'
   '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
-  '-DRF_RECEIVER_GPIO=4'  ; CC1101 - GDO2
-  '-DRF_EMITTER_GPIO=2'   ; CC1101 - GDO0
   '-DvalueAsASubject=true'    ; mqtt topic includes model and device
 ;  '-DPUBLISH_UNPARSED=true'  ; Publish details of undecoded signals 
 ;  '-DRTL_DEBUG=4'            ; enable rtl_433 verbose device decode
@@ -586,8 +584,6 @@ build_flags =
   '-DZgatewayPilight="Pilight"'
   '-DZradioCC1101="CC1101"'
   '-DGateway_Name="OpenMQTTGateway_multi_receiver"'
-  '-DRF_RECEIVER_GPIO=4'  ; CC1101 - GDO2
-  '-DRF_EMITTER_GPIO=2'   ; CC1101 - GDO0
   '-DvalueAsASubject=true'  ; mqtt topic includes model and device (rtl_433) or protocol and id ( RF and PiLight )
 ;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
 


### PR DESCRIPTION
As identified in this forum post (
https://community.openmqttgateway.com/t/rtl-433-esp32-bme280-but-what-ra
dio/1563) , the default builds have incorrect connections for the
RTL_433 module.  This fixes the default build configuration and
crispness the documentation.