### PR TITLE
Suggestion to also allow BLE WRITE procedures for WriteWithoutResponse characteristics

### DIFF
--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -36,7 +36,7 @@ NimBLERemoteCharacteristic* zBLEConnect::getCharacteristic(const NimBLEUUID& ser
 
 bool zBLEConnect::writeData(BLEAction* action) {
   NimBLERemoteCharacteristic* pChar = getCharacteristic(action->service, action->characteristic);
-  if (pChar && pChar->canWrite()) {
+  if (pChar && (pChar->canWrite() || pChar->canWriteNoResponse())) {
     switch (action->value_type) {
       case BLE_VAL_HEX: {
         int len = action->value.length();


### PR DESCRIPTION
While playing with the new BLE READ/WRITE feature for my Playbulb Candles I found that writing was not possible for characteristics which are WriteWithoutResponse only.

I implemented this quick fix which might be useful for others with devices for which they want to write to WriteWithoutResponse characteristics.

Alternatively a more slective option could be possible for a future release, i.e. adding an additional WRITE tag like "ble_write_withoutresponse": true/false

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
