### PR TITLE
[Breaking] Set gateway name with the MAC address and AP name with OMG_<MAC>

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -612,7 +612,6 @@ build_flags =
 [env:heltec_wifi_lora_32]
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
-
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.lora}
@@ -674,8 +673,6 @@ build_flags =
   '-DZsensorGPIOKeyCode="GPIOKeyCode"'
   '-DZgatewayWeatherStation="WeatherStation"'
   '-DsimplePublishing=true'
-board_build.flash_mode = dout
-
 
 [env:nodemcuv2-2g]
 platform = ${com.esp8266_platform}
@@ -793,7 +790,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
   '-DESPWifiManualSetup=true'
-board_build.flash_mode = dout
 
 [env:rf-wifi-gateway]
 platform = ${com.esp8266_platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -155,6 +155,7 @@ build_flags =
   '-DCONFIG_BT_NIMBLE_ROLE_BROADCASTER_DISABLED'
   '-DMQTTsetMQTT'
   '-DMQTT_HTTPS_FW_UPDATE'
+  '-DUSE_MAC_AS_GATEWAY_NAME'
   ;'-DCORE_DEBUG_LEVEL=4'
 
 [com-arduino]
@@ -191,7 +192,6 @@ build_flags =
   '-DZgatewaySRFB="SRFB"'
   '-DLED_INFO=13'
   '-DLED_INFO_ON=0'
-  '-DGateway_Name="OpenMQTTGateway_SRFB"'
   '-UMQTTsetMQTT' ;We remove this function to have sufficient FLASH available for OTA, you should also use ESPWifiManualSetup to save flash memory and have OTA working
 board_build.flash_mode = dout
 
@@ -246,7 +246,6 @@ build_flags =
   '-DZsensorGPIOKeyCode="GPIOKeyCode"'
   '-DZgatewayWeatherStation="WeatherStation"'
   '-DsimplePublishing=true'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_ALL"'
 
 [env:esp32dev-rf]
 platform = ${com.esp32_platform}
@@ -257,7 +256,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_RF"'
 
 [env:esp32dev-pilight]
 platform = ${com.esp32_platform}
@@ -268,7 +266,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayPilight="Pilight"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_Pilight"'
 
 [env:esp32dev-pilight-cc1101]
 platform = ${com.esp32_platform}
@@ -281,7 +278,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayPilight="Pilight"'
   '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_Pilight-CC1101"'
 
 [env:esp32dev-somfy-cc1101]
 platform = ${com.esp32_platform}
@@ -294,7 +290,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZactuatorSomfy="Somfy"'
   '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_Somfy-CC1101"'
 
 [env:esp32dev-pilight-somfy-cc1101]
 platform = ${com.esp32_platform}
@@ -309,7 +304,6 @@ build_flags =
   '-DZgatewayPilight="Pilight"'
   '-DZactuatorSomfy="Somfy"'
   '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_Pilight-Somfy-CC1101"'
 
 [env:esp32dev-weatherstation]
 platform = ${com.esp32_platform}
@@ -320,7 +314,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayWeatherStation="WeatherStation"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_WeatherStation"'
 
 [env:esp32dev-gf-sun-inverter]
 platform = ${com.esp32_platform}
@@ -332,7 +325,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}  
   '-DZgatewayGFSunInverter="GFSunInverter"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_GFSunInverter"'
 
 [env:esp32dev-ir]
 platform = ${com.esp32_platform}
@@ -343,7 +335,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayIR="IR"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_IR"'
 
 [env:esp32dev-ble]
 platform = ${com.esp32_platform}
@@ -357,7 +348,6 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DLED_SEND_RECEIVE=2'
   '-DLED_SEND_RECEIVE_ON=0'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 
 [env:esp32dev-ble-cont]
 platform = ${com.esp32_platform}
@@ -371,7 +361,6 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DLED_SEND_RECEIVE=2'
   '-DLED_SEND_RECEIVE_ON=0'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_C"'
   '-DTimeBtwRead=0'
   '-DScan_duration=1000'
   '-DAttemptBLECOnnect=false'
@@ -388,7 +377,6 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DLED_SEND_RECEIVE=13'
   '-DLED_SEND_RECEIVE_ON=0'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_FTH_BLE"'
 
 [env:esp32-lolin32lite-ble]
 platform = ${com.esp32_platform}
@@ -402,7 +390,6 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DLED_SEND_RECEIVE=22'
   '-DLED_SEND_RECEIVE_ON=0'
-  '-DGateway_Name="OpenMQTTGateway_LOLIN32LITE_BLE"'
 ;; Low power parameters, uncomment and fill credentials
 ;  '-DDEFAULT_LOW_POWER_MODE=0'
 ;  '-DTimeBtwRead=550000'
@@ -428,7 +415,6 @@ build_flags =
   '-DLED_INFO=33'
   '-DLED_INFO_ON=1'
   '-DESP32_ETHERNET=true'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_OLM_GTWE"'
 
 [env:esp32-olimex-gtw-ble-wifi]
 platform = ${com.esp32_platform}
@@ -443,7 +429,6 @@ build_flags =
   '-DLED_INFO=33'
   '-DLED_INFO_ON=1'
   '-DTRIGGER_GPIO=34'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_OLM_GTWW"'
 
 [env:esp32-m5stick-ble]
 platform = ${com.esp32_platform}
@@ -461,7 +446,6 @@ build_flags =
   '-DLED_SEND_RECEIVE_ON=1'
   '-DTRIGGER_GPIO=35'
   '-DIR_EMITTER_GPIO=17'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_M5STICK_BLE_IR"'
 board_upload.speed = 921600
 
 [env:esp32-m5stack-ble]
@@ -481,7 +465,6 @@ build_flags =
   '-DTRIGGER_GPIO=37'
   '-DSLEEP_BUTTON=38'
   '-DINPUT_GPIO=39'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_M5STACK_BLE"'
 board_upload.speed = 921600
 
 [env:esp32-m5stick-c-ble]
@@ -507,7 +490,6 @@ build_flags =
   '-DTRIGGER_GPIO=39'
   '-DIR_EMITTER_INVERTED=true'
   '-DIR_EMITTER_GPIO=9'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_M5STICK_C_BLE_IR"'
 board_upload.speed = 1500000
 
 [env:esp32-m5stick-cp-ble]
@@ -533,7 +515,6 @@ build_flags =
   '-DTRIGGER_GPIO=39'
   '-DIR_EMITTER_INVERTED=true'
   '-DIR_EMITTER_GPIO=9'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_M5STICK_CP_BLE_IR"'
 board_upload.speed = 1500000
 
 [env:esp32-m5atom]
@@ -551,7 +532,6 @@ build_flags =
   '-DTRIGGER_GPIO=39'
   '-DSLEEP_BUTTON=39'
   '-DIR_EMITTER_GPIO=12'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_ATOM_BLE_IR"'
 board_upload.speed = 1500000
 
 [env:esp32dev-rtl_433]
@@ -565,7 +545,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZradioCC1101="CC1101"'
   '-DZgatewayRTL_433="rtl_433"'
-  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
   '-DvalueAsASubject=true'    ; mqtt topic includes model and device
 ;  '-DPUBLISH_UNPARSED=true'  ; Publish details of undecoded signals 
 ;  '-DRTL_DEBUG=4'            ; enable rtl_433 verbose device decode
@@ -588,7 +567,6 @@ build_flags =
   '-DZgatewayRTL_433="RTL_433"'
   '-DZgatewayPilight="Pilight"'
   '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway_multi_receiver"'
   '-DvalueAsASubject=true'  ; mqtt topic includes model and device (rtl_433) or protocol and id ( RF and PiLight )
 ;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
 
@@ -601,7 +579,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayLORA="LORA"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
 
 [env:ttgo-t-beam]
 # See version pinout differences here
@@ -617,7 +594,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayLORA="LORA"'
   '-DZgatewayBT="BT"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_LORA"'
   
   '-DLED_SEND_RECEIVE=21' # T-BEAM board V0.5
 #  '-DLED_SEND_RECEIVE=14' # T-BEAM board  V0.7
@@ -643,7 +619,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayLORA="LORA"'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
   '-DLED_SEND_RECEIVE=25'
   '-DTimeLedON=0.1'
   '-DLED_SEND_RECEIVE_ON=1' 
@@ -699,7 +674,6 @@ build_flags =
   '-DZsensorGPIOKeyCode="GPIOKeyCode"'
   '-DZgatewayWeatherStation="WeatherStation"'
   '-DsimplePublishing=true'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_ALL"'
 board_build.flash_mode = dout
 
 
@@ -712,7 +686,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="2G"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_2G"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-ble]
@@ -725,7 +698,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_BLE"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-ir]
@@ -738,7 +710,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayIR="IR"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_IR"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-rs232]
@@ -750,7 +721,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRS232="RS232"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_RS232"'
 board_build.flash_mode = dout
 
 [env:avatto-bakeey-ir]
@@ -770,7 +740,6 @@ build_flags =
   '-DIR_RECEIVER_GPIO=5'
   '-UMQTTsetMQTT' ;We remove this function to have sufficient FLASH available for OTA, you should also use ESPWifiManualSetup and 'board_build.ldscript = eagle.flash.1m64.ld' to save flash memory and have OTA working
   '-UMQTT_HTTPS_FW_UPDATE' ;We remove this function to have sufficient FLASH available for OTA, you should also use ESPWifiManualSetup and 'board_build.ldscript = eagle.flash.1m64.ld' to save flash memory and have OTA working
-  '-DGateway_Name="OpenMQTTGateway_AVATTO_IR"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-rf]
@@ -783,7 +752,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_RF"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-rf-cc1101]
@@ -798,7 +766,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
   '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_RF-CC1101"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-somfy-cc1101]
@@ -813,7 +780,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZactuatorSomfy="Somfy"'
   '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_Somfy-CC1101"'
 board_build.flash_mode = dout
 
 [env:manual-wifi-test]
@@ -827,30 +793,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
   '-DESPWifiManualSetup=true'
-  '-DGateway_Name="OpenMQTTGateway_TEST_MANUAL_WIFI"'
-board_build.flash_mode = dout
-
-[env:esp32dev-mqtt-fw-test]
-platform = ${com.esp32_platform}
-board = esp32dev
-lib_deps =
-  ${com-esp.lib_deps}
-build_flags =
-  ${com-esp.build_flags}
-  '-DMQTT_HTTPS_FW_UPDATE'
-  '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
-board_build.flash_mode = dout
-
-
-[env:nodemcuv2-mqtt-fw-test]
-platform = ${com.esp8266_platform}
-board = nodemcuv2
-lib_deps =
-  ${com-esp.lib_deps}
-build_flags =
-  ${com-esp.build_flags}
-  '-DMQTT_HTTPS_FW_UPDATE'
-  '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
 board_build.flash_mode = dout
 
 [env:rf-wifi-gateway]
@@ -863,7 +805,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_RF_WIFI_GW"'
   '-DRF_RECEIVER_GPIO=5'
 board_build.flash_mode = dout
 
@@ -877,7 +818,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF2="RF2"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_RF2"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-rf2-cc1101]
@@ -892,7 +832,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF2="RF2"'
   '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_RF2-CC1101"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-pilight]
@@ -905,7 +844,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayPilight="Pilight"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_Pilight"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-weatherstation]
@@ -918,7 +856,6 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayWeatherStation="WeatherStationDataRx"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_RF3"'
 board_build.flash_mode = dout
 
 [env:sonoff-basic]
@@ -936,7 +873,6 @@ build_flags =
   '-DACTUATOR_ON=0'
   '-DACTUATOR_ONOFF_DEFAULT=ACTUATOR_ON'
   '-DACTUATOR_BUTTON_TRIGGER_LEVEL=0'
-  '-DGateway_Name="OpenMQTTGateway_SONOFF_RELAY"'
 board_build.flash_mode = dout
 
 [env:sonoff-basic-rfr3]
@@ -957,7 +893,6 @@ build_flags =
   '-DACTUATOR_BUTTON_TRIGGER_LEVEL=0'
   '-DRF_RECEIVER_GPIO=4'
   '-DZgatewayRF="RF"'
-  '-DGateway_Name="OpenMQTTGateway_SONOFF_BASIC_RFR3"'
 board_build.flash_mode = dout
 
 [env:atmega-all-test]
@@ -1050,5 +985,4 @@ build_flags =
 	'-DLED_INFO_ON=0'
 	'-DZsensorGPIOInput="GPIOInput"'
 	'-DINPUT_GPIO=0'
-	'-DGateway_Name="OpenMQTTGateway_SRFB_Direct"'
 board_build.flash_mode = dout


### PR DESCRIPTION
## Description:
As announced on the v0.9.7 release note we are now going to set automatically per default the gateway name with the MAC address for all ESP boards.
The wifi AP default will be OMG_<MAC>
On your integration consider using the mqtt wildcard '+' instead of the gateway name. This enable for the controller to receive information from all the gateways.

Also removing the PIO env used to test this functionality and for the MQTT FW update

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
