### PR TITLE
Save currently active receiver and restore on reboot

### DIFF
--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -194,7 +194,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       pub(subjectGTWPilighttoMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("MQTTtoPilight Fail json" CR));
     }
-    enableActiveReceiver();
+    enableActiveReceiver(false);
   }
 }
 

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -292,7 +292,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
         Log.error(F("MQTTtoRF Fail json" CR));
       }
     }
-    enableActiveReceiver();
+    enableActiveReceiver(false);
   }
 }
 #  endif

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -329,7 +329,7 @@ void MQTTtoRF2(char* topicOri, JsonObject& RF2data) { // json object decoding
 #    endif
       Log.error(F("MQTTtoRF2 failed json read" CR));
     }
-    enableActiveReceiver();
+    enableActiveReceiver(false);
   }
 }
 #  endif

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -116,7 +116,7 @@ extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
       pub(subjectRTL_433toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("MQTTtoRTL_433 Fail json" CR));
     }
-    enableActiveReceiver();
+    enableActiveReceiver(false);
   }
 }
 

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -181,7 +181,6 @@ int currentReceiver = -1;
 extern void stateMeasures(); // Send a status message
 
 void enableActiveReceiver(bool isBoot) {
-
 // Save currently active receiver and restore after reboot.
 // Only works with ESP and if there is no conflict.
 #  if !defined(ZgatewayRFM69) && !defined(ZactuatorSomfy)

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -30,7 +30,7 @@
 #include <ArduinoJson.h>
 
 #if defined(ESP8266) || defined(ESP32)
-#include <EEPROM.h>
+#  include <EEPROM.h>
 #endif
 
 #ifdef ZgatewayRF
@@ -188,21 +188,21 @@ void enableActiveReceiver(bool isBoot) {
 #    if defined(ESP8266) || defined(ESP32)
 #      define _ACTIVE_RECV_MAGIC 0xA1B2C3D4 
   
-       struct {
-         uint64_t magic;
-         int receiver;
-       } data;
+  struct {
+    uint64_t magic;
+    int receiver;
+  } data;
 
-       EEPROM.begin(sizeof(data));
-       EEPROM.get(0, data);
-       if (isBoot && data.magic == _ACTIVE_RECV_MAGIC) {
-         activeReceiver = data.receiver;
-       } else {
-         data.magic = _ACTIVE_RECV_MAGIC;
-         data.receiver = activeReceiver;
-         EEPROM.put(0, data);
-       }
-       EEPROM.end();
+  EEPROM.begin(sizeof(data));
+  EEPROM.get(0, data);
+  if (isBoot && data.magic == _ACTIVE_RECV_MAGIC) {
+    activeReceiver = data.receiver;
+  } else {
+    data.magic = _ACTIVE_RECV_MAGIC;
+    data.receiver = activeReceiver;
+    EEPROM.put(0, data);
+  }
+  EEPROM.end();
 #    endif
 #  endif
 

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -29,6 +29,10 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 
+#if defined(ESP8266) || defined(ESP32)
+#include <EEPROM.h>
+#endif
+
 #ifdef ZgatewayRF
 extern void setupRF();
 extern void RFtoMQTT();
@@ -176,7 +180,32 @@ int currentReceiver = -1;
 
 extern void stateMeasures(); // Send a status message
 
-void enableActiveReceiver() {
+void enableActiveReceiver(bool isBoot) {
+  
+// Save currently active receiver and restore after reboot.
+// Only works with ESP and if there is no conflict.
+#  if !defined(ZgatewayRFM69) && !defined(ZactuatorSomfy)
+#    if defined(ESP8266) || defined(ESP32)
+#      define _ACTIVE_RECV_MAGIC 0xA1B2C3D4 
+  
+       struct {
+         uint64_t magic;
+         int receiver;
+       } data;
+
+       EEPROM.begin(sizeof(data));
+       EEPROM.get(0, data);
+       if (isBoot && data.magic == _ACTIVE_RECV_MAGIC) {
+         activeReceiver = data.receiver;
+       } else {
+         data.magic = _ACTIVE_RECV_MAGIC;
+         data.receiver = activeReceiver;
+         EEPROM.put(0, data);
+       }
+       EEPROM.end();
+#    endif
+#  endif
+
   // if (currentReceiver != activeReceiver) {
   Log.trace(F("enableActiveReceiver: %d" CR), activeReceiver);
   switch (activeReceiver) {

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -181,13 +181,13 @@ int currentReceiver = -1;
 extern void stateMeasures(); // Send a status message
 
 void enableActiveReceiver(bool isBoot) {
-  
+
 // Save currently active receiver and restore after reboot.
 // Only works with ESP and if there is no conflict.
 #  if !defined(ZgatewayRFM69) && !defined(ZactuatorSomfy)
 #    if defined(ESP8266) || defined(ESP32)
-#      define _ACTIVE_RECV_MAGIC 0xA1B2C3D4 
-  
+#      define _ACTIVE_RECV_MAGIC 0xA1B2C3D4
+
   struct {
     uint64_t magic;
     int receiver;

--- a/main/main.ino
+++ b/main/main.ino
@@ -794,7 +794,7 @@ void setup() {
 #  else
   activeReceiver = ACTIVE_RECEIVER;
 #  endif
-  enableActiveReceiver();
+  enableActiveReceiver(true);
 #endif
   Log.trace(F("mqtt_max_packet_size: %d" CR), mqtt_max_packet_size);
 


### PR DESCRIPTION
## Description:

ESP32 and ESP8266 only: On activation of a receiver, the newly active receiver is saved to flash. When the gateway reboots because of power loss, for example, the previously saved receiver is automatically re-enabled.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
