### PR TITLE
DT24 - Update messages to support temp

### DIFF
--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -126,6 +126,8 @@ void DT24_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, s
       BLEdata.set("power", (float)(((m_data[10] * 256 * 256) + (m_data[11] * 256) + m_data[12]) / 10.0));
       BLEdata.set("energy", (float)(((m_data[13] * 256 * 256 * 256) + (m_data[14] * 256 * 256) + (m_data[15] * 256) + m_data[16]) / 100.0));
       BLEdata.set("price", (float)(((m_data[17] * 256 * 256) + (m_data[18] * 256) + m_data[19]) / 100.0));
+      BLEdata.set("tempc", (float)(m_data[24] * 256) + m_data[25]);
+      BLEdata.set("tempf", (float)(convertTemp_CtoF((m_data[24] * 256) + m_data[25])));
 
       pubBT(BLEdata);
     } else {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -541,14 +541,15 @@ void WS02Discovery(const char* mac, const char* sensorModel) {
 }
 
 void DT24Discovery(const char* mac, const char* sensorModel) {
-#    define DT24parametersCount 5
+#    define DT24parametersCount 6
   Log.trace(F("DT24Discovery" CR));
   const char* DT24sensor[DT24parametersCount][8] = {
       {"sensor", "DT24-volt", mac, "power", jsonVolt, "", "", "V"},
       {"sensor", "DT24-amp", mac, "power", jsonCurrent, "", "", "A"},
       {"sensor", "DT24-watt", mac, "power", jsonPower, "", "", "W"},
       {"sensor", "DT24-watt-hour", mac, "power", jsonEnergy, "", "", "kWh"},
-      {"sensor", "DT24-price", mac, "", jsonMsg, "", "", ""}
+      {"sensor", "DT24-price", mac, "", jsonMsg, "", "", ""},
+      {"sensor", "DT24-temp", mac, "temperature", jsonTempc, "", "", "°C"}
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 


### PR DESCRIPTION
With the additional functionality added by @h2zero I’m able to extract
the temperate data from the 2nd part of the bluetooth message.