### PR TITLE
Add a macro to use the MAC address as the gateway name.

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -49,6 +49,10 @@
  * to the access point with your password (SSID: WifiManager_ssid, password: WifiManager_password)
  */
 /*-------------DEFINE GATEWAY NAME BELOW IT CAN ALSO BE DEFINED IN platformio.ini----------------*/
+
+// Uncomment to use the mac address in the format of 112233445566 as the gateway name
+// Any definition of Gateway_Name will be ignored. The Gateway_Short_name _ MAC will be used as the access point name.
+//#define USE_MAC_AS_GATEWAY_NAME
 #ifndef Gateway_Name
 #  define Gateway_Name "OpenMQTTGateway"
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -166,7 +166,10 @@ char mqtt_server[parameters_size] = MQTT_SERVER;
 char mqtt_port[6] = MQTT_PORT;
 char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
 char gateway_name[parameters_size * 2] = Gateway_Name;
-
+#ifdef USE_MAC_AS_GATEWAY_NAME
+#  undef WifiManager_ssid
+char WifiManager_ssid[20];
+#endif
 bool connectedOnce = false; //indicate if we have been connected once to MQTT
 int failure_number_ntwk = 0; // number of failure connecting to network
 int failure_number_mqtt = 0; // number of failure connecting to MQTT
@@ -586,6 +589,13 @@ void setup() {
   setupM5();
 #    endif
   Log.notice(F("OpenMQTTGateway Version: " OMG_VERSION CR));
+#  endif
+
+#  ifdef USE_MAC_AS_GATEWAY_NAME
+  String s = WiFi.macAddress();
+  sprintf(gateway_name, "%.2s%.2s%.2s%.2s%.2s%.2s",
+          s.c_str(), s.c_str() + 3, s.c_str() + 6, s.c_str() + 9, s.c_str() + 12, s.c_str() + 15);
+  sprintf(WifiManager_ssid, "%s_%s", Gateway_Short_Name, gateway_name);
 #  endif
 
 #  ifdef ESP32_ETHERNET


### PR DESCRIPTION
## Description:
Adds the macro USE_MAC_AS_GATEWAY_NAME, when defined the gateway name will default to: 
OMG_XXXXXXXXXXXX, where the X's are the mac address characters.
This can be changed in WiFiManager.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
