### PR TITLE
Erase stored settings in NVS when triggered.

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -186,6 +186,8 @@ static String mqtt_cert = "";
 #  include <ArduinoOTA.h>
 #  include <FS.h>
 #  include <SPIFFS.h>
+#  include <nvs.h>
+#  include <nvs_flash.h>
 
 #  ifdef ESP32_ETHERNET
 #    define ETH_CLK_MODE  ETH_CLOCK_GPIO17_OUT
@@ -978,19 +980,14 @@ void checkButton() {}
 #  endif
 
 void eraseAndRestart() {
-#  if defined(ESP8266)
-  WiFi.disconnect(true);
-#  else
-  WiFi.disconnect(true, true);
-#  endif
-
   Log.trace(F("Formatting requested, result: %d" CR), SPIFFS.format());
 
 #  if defined(ESP8266)
-  ESP.eraseConfig();
+  SPIFFS.format();
   delay(5000);
   ESP.reset();
 #  else
+  nvs_flash_erase();
   ESP.restart();
 #  endif
 }


### PR DESCRIPTION
## Description:
This resolves #994 where the esp32 would still save the client information after a factory reset is performed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
