### PR TITLE
Bugfix: missing break in BLE connect switch.

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -771,6 +771,7 @@ void BLEconnect() {
         case GENERIC: {
           GENERIC_connect BLEclient(addr);
           BLEclient.processActions(BLEactions);
+          break;
         }
         case HHCCJCY01HHCC: {
           HHCCJCY01HHCC_connect BLEclient(addr);


### PR DESCRIPTION
Fixes #1041, GENERIC device case was falling through to MiFlora.

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
