### PR TITLE
Implement error LED and status codes.

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -334,33 +334,33 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #endif
 
 /*-------------DEFINE PINs FOR STATUS LEDs----------------*/
-#ifndef LED_RECEIVE
+#ifndef LED_SEND_RECEIVE
 #  ifdef ESP8266
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  elif ESP32
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  elif __AVR_ATmega2560__ //arduino mega
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  else //arduino uno/nano
-#    define LED_RECEIVE 40
+#    define LED_SEND_RECEIVE 40
 #  endif
 #endif
-#ifndef LED_RECEIVE_ON
-#  define LED_RECEIVE_ON HIGH
+#ifndef LED_SEND_RECEIVE_ON
+#  define LED_SEND_RECEIVE_ON HIGH
 #endif
-#ifndef LED_SEND
+#ifndef LED_ERROR
 #  ifdef ESP8266
-#    define LED_SEND 42
+#    define LED_ERROR 42
 #  elif ESP32
-#    define LED_SEND 42
+#    define LED_ERROR 42
 #  elif __AVR_ATmega2560__ //arduino mega
-#    define LED_SEND 42
+#    define LED_ERROR 42
 #  else //arduino uno/nano
-#    define LED_SEND 42
+#    define LED_ERROR 42
 #  endif
 #endif
-#ifndef LED_SEND_ON
-#  define LED_SEND_ON HIGH
+#ifndef LED_ERROR_ON
+#  define LED_ERROR_ON HIGH
 #endif
 #ifndef LED_INFO
 #  ifdef ESP8266


### PR DESCRIPTION
## Description:
Merges LED_RECEIVE/LED_SEND into LED_SEND_RECEIVE pin definition.

Adds LED_ERROR to display error status based on blink times as follows:

Disconnected from Wifi: 2 seconds on 2 seconds off.
Disconnected from broker: 2 seconds on 5 seconds off.

Other status LED indications added:
WifiManager configuration web portal active: LED_INFO and LED_ERROR = ON.
OTA Update in progress: LED_SEND_RECIEVE and LED_ERROR = ON.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
