### PR TITLE
Allow inversion of input GPIO

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -479,7 +479,7 @@ void pubMqttDiscovery() {
 
 #  ifdef ZsensorGPIOInput
   Log.trace(F("GPIOInputDiscovery" CR));
-  char* GPIOInputsensor[8] = {"binary_sensor", "GPIOInput", "", "", jsonGpio, "HIGH", "LOW", ""};
+  char* GPIOInputsensor[8] = {"binary_sensor", "GPIOInput", "", "", jsonGpio, INPUT_GPIO_ON_VALUE, INPUT_GPIO_OFF_VALUE, ""};
   //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
 
   Log.trace(F("CreateDiscoverySensor" CR));

--- a/main/config_GPIOInput.h
+++ b/main/config_GPIOInput.h
@@ -42,4 +42,7 @@ extern void GPIOInputtoMQTT();
 #  endif
 #endif
 
+#define INPUT_GPIO_ON_VALUE "HIGH"
+#define INPUT_GPIO_OFF_VALUE "LOW"
+
 #endif

--- a/main/config_GPIOInput.h
+++ b/main/config_GPIOInput.h
@@ -42,7 +42,7 @@ extern void GPIOInputtoMQTT();
 #  endif
 #endif
 
-#define INPUT_GPIO_ON_VALUE "HIGH"
+#define INPUT_GPIO_ON_VALUE  "HIGH"
 #define INPUT_GPIO_OFF_VALUE "LOW"
 
 #endif


### PR DESCRIPTION
This PR enables users of the input GPIO to switch the on/off values.

Rationale:
The ESP8266 uses internal pull-up for input GPIO. A common use case is to use a switch to pull the input to ground. So the value is `LOW` while the button is pressed and `HIGH` otherwise.

Swapping the values for `INPUT_GPIO_ON_VALUE` and `INPUT_GPIO_OFF_VALUE` introduced in this PR, makes a `LOW` button report as `On`.