### PR TITLE
Remove download count and replace it with hit badge on upload pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Community forum](https://img.shields.io/badge/community-forum-brightgreen.svg)](https://community.openmqttgateway.com)
 [![GitLicense](https://gitlicense.com/badge/1technophile/OpenMQTTGateway)](https://gitlicense.com/license/1technophile/OpenMQTTGateway)
-[![Download count](https://img.shields.io/github/downloads/1technophile/OpenMQTTGateway/total.svg)](https://github.com/1technophile/OpenMQTTGateway/releases)
 
 ![Build](https://github.com/1technophile/OpenMQTTGateway/workflows/Build/badge.svg?branch=development)
 ![Check Code Format](https://github.com/1technophile/OpenMQTTGateway/workflows/Check%20Code%20Format/badge.svg?branch=development)

--- a/docs/upload/binaries.md
+++ b/docs/upload/binaries.md
@@ -39,3 +39,5 @@ The upload details appears.
 With an ESP if you did not set your network and mqtt parameters manually you can now open the [web portal configuration](portal.md).
 
 Note that to reset the wifi and mqtt settings you can check *yes, wipes all data*
+
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fdocs.openmqttgateway.com%2Fupload%2Fbinaries.html&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)

--- a/docs/upload/builds.md
+++ b/docs/upload/builds.md
@@ -266,3 +266,5 @@ With an ESP if you did not set your network and mqtt parameters manualy you can 
 ::: warning Note
 simpleReceiving on Arduino boards doesn't accept 64 bits MQTT values, you can only send 32bits values from the MQTT broker.
 :::
+
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fdocs.openmqttgateway.com%2Fupload%2Fbuilds.html&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)

--- a/docs/upload/web-install.md
+++ b/docs/upload/web-install.md
@@ -6,3 +6,5 @@ You can upload the firmware to your ESP device directly from here.
 4. Wait until the process is complete.
 
 <web-uploader/>
+
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fdocs.openmqttgateway.com%2Fupload%2Fweb-install.html&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)


### PR DESCRIPTION

## Description:
as the binary download from the release page doesn't show all the download sources

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
