### PR TITLE
Add ability to change MQTT topic and or gateway name by MQTT command.

### DIFF
--- a/docs/use/gateway.md
+++ b/docs/use/gateway.md
@@ -72,12 +72,12 @@ If the new connection fails the gateway will fallback to the previous connection
 ```
 mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m
 '{
-  "mqtt_topic": "topic",
+  "mqtt_topic": "topic/",
   "gateway_name: "name"
 }'
 ```
 ::: info
-This will change the subscribed and published topic/gateway_name that the gateway uses. No parameters are manditory, the current topic or gateway name will be used if not supplied.
+This will change the subscribed and published mqtt_topic/gateway_name that the gateway uses. No parameters are manditory, the current topic or gateway name will be used if not supplied.
 :::
 
 ## Switching brokers and using self signed and client certificates

--- a/docs/use/gateway.md
+++ b/docs/use/gateway.md
@@ -68,6 +68,18 @@ Server, port, and secure_flag are only required if changing connection to anothe
 If the new connection fails the gateway will fallback to the previous connection.
 :::
 
+## Change the MQTT main topic and or gateway name
+```
+mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m
+'{
+  "mqtt_topic": "topic",
+  "gateway_name: "name"
+}'
+```
+::: info
+This will change the subscribed and published topic/gateway_name that the gateway uses. No parameters are manditory, the current topic or gateway name will be used if not supplied.
+:::
+
 ## Switching brokers and using self signed and client certificates
 
 In the `user_config.h` file it is possible to specify multiple MQTT brokers and client certificates. These are commonly self signed and are supported by defining `MQTT_SECURE_SELF_SIGNED` as true or 1.  

--- a/main/main.ino
+++ b/main/main.ino
@@ -2026,6 +2026,18 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
 #    endif
     }
 #  endif
+    if (SYSdata.containsKey("mqtt_topic") || SYSdata.containsKey("gateway_name")) {
+      if (SYSdata.containsKey("mqtt_topic")) {
+        strncpy(mqtt_topic, SYSdata["mqtt_topic"], mqtt_topic_max_size);
+      }
+      if (SYSdata.containsKey("gateway_name")) {
+        strncpy(gateway_name, SYSdata["gateway_name"], parameters_size * 2);
+      }
+#  ifndef ESPWifiManualSetup
+      saveMqttConfig();
+#  endif
+      client.disconnect(); // reconnects in loop using the new topic/name
+    }
 #endif
 
 #ifdef ZmqttDiscovery


### PR DESCRIPTION
## Description:
This adds new commands to allow changing the MQTT topic and or gateway name from a command.
The new topic/name will be saved in flash memory and used on subsequent reboots.
Either/both parameters can be sent or combined with other commands.

Example use:
```
mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m
'{
  "mqtt_topic": "topic",
  "gateway_name: "name"
}'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
