### PR TITLE
Fix version tag in create docs actions

### DIFF
--- a/.github/workflows/manual_docs.yml
+++ b/.github/workflows/manual_docs.yml
@@ -20,8 +20,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install requests
           npm install
+      - name: get lastest release tag
+        id: last_release
+        uses: InsonusK/get-latest-release@v1.0.1
+        with:
+          myToken: ${{ github.token }}
+          view_top: 1
       - name: Set version tag from git
-        run: sed -i "s/version_tag/${GITHUB_REF#refs/tags/}/g" docs/.vuepress/config.js
+        run: sed -i "s/version_tag/${{steps.last_release.outputs.tag_name}}/g" docs/.vuepress/config.js
       - name: Build documentation
         run: |
           python ./scripts/gen_wu.py ${GITHUB_REPOSITORY}


### PR DESCRIPTION
## Description:
Get the last release tag and update it in the docs when manually creating documentation.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
