### PR TITLE
fix: add code for miscale_v2 lbs

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1466,7 +1466,16 @@ JsonObject& process_scale_v1(JsonObject& BLEdata) {
 JsonObject& process_scale_v2(JsonObject& BLEdata) {
   const char* servicedata = BLEdata["servicedata"].as<const char*>();
 
-  double weight = (double)value_from_hex_data(servicedata, 22, 4, true) / 200;
+  double weight = 0;
+  if (servicedata[1] == '2') { //kg
+    weight = (double)value_from_hex_data(servicedata, 22, 4, true) / 200;
+    BLEdata.set("unit", "kg");
+  } else if (servicedata[1] == '3') { //lbs
+    weight = (double)value_from_hex_data(servicedata, 22, 4, true) / 100;
+    BLEdata.set("unit", "lbs");
+  } else { //unknown unit
+    BLEdata.set("unit", "unknown");
+  }
   double impedance = (double)value_from_hex_data(servicedata, 18, 4, true);
 
   //Set Json values


### PR DESCRIPTION
## Description:
Currently, if the scale is set to imperial units, the incorrect weight is reported (by half). This patch duplicates the code from process_scale_v1 to account for kg or lbs. I have tested the patch with both.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
