### PR TITLE
Set WifiManager debug level.

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -102,6 +102,9 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #ifndef WifiManager_TimeOut
 #  define WifiManager_TimeOut 5
 #endif
+#ifndef WM_DEBUG_LEVEL
+#  define WM_DEBUG_LEVEL 1 // valid values are: DEBUG_ERROR = 0, DEBUG_NOTIFY = 1, DEBUG_VERBOSE = 2, DEBUG_DEV = 3, DEBUG_MAX = 4
+#endif
 
 /*-------------DEFINE YOUR ADVANCED NETWORK PARAMETERS BELOW----------------*/
 //#define MDNS_SD //uncomment if you  want to use mdns for discovering automatically your ip server, please note that MDNS with ESP32 can cause the BLE to not work

--- a/main/main.ino
+++ b/main/main.ino
@@ -1082,6 +1082,8 @@ void setup_wifimanager(bool reset_settings) {
     }
   }
 
+  wifiManager.setDebugOutput(WM_DEBUG_LEVEL);
+
   // The extra parameters to be configured (can be either global or just in the setup)
   // After connecting, parameter.getValue() will get you the configured value
   // id/name placeholder/prompt default length


### PR DESCRIPTION
## Description:
This allows for setting the WiFimanager debug level for more or less verbosity using the WM_DEBUG_LEVEL macro.
Valid values are:
        DEBUG_ERROR       = 0,
        DEBUG_NOTIFY      = 1, // default
        DEBUG_VERBOSE   = 2,
        DEBUG_DEV           = 3,
        DEBUG_MAX          = 4

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
