### PR TITLE
Bump theengs decoder to v0.1.4

### DIFF
--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -30,11 +30,13 @@ Added to that it retrieves the measures from the devices below. By default the d
 | XIAOMI Mi Lamp |MUE4094RT|presence|
 | GOVEE |H5075|temperature/humidity/battery|
 | GOVEE |H5072|temperature/humidity/battery|
+| GOVEE |H5102|temperature/humidity/battery|
 | HONEYWELL |JQJCY01YM|formaldehyde/temperature/humidity/battery|
 | INKBIRD (1)|IBS-TH1|temperature/humidity/battery|
 | INKBIRD (1)|IBS-TH2|temperature/battery|
-| INKBIRD (1)|IBT-4XS|temperature1/temperature2/temperature3/temperature4|
 | INKBIRD (1)|IBT-2X|temperature1/temperature2|
+| INKBIRD (1)|IBT-4XS|temperature1/temperature2/temperature3/temperature4|
+| INKBIRD (1)|IBT-6XS|temperature1/temperature2/temperature3/temperature4/temperature5/temperature6|
 | ClearGrass |CGG1|temperature/humidity/battery|
 | Qingping |CGDK2|temperature/humidity|
 | Qingping |CGH1|open|

--- a/platformio.ini
+++ b/platformio.ini
@@ -127,7 +127,7 @@ somfy_remote=Somfy_Remote_Lib@0.3.0
 rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP#e03f689
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.1.3
+decoder = https://github.com/theengs/decoder.git#v0.1.4
 
 [env]
 framework = arduino


### PR DESCRIPTION
## Description:
Add devices Govee H5102 and IBT-6XS
Correct #1112 for INKBIRD IBS-TH2

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
