### PR TITLE
Add LORA board definition for 915mhz

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -52,9 +52,11 @@ extra_configs =
 ;default_envs = esp32-m5stick-c-ble
 ;default_envs = esp32-m5stick-cp-ble
 ;default_envs = esp32-m5atom
-;default_envs = ttgo-lora32-v1
+;default_envs = ttgo-lora32-v1-868
+;default_envs = ttgo-lora32-v1-915
 ;default_envs = ttgo-t-beam
-;default_envs = heltec_wifi_lora_32
+;default_envs = heltec-wifi-lora-32-868
+;default_envs = heltec-wifi-lora-32-915
 ;default_envs = nodemcuv2-rf
 ;default_envs = nodemcuv2-rf-cc1101
 ;default_envs = nodemcuv2-somfy-cc1101
@@ -627,7 +629,7 @@ build_flags =
   '-DvalueAsASubject=true'  ; mqtt topic includes model and device (rtl_433) or protocol and id ( RF and PiLight )
 ;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
 
-[env:ttgo-lora32-v1]
+[env:ttgo-lora32-v1-868]
 platform = ${com.esp32_platform}
 board = ttgo-lora32-v1
 lib_deps =
@@ -636,6 +638,19 @@ lib_deps =
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayLORA="LORA"'
+  '-DLORA_BAND=868E6'
+  '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
+
+[env:ttgo-lora32-v1-915]
+platform = ${com.esp32_platform}
+board = ttgo-lora32-v1
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.lora}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayLORA="LORA"'
+  '-DLORA_BAND=915E6'
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
 
 [env:ttgo-t-beam]
@@ -669,16 +684,31 @@ build_flags =
   # Reading battery level every minutes should be more than enought
   '-DTimeBetweenReadingADC=60000' 
 
-[env:heltec_wifi_lora_32]
+[env:heltec-wifi-lora-32-868]
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
-
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.lora}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayLORA="LORA"'
+  '-DLORA_BAND=868E6'
+  '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
+  '-DLED_SEND_RECEIVE=25'
+  '-DTimeLedON=0.1'
+  '-DLED_SEND_RECEIVE_ON=1'
+
+[env:heltec-wifi-lora-32-915]
+platform = ${com.esp32_platform}
+board = heltec_wifi_lora_32
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.lora}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayLORA="LORA"'
+  '-DLORA_BAND=915E6'
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
   '-DLED_SEND_RECEIVE=25'
   '-DTimeLedON=0.1'


### PR DESCRIPTION
## Description:
Before having a captive portal for config settings like requested in #1056 let's begin by a board definition for 915mhz

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
