### PR TITLE
Ble read/write characteristics over MQTT.

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -103,7 +103,7 @@ In this case you should deactivate the BLE connection mechanism to avoid concurr
 For certain devices like LYWSD03MMC OpenMQTTGateway use a connection (due to the fact that the advertized data are encrypted), this connection mechanism is launched after every `ScanBeforeConnect` per default, you can modify it by following the procedure below.
 :::
 
-## Setting the number of scans between before connect attempt
+## Setting the number of scans between connection attempts
 
 If you want to change the number of BLE scans that are done before a BLE connect you can change it by MQTT, if you want the BLE connect to be every 30 scans:
 
@@ -154,7 +154,10 @@ The default value is set into config_BT.h
 
 ## Read/write BLE characteristics over MQTT (ESP32 only)
 
-The gateway can read and write BLE characteristics from devices and provide the results in an MQTT message.   
+The gateway can read and write BLE characteristics from devices and provide the results in an MQTT message.  
+::: tip
+These actions will be taken on the next BLE connection, which occurs after scanning and after the scan count is reached, [see above to set this.](#setting-the-number-of-scans-between-connection-attempts)
+:::
 
 ### Example write command
 ```

--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -152,6 +152,55 @@ you can also accept all the devices by the following command:
 
 The default value is set into config_BT.h
 
+## Read/write BLE characteristics over MQTT (ESP32 only)
+
+The gateway can read and write BLE characteristics from devices and provide the results in an MQTT message.   
+
+### Example write command
+```
+mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
+  "ble_write_address":"AA:BB:CC:DD:EE:FF",
+  "ble_write_service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+  "ble_write_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
+  "ble_write_value":"TEST",
+  "value_type":"STRING",
+  "ttl":4 }'
+```
+Response:
+```
+{
+  "id":"AA:BB:CC:DD:EE:FF",
+  "service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+  "characteristic":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
+  "write":"TEST",
+  "success":true
+}
+```
+### Example read commnad
+```
+mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
+  "ble_read_address":"AA:BB:CC:DD:EE:FF",
+  "ble_read_service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+  "ble_read_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
+  "value_type":"STRING",
+  "ttl": 2 }'
+```
+Response:
+```
+{
+  "id":"AA:BB:CC:DD:EE:FF",
+  "service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+  "characteristic":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
+  "read":"TEST",
+  "success":true
+}
+```
+
+::: tip
+The `ttl` parameter is the number of attempts to connect (defaults to 1), which occur after the BLE scan completes.  
+`value_type` can be one of: STRING, HEX, INT, FLOAT. Default is STRING if omitted in the message.
+:::
+
 ## Other
 
 To check your hm10 firmware version upload a serial sketch to the nodemcu (this will enable communication directly with the hm10) and launch the command:

--- a/main/ZgatewayBLEConnect.h
+++ b/main/ZgatewayBLEConnect.h
@@ -4,6 +4,7 @@
 #ifdef ESP32
 #  include "ArduinoJson.h"
 #  include "NimBLEDevice.h"
+#  include "config_BT.h"
 
 extern void pubBT(JsonObject& data);
 
@@ -13,6 +14,9 @@ public:
   TaskHandle_t m_taskHandle = nullptr;
   zBLEConnect(NimBLEAddress& addr) { m_pClient = NimBLEDevice::createClient(addr); }
   virtual ~zBLEConnect() { NimBLEDevice::deleteClient(m_pClient); }
+  virtual bool writeData(BLEAction* action);
+  virtual bool readData(BLEAction* action);
+  virtual bool processActions(std::vector<BLEAction>& actions);
   virtual void publishData() {}
   virtual NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID& service, const NimBLEUUID& characteristic);
 };

--- a/main/ZgatewayBLEConnect.h
+++ b/main/ZgatewayBLEConnect.h
@@ -38,5 +38,12 @@ public:
   void publishData() override;
 };
 
+class GENERIC_connect : public zBLEConnect {
+  std::vector<uint8_t> m_data;
+
+public:
+  GENERIC_connect(NimBLEAddress& addr) : zBLEConnect(addr) {}
+};
+
 #endif //ESP32
 #endif //zBLEConnect_h

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -72,7 +72,9 @@ bool zBLEConnect::processActions(std::vector<BLEAction>& actions) {
         } else {
           Log.trace(F("processing BLE read" CR));
           result = readData(&it);
-          BLEresult.set("read", it.value.c_str());
+          char* pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*)it.value.c_str(), it.value.length());
+          BLEresult.set("read", (pHex != nullptr) ? pHex : "invalid data");
+          free(pHex);
         }
 
         it.complete = true;

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -746,6 +746,11 @@ void BLEconnect() {
           BLEclient.publishData();
           break;
         }
+        case GENERIC: {
+          GENERIC_connect BLEclient(addr);
+          BLEclient.processActions(BLEactions);
+          break;
+        }
         default:
           break;
       }
@@ -1692,6 +1697,7 @@ void MQTTtoBTAction(JsonObject& BTdata) {
     action.characteristic = NimBLEUUID((const char*)BTdata["ble_write_char"]);
     action.value = std::string((const char*)BTdata["ble_write_value"]);
     action.write = true;
+    Log.trace(F("BLE ACTION Write" CR));
   } else if (BTdata.containsKey("ble_read_address") &&
              BTdata.containsKey("ble_read_service") &&
              BTdata.containsKey("ble_read_char")) {
@@ -1699,10 +1705,11 @@ void MQTTtoBTAction(JsonObject& BTdata) {
     action.service = NimBLEUUID((const char*)BTdata["ble_read_service"]);
     action.characteristic = NimBLEUUID((const char*)BTdata["ble_read_char"]);
     action.write = false;
+    Log.trace(F("BLE ACTION Read" CR));
   } else {
     return;
   }
-
+  createOrUpdateDevice(action.addr, device_flags_connect, GENERIC);
   BLEactions.push_back(action);
 #  endif
 }

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1686,6 +1686,22 @@ void MQTTtoBTAction(JsonObject& BTdata) {
 #  ifdef ESP32
   BLEAction action;
   action.ttl = BTdata.containsKey("ttl") ? (uint8_t)BTdata["ttl"] : 1;
+  action.value_type = BLE_VAL_STRING;
+  if (BTdata.containsKey("value_type")) {
+    String vt = BTdata["value_type"];
+    vt.toUpperCase();
+    if (vt == "HEX")
+      action.value_type = BLE_VAL_HEX;
+    else if (vt == "INT")
+      action.value_type = BLE_VAL_INT;
+    else if (vt == "FLOAT")
+      action.value_type = BLE_VAL_FLOAT;
+    else if (vt != "STRING") {
+      Log.error(F("BLE value type invalid %s" CR), vt.c_str());
+      return;
+    }
+  }
+
   Log.trace(F("BLE ACTION TTL = %u" CR), action.ttl);
   action.complete = false;
   if (BTdata.containsKey("ble_write_address") &&

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -171,6 +171,13 @@ enum ble_sensor_model {
 
 /*---------------INTERNAL USE: DO NOT MODIFY--------------*/
 #ifdef ESP32
+enum ble_val_type {
+  BLE_VAL_STRING = 0,
+  BLE_VAL_HEX,
+  BLE_VAL_INT,
+  BLE_VAL_FLOAT,
+};
+
 struct BLEAction {
   std::string value;
   char addr[18];
@@ -179,6 +186,7 @@ struct BLEAction {
   bool write;
   bool complete;
   uint8_t ttl;
+  ble_val_type value_type;
 };
 #endif
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -46,6 +46,7 @@ bool bleConnect = AttemptBLECOnnect;
 #  ifndef BLE_FILTER_CONNECTABLE
 #    define BLE_FILTER_CONNECTABLE 1
 #  endif
+#  include "NimBLEDevice.h"
 #endif
 
 /*----------------------BT topics & parameters-------------------------*/
@@ -168,6 +169,18 @@ enum ble_sensor_model {
 #endif
 
 /*---------------INTERNAL USE: DO NOT MODIFY--------------*/
+#ifdef ESP32
+struct BLEAction {
+  std::string value;
+  char addr[18];
+  NimBLEUUID service;
+  NimBLEUUID characteristic;
+  bool write;
+  bool complete;
+  uint8_t ttl;
+};
+#endif
+
 struct BLEdevice {
   char macAdr[18];
   bool isDisc;

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -152,6 +152,7 @@ enum ble_sensor_model {
   IBT4XS,
   DT24,
   EDDYSTONE_TLM,
+  GENERIC,
 };
 
 /*-------------------PIN DEFINITIONS----------------------*/


### PR DESCRIPTION
This allows reading and writing BLE characteristics from an MQTT message.

Example MQTT message format:
```
mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
  "ble_write_address":"AA:BB:CC:DD:EE:FF", 
  "ble_write_service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
  "ble_write_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b", 
  "ble_write_value":"TEST",
  "value_type":"STRING",
  "ttl":4 }'
```
```
mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
  "ble_read_address":"AA:BB:CC:DD:EE:FF", 
  "ble_read_service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
  "ble_read_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b", 
  "value_type":"STRING",
  "ttl": 2 }'
```
The `ttl` parameter is the number of attempts to connect (defaults to 1), which occur after the BLE scan completes.
`value_type` can be one of: STRING, HEX, INT, FLOAT. Default is STRING if omitted in the message.

A response is provided over MQTT in the format:
write : 
```
{
  "id":"AA:BB:CC:DD:EE:FF",
  "service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
  "characteristic":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
  "write":"TEST",
  "success":true
}
```
read :
```
{
  "id":"AA:BB:CC:DD:EE:FF",
  "service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
  "characteristic":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
  "read":"TEST",
  "success":true
}
``` 
