### PR TITLE
Set BLE_FILTER_CONNECTABLE default to 0.

### DIFF
--- a/docs/integrate/openhab2.md
+++ b/docs/integrate/openhab2.md
@@ -10,6 +10,10 @@ So as to use the autodiscovery function you need to have:
 You need to set `OpenHABAutoDiscovery` to true into `config_mqttDiscovery.h`
 `#define OpenHABDiscovery true`
 
+::: tip
+If you are connecting to BLE devices it is highly recommended to set `BLE_FILTER_CONNECTABLE` to `1` in `config_BT.h`. Otherwise you may encounter incomplete data.
+:::
+
 The things will appear in the inbox of the paperUI, add them and links the channels. You should see them into the control panel for further usage.
 ![](../img/OpenMQTTgateway_OpenHAB_Control.png)
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -42,9 +42,9 @@ extern int btQueueLengthCount;
 bool bleConnect = AttemptBLECOnnect;
 
 // Sets whether to filter publishing of scanned devices that require a connection.
-// Default (1) prevents overwriting the publication of the device connection data with the advertised data.
+// Setting this to 1 prevents overwriting the publication of the device connection data with the advertised data (Recommended for use with OpenHAB).
 #  ifndef BLE_FILTER_CONNECTABLE
-#    define BLE_FILTER_CONNECTABLE 1
+#    define BLE_FILTER_CONNECTABLE 0
 #  endif
 #  include "NimBLEDevice.h"
 #endif


### PR DESCRIPTION
## Description:
Sets the BLE_FILTER_CONNECTABLE default value to 0.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
