### PR TITLE
Set OTA name as Gateway_Short_Name + MAC if using mac as gateway name.

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -600,6 +600,7 @@ void setup() {
           s.c_str(), s.c_str() + 3, s.c_str() + 6, s.c_str() + 9, s.c_str() + 12, s.c_str() + 15);
   snprintf(WifiManager_ssid, MAC_NAME_MAX_LEN, "%s_%s", Gateway_Short_Name, gateway_name);
   strcpy(ota_hostname, WifiManager_ssid);
+  Log.notice(F("OTA Hostname: %s.local" CR), ota_hostname);
 #  endif
 
 #  ifdef ESP32_ETHERNET

--- a/main/main.ino
+++ b/main/main.ino
@@ -168,7 +168,10 @@ char mqtt_topic[mqtt_topic_max_size] = Base_Topic;
 char gateway_name[parameters_size * 2] = Gateway_Name;
 #ifdef USE_MAC_AS_GATEWAY_NAME
 #  undef WifiManager_ssid
-char WifiManager_ssid[20];
+#  undef ota_hostname
+#  define MAC_NAME_MAX_LEN 30
+char WifiManager_ssid[MAC_NAME_MAX_LEN];
+char ota_hostname[MAC_NAME_MAX_LEN];
 #endif
 bool connectedOnce = false; //indicate if we have been connected once to MQTT
 int failure_number_ntwk = 0; // number of failure connecting to network
@@ -595,7 +598,8 @@ void setup() {
   String s = WiFi.macAddress();
   sprintf(gateway_name, "%.2s%.2s%.2s%.2s%.2s%.2s",
           s.c_str(), s.c_str() + 3, s.c_str() + 6, s.c_str() + 9, s.c_str() + 12, s.c_str() + 15);
-  sprintf(WifiManager_ssid, "%s_%s", Gateway_Short_Name, gateway_name);
+  snprintf(WifiManager_ssid, MAC_NAME_MAX_LEN, "%s_%s", Gateway_Short_Name, gateway_name);
+  strcpy(ota_hostname, WifiManager_ssid);
 #  endif
 
 #  ifdef ESP32_ETHERNET


### PR DESCRIPTION

## Description:
This will set the OTA name of the gateway to the *Gateway_Short_Name*_*MAC* when USE_MAC_AS_GATEWAY_NAME is defined in the config.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
