### PR TITLE
Use correct SDA+SCL pins

### DIFF
--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -59,7 +59,7 @@ unsigned long timebme280 = 0;
 int BME280_i2c_addr = 0x76; // Bosch BME280 I2C Address
 
 // Only supported for ESP
-int BME280_PIN_SDA = 21; // PIN SDA
-int BME280_PIN_SCL = 22; // PIN SCL
+int BME280_PIN_SDA = SDA; // PIN SDA
+int BME280_PIN_SCL = SCL; // PIN SCL
 
 #endif


### PR DESCRIPTION
ESP8266 uses D1 (5) and D2 (4), ESP32 uses 21 and 22. Both provide defines for SDA and SCL pin numbers though.

This PR fixes the pin numbers for SDA and SCL on ESP8266 and keeps them unchanged for ESP32.