### PR TITLE
add script to compress firmware before ota upload

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,6 @@ include_dir = main
 extra_configs =
   tests/*_env.ini
   *_env.ini
-;extra_scripts = scripts/compressedFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                 ENVIRONMENT CHOICE                                   ;
@@ -190,6 +189,8 @@ build_flags =
   '-DLED_INFO_ON=0'
   '-DGateway_Name="OpenMQTTGateway_SRFB"'
 board_build.flash_mode = dout
+board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad via OTA.
+;extra_scripts = scripts/compressFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.
 
 [env:esp32dev-all-test]
 platform = ${com.esp32_platform}
@@ -1039,3 +1040,5 @@ build_flags =
 	'-DINPUT_GPIO=0'
 	'-DGateway_Name="OpenMQTTGateway_SRFB_Direct"'
 board_build.flash_mode = dout
+board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad via OTA.
+;extra_scripts = scripts/compressFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ include_dir = main
 extra_configs =
   tests/*_env.ini
   *_env.ini
+;extra_scripts = scripts/compressedFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                 ENVIRONMENT CHOICE                                   ;

--- a/prod_env.ini.example
+++ b/prod_env.ini.example
@@ -78,3 +78,50 @@ build_flags =
   '-DMQTT_PASS="abcdefghi"'
   '-DMQTT_SERVER="192.168.1.17"'
   '-DDEFAULT_LOW_POWER_MODE=2'
+
+;hacked Sonoff RF-Bridge
+[env:sonoff-rfbridge-hacked]
+platform = ${com.esp8266_platform}
+board = esp8285
+lib_deps = 
+	${com-esp.lib_deps}
+	${libraries.esppilight}
+build_flags = 
+	${com-esp.build_flags}
+	'-DZgatewayPilight="Pilight"'
+	'-DRF_RECEIVER_GPIO=4'
+	'-DRF_EMITTER_GPIO=5'
+	'-DLED_INFO=13'
+	'-DLED_INFO_ON=0'
+	'-DZsensorGPIOInput="GPIOInput"'
+	'-DINPUT_GPIO=0'
+	'-DGateway_Name="OpenMQTTGateway_SRFB_Direct"'
+board_build.flash_mode = dout
+board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad via OTA.
+
+;hacked Sonoff RF-Bridge OTA flash
+[env:sonoff-rfbridge-hacked-ota]
+upload_protocol = espota
+upload_port = <ip> ;change this to the ip address of you SRFB
+upload_speed = 512000
+upload_flags = 
+    --auth=OTAPASSWORD
+    --port=8266
+platform = ${com.esp8266_platform}
+board = esp8285
+lib_deps = 
+	${com-esp.lib_deps}
+	${libraries.esppilight}
+build_flags = 
+	${com-esp.build_flags}
+	'-DZgatewayPilight="Pilight"'
+	'-DRF_RECEIVER_GPIO=4'
+	'-DRF_EMITTER_GPIO=5'
+	'-DLED_INFO=13'
+	'-DLED_INFO_ON=0'
+	'-DZsensorGPIOInput="GPIOInput"'
+	'-DINPUT_GPIO=0'
+	'-DGateway_Name="OpenMQTTGateway_SRFB_Direct"'
+board_build.flash_mode = dout
+extra_scripts = scripts/compressFirmware.py
+board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad. Should also be uses for initial flash via serial

--- a/scripts/compressFirmware.py
+++ b/scripts/compressFirmware.py
@@ -1,0 +1,33 @@
+import gzip
+import shutil
+import os
+Import("env")
+
+
+def compressFirmware(source, target, env):
+    """ Compress firmware using gzip for 'compressed OTA upload' """
+    SOURCE_FILE = env.subst("$BUILD_DIR") + os.sep + env.subst("$PROGNAME") + ".bin"
+    SOURCE_BAK = SOURCE_FILE + '.bak'
+    do_compress = True
+    if os.path.exists(SOURCE_FILE) and os.path.exists(SOURCE_BAK):
+        src_mtime = os.stat(SOURCE_FILE).st_mtime
+        bak_mtime = os.stat(SOURCE_BAK).st_mtime
+        """ Recompress if .bin file is newer than .bak file """
+        do_compress = (src_mtime > bak_mtime)
+
+    if do_compress:
+        print("Compressing firmware for upload...")
+        shutil.move(SOURCE_FILE, SOURCE_BAK)
+        with open(SOURCE_BAK, 'rb') as f_in:
+            with gzip.open(SOURCE_FILE, 'wb', compresslevel = 9) as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        """ Set modification time on compressed file so incremental build works """
+        shutil.copystat(SOURCE_BAK, SOURCE_FILE)
+
+    if os.path.exists(SOURCE_BAK):
+        ORG_FIRMWARE_SIZE = os.stat(SOURCE_BAK).st_size
+        GZ_FIRMWARE_SIZE = os.stat(SOURCE_FILE).st_size
+
+        print("Compression reduced firmware size to {:.0f}% (was {} bytes, now {} bytes)".format((GZ_FIRMWARE_SIZE / ORG_FIRMWARE_SIZE) * 100, ORG_FIRMWARE_SIZE, GZ_FIRMWARE_SIZE))
+
+env.AddPostAction("$BUILD_DIR/firmware.bin", [compressFirmware])


### PR DESCRIPTION
## Description:
adds an extra script to compress firmware bofore OTA upload. The Script is located in scripts/compressed_ota.py and added in platformio.ini with "extra_scripts = scripts/compressed_ota.py". This fixes the issue that OTA failes for Sonoff RF Bridge due to the code becoming too large with the last releases. In my case the compression reduced the firmware to 72%.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
