### PR TITLE
Indicate gateway status with LED's

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -334,33 +334,19 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #endif
 
 /*-------------DEFINE PINs FOR STATUS LEDs----------------*/
-#ifndef LED_RECEIVE
+#ifndef LED_SEND_RECEIVE
 #  ifdef ESP8266
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  elif ESP32
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  elif __AVR_ATmega2560__ //arduino mega
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  else //arduino uno/nano
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  endif
 #endif
-#ifndef LED_RECEIVE_ON
-#  define LED_RECEIVE_ON HIGH
-#endif
-#ifndef LED_SEND
-#  ifdef ESP8266
-#    define LED_SEND 42
-#  elif ESP32
-#    define LED_SEND 42
-#  elif __AVR_ATmega2560__ //arduino mega
-#    define LED_SEND 42
-#  else //arduino uno/nano
-#    define LED_SEND 42
-#  endif
-#endif
-#ifndef LED_SEND_ON
-#  define LED_SEND_ON HIGH
+#ifndef LED_SEND_RECEIVE_ON
+#  define LED_SEND_RECEIVE_ON HIGH
 #endif
 #ifndef LED_INFO
 #  ifdef ESP8266
@@ -375,6 +361,20 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #endif
 #ifndef LED_INFO_ON
 #  define LED_INFO_ON HIGH
+#endif
+#ifndef LED_ERROR
+#  ifdef ESP8266
+#    define LED_ERROR 44
+#  elif ESP32
+#    define LED_ERROR 44
+#  elif __AVR_ATmega2560__ //arduino mega
+#    define LED_ERROR 44
+#  else //arduino uno/nano
+#    define LED_ERROR 44
+#  endif
+#endif
+#ifndef LED_ERROR_ON
+#  define LED_ERROR_ON HIGH
 #endif
 
 #ifdef ESP8266


### PR DESCRIPTION
## Description:
- Adds a LED pin definition for error conditions that the gateway will blink in certain patterns when an error condition occurs.
- LED_RECEIVE and LED_SEND have been replaced by the combined LED_SEND_RECEIVE to accommodate the error LED for devices with RGB LED's. 

The LED blink patterns are as follows:
Configuration web portal active: LED_INFO = on for 2 seconds, off for 2 seconds.
Disconnected from Wifi: LED_ERROR = on for 2 seconds, off for 2 seconds.
Disconnected from broker: LED_ERROR = on for 2 seconds, off for 10 seconds.
OTA update in progress: LED_SEND_RECEIVE and LED_ERROR = ON.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
