### PR TITLE
Remove duplicate BLE service data sent over MQTT.

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -685,36 +685,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
             process_bledata(BLEdata); // this will force to resolve all the service data
           }
 
-          if (serviceDataCount > 1) {
-            BLEdata.remove("servicedata");
-            BLEdata.remove("servicedatauuid");
-
-            int msglen = BLEdata.measureLength() + 1;
-            char jsonmsg[msglen];
-            char jsonmsgb[msglen];
-            BLEdata.printTo(jsonmsgb, sizeof(jsonmsgb));
-            for (int j = 0; j < serviceDataCount; j++) {
-              strcpy(jsonmsg, jsonmsgb); // the parse _destroys_ the message buffer
-              JsonObject& BLEdataLocal = getBTJsonObject(jsonmsg, j == 0); // note, that first time we will get here the BLEdata itself; haPresence for the first msg
-              if (!BLEdataLocal.containsKey("id")) { // would crash without id
-                Log.trace("Json parsing error for %s" CR, jsonmsgb);
-                break;
-              }
-              std::string service_data = convertServiceData(advertisedDevice->getServiceData(j));
-              std::string serviceDatauuid = advertisedDevice->getServiceDataUUID(j).toString();
-
-              int last = atomic_load_explicit(&jsonBTBufferQueueLast, ::memory_order_seq_cst) % BTQueueSize;
-              int size1 = jsonBTBufferQueue[last].buffer.size();
-              BLEdataLocal.set("servicedata", (char*)service_data.c_str());
-              int size2 = jsonBTBufferQueue[last].buffer.size();
-              BLEdataLocal.set("servicedatauuid", (char*)serviceDatauuid.c_str());
-              int size3 = jsonBTBufferQueue[last].buffer.size();
-              Log.trace("Buffersize for %d : %d -> %d -> %d" CR, j, size1, size2, size3);
-              PublishDeviceData(BLEdataLocal);
-            }
-          } else {
-            PublishDeviceData(BLEdata, false); // easy case
-          }
+          PublishDeviceData(BLEdata, false);
         } else {
           PublishDeviceData(BLEdata); // PublishDeviceData has its own logic whether it needs to publish the json or not
         }


### PR DESCRIPTION
## Description:
This will remove the sending of BLE service data when multiple service data attributes are advertised by a broadcasting device.

Instead the data for known device types will be consolidated into a single message to reduce overhead.

See #1040 


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
