### PR TITLE
Update the LED_SEND and LED_RECEIVE macro to fit LED_SEND_RECEIVE

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -352,8 +352,8 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-  '-DLED_RECEIVE=2'
-  '-DLED_RECEIVE_ON=0'
+  '-DLED_SEND_RECEIVE=2'
+  '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 
 [env:esp32dev-ble-cont]
@@ -366,8 +366,8 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-  '-DLED_RECEIVE=2'
-  '-DLED_RECEIVE_ON=0'
+  '-DLED_SEND_RECEIVE=2'
+  '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_C"'
   '-DTimeBtwRead=0'
   '-DScan_duration=1000'
@@ -383,8 +383,8 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-  '-DLED_RECEIVE=13'
-  '-DLED_RECEIVE_ON=0'
+  '-DLED_SEND_RECEIVE=13'
+  '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_FTH_BLE"'
 
 [env:esp32-lolin32lite-ble]
@@ -397,8 +397,8 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-  '-DLED_RECEIVE=22'
-  '-DLED_RECEIVE_ON=0'
+  '-DLED_SEND_RECEIVE=22'
+  '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_LOLIN32LITE_BLE"'
 ;; Low power parameters, uncomment and fill credentials
 ;  '-DDEFAULT_LOW_POWER_MODE=0'
@@ -454,8 +454,8 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
   '-DZgatewayIR="IR"'
-  '-DLED_RECEIVE=19'
-  '-DLED_RECEIVE_ON=1'
+  '-DLED_SEND_RECEIVE=19'
+  '-DLED_SEND_RECEIVE_ON=1'
   '-DTRIGGER_GPIO=35'
   '-DIR_EMITTER_GPIO=17'
   '-DGateway_Name="OpenMQTTGateway_ESP32_M5STICK_BLE_IR"'
@@ -474,7 +474,7 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DZsensorGPIOInput="GPIOInput"'
   '-DZboardM5STACK="M5Stack"'
-  '-DLED_RECEIVE=15'
+  '-DLED_SEND_RECEIVE=15'
   '-DTRIGGER_GPIO=37'
   '-DSLEEP_BUTTON=38'
   '-DINPUT_GPIO=39'
@@ -498,8 +498,8 @@ build_flags =
   '-DZboardM5STICKC="M5StickC"'
   '-DACTUATOR_ONOFF_GPIO=10'
   '-DINPUT_GPIO=37'
-  '-DLED_RECEIVE=10'
-  '-DLED_RECEIVE_ON=0'
+  '-DLED_SEND_RECEIVE=10'
+  '-DLED_SEND_RECEIVE_ON=0'
   '-DSLEEP_BUTTON=39'
   '-DTRIGGER_GPIO=39'
   '-DIR_EMITTER_INVERTED=true'
@@ -524,8 +524,8 @@ build_flags =
   '-DZboardM5STICKCP="M5StickCP"'
   '-DACTUATOR_ONOFF_GPIO=10'
   '-DINPUT_GPIO=37'
-  '-DLED_RECEIVE=10'
-  '-DLED_RECEIVE_ON=0'
+  '-DLED_SEND_RECEIVE=10'
+  '-DLED_SEND_RECEIVE_ON=0'
   '-DSLEEP_BUTTON=39'
   '-DTRIGGER_GPIO=39'
   '-DIR_EMITTER_INVERTED=true'
@@ -616,11 +616,11 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_LORA"'
   
-  '-DLED_RECEIVE=21' # T-BEAM board V0.5
-#  '-DLED_RECEIVE=14' # T-BEAM board  V0.7
-#  '-DLED_RECEIVE=4' # T-BEAM board  V1.0+
+  '-DLED_SEND_RECEIVE=21' # T-BEAM board V0.5
+#  '-DLED_SEND_RECEIVE=14' # T-BEAM board  V0.7
+#  '-DLED_SEND_RECEIVE=4' # T-BEAM board  V1.0+
   '-DTimeLedON=0.05'
-  '-DLED_RECEIVE_ON=1' # Set 0 for board V1.0+
+  '-DLED_SEND_RECEIVE_ON=1' # Set 0 for board V1.0+
 
   # for V0.5 and V0.7 ONLY (V1.0+ as onboard AXP202 dedicated chip, need driver)
   # it's a 100K/100K divider (so 2 divider) and connected to GPIO35
@@ -641,9 +641,9 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayLORA="LORA"'
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
-  '-DLED_RECEIVE=25'
+  '-DLED_SEND_RECEIVE=25'
   '-DTimeLedON=0.1'
-  '-DLED_RECEIVE_ON=1' 
+  '-DLED_SEND_RECEIVE_ON=1' 
   
 [env:nodemcuv2-all-test]
 platform = ${com.esp8266_platform}
@@ -761,7 +761,7 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayIR="IR"'
   '-DTRIGGER_GPIO=13'
-  '-DLED_SEND=4'
+  '-DLED_SEND_RECEIVE=4'
   '-DIR_EMITTER_GPIO=14'
   '-DIR_RECEIVER_GPIO=5'
   '-DGateway_Name="OpenMQTTGateway_AVATTO_IR"'


### PR DESCRIPTION
## Description:
LED Macro on platformio.ini file does not fit the new keyword LED_SEND_RECEIVE, updating it

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
