### PR TITLE
Support for BME280 Temperature Correction

### DIFF
--- a/main/ZsensorBME280.ino
+++ b/main/ZsensorBME280.ino
@@ -107,13 +107,11 @@ void setupZsensorBME280() {
   //  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
   mySensor.settings.humidOverSample = 1;
 
-#  ifdef BME280Correction
-  // tempCorrection - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit tempaeratures are adjusted.
+  // tempCorrection - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
+  // -------------------------
   // Value is a float
   // ie Compiler Directive '-DBME280Correction=-3.4'
-
   mySensor.settings.tempCorrection = BME280Correction;
-#  endif
 
   delay(10); // Gives the Sensor enough time to turn on (The BME280 requires 2ms to start up)
 

--- a/main/ZsensorBME280.ino
+++ b/main/ZsensorBME280.ino
@@ -107,6 +107,14 @@ void setupZsensorBME280() {
   //  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
   mySensor.settings.humidOverSample = 1;
 
+#  ifdef BME280Correction
+  // tempCorrection - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit tempaeratures are adjusted.
+  // Value is a float
+  // ie Compiler Directive '-DBME280Correction=-3.4'
+
+  mySensor.settings.tempCorrection = BME280Correction;
+#  endif
+
   delay(10); // Gives the Sensor enough time to turn on (The BME280 requires 2ms to start up)
 
   int ret = mySensor.begin();

--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -62,4 +62,15 @@ int BME280_i2c_addr = 0x76; // Bosch BME280 I2C Address
 int BME280_PIN_SDA = SDA; // PIN SDA
 int BME280_PIN_SCL = SCL; // PIN SCL
 
+// Temperature correction for BME280 devices
+
+#  ifndef BME280Correction
+  // tempCorrection - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
+  // -------------------------
+  // Value is a float
+  // ie Compiler Directive '-DBME280Correction=-3.4'
+
+  #define BME280Correction 0;
+#  endif
+
 #endif

--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -64,13 +64,13 @@ int BME280_PIN_SCL = SCL; // PIN SCL
 
 // Temperature correction for BME280 devices
 
-#  ifndef BME280Correction
+#ifndef BME280Correction
   // tempCorrection - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
   // -------------------------
   // Value is a float
   // ie Compiler Directive '-DBME280Correction=-3.4'
 
   #define BME280Correction 0
-#  endif
+#endif
 
 #endif

--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -65,7 +65,7 @@ int BME280_PIN_SCL = SCL; // PIN SCL
 // Temperature correction for BME280 devices
 
 #ifndef BME280Correction
-    
+
 // BME280Correction - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
 // -------------------------
 // Value is a float

--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -65,12 +65,13 @@ int BME280_PIN_SCL = SCL; // PIN SCL
 // Temperature correction for BME280 devices
 
 #ifndef BME280Correction
-  // tempCorrection - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
-  // -------------------------
-  // Value is a float
-  // ie Compiler Directive '-DBME280Correction=-3.4'
+    
+// BME280Correction - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
+// -------------------------
+// Value is a float
+// ie Compiler Directive '-DBME280Correction=-3.4'
 
-  #define BME280Correction 0
+#  define BME280Correction 0
 #endif
 
 #endif

--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -70,7 +70,7 @@ int BME280_PIN_SCL = SCL; // PIN SCL
   // Value is a float
   // ie Compiler Directive '-DBME280Correction=-3.4'
 
-  #define BME280Correction 0;
+  #define BME280Correction 0
 #  endif
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -236,6 +236,7 @@ build_flags =
   '-DZsensorADC="ADC"'
   '-DZsensorBH1750="BH1750"'
   '-DZsensorBME280="BME280"'
+  '-DBME280Correction=-3.4'
   '-DZsensorHTU21="HTU21"'
   '-DZsensorAHTx0="AHTx0"'
   '-DZsensorTSL2561="TSL2561"'


### PR DESCRIPTION
## Description:

The Spark Fun BME 280 library has support for Temperature correction, and this pull request implements the ability to apply a correction via a compiler directive ( BME280Correction ).

 Correction is in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit tempaeratures are adjusted.
 Value is a float
 ie Compiler Directive '-DBME280Correction=-3.4'

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
