### PR TITLE
Deactivate RF switch discovery per default

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -37,7 +37,7 @@
 
 RCSwitch mySwitch = RCSwitch();
 
-#  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT)
+#  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT) && defined(RFmqttDiscovery)
 void RFtoMQTTdiscovery(SIGNAL_SIZE_UL_ULL MQTTvalue) { //on the fly switch creation from received RF values
   char val[11];
   sprintf(val, "%lu", MQTTvalue);

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -98,7 +98,7 @@ void RFtoMQTT() {
     mySwitch.resetAvailable();
 
     if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of RF -->MQTT
-#  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT) //component creation for HA
+#  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT) && defined(RFmqttDiscovery) //component creation for HA
       if (disc)
         RFtoMQTTdiscovery(MQTTvalue);
 #  endif

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -81,6 +81,7 @@ int minimumRssi = 0;
 //RF number of signal repetition - Can be overridden by specifying "repeat" in a JSON message.
 #define RF_EMITTER_REPEAT 20
 //#define RF_DISABLE_TRANSMIT //Uncomment this line to disable RF transmissions. (RF Receive will work as normal.)
+//#define RFmqttDiscovery true //uncomment this line so as to create a discovery switch for each RF signal received
 
 /*-------------------RF2 topics & parameters----------------------*/
 //433Mhz newremoteswitch MQTT Subjects and keys


### PR DESCRIPTION
## Description:
Per default deactivate RF discovery for switches to  prevent creating many switches into Home Assistant

To activate it uncomment:
`//#define RFmqttDiscovery true`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
