### PR TITLE
Behaviour when MQTT and/or Wifi is not available

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -135,7 +135,7 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 //#define MDNS_SD //uncomment if you  want to use mdns for discovering automatically your ip server, please note that MDNS with ESP32 can cause the BLE to not work
 #define maxConnectionRetry     10 //maximum MQTT connection attempts before going to wifimanager setup if never connected once
 #define maxConnectionRetryWifi 5 //maximum Wifi connection attempts with existing credential at start (used to bypass ESP32 issue on wifi connect)
-#define maxRetryWatchDog 11 //maximum Wifi or mqtt re-connection attempts before restarting
+#define maxRetryWatchDog  11 //maximum Wifi or mqtt re-connection attempts before restarting
 
 //set minimum quality of signal so it ignores AP's under that quality
 #define MinimumWifiSignalQuality 8

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -135,7 +135,7 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 //#define MDNS_SD //uncomment if you  want to use mdns for discovering automatically your ip server, please note that MDNS with ESP32 can cause the BLE to not work
 #define maxConnectionRetry     10 //maximum MQTT connection attempts before going to wifimanager setup if never connected once
 #define maxConnectionRetryWifi 5 //maximum Wifi connection attempts with existing credential at start (used to bypass ESP32 issue on wifi connect)
-#define maxRetryWatchDog  11 //maximum Wifi or mqtt re-connection attempts before restarting
+#define maxRetryWatchDog       11 //maximum Wifi or mqtt re-connection attempts before restarting
 
 //set minimum quality of signal so it ignores AP's under that quality
 #define MinimumWifiSignalQuality 8

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -135,6 +135,7 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 //#define MDNS_SD //uncomment if you  want to use mdns for discovering automatically your ip server, please note that MDNS with ESP32 can cause the BLE to not work
 #define maxConnectionRetry     10 //maximum MQTT connection attempts before going to wifimanager setup if never connected once
 #define maxConnectionRetryWifi 5 //maximum Wifi connection attempts with existing credential at start (used to bypass ESP32 issue on wifi connect)
+#define maxRetryWatchDog 11 //maximum Wifi or mqtt re-connection attempts before restarting
 
 //set minimum quality of signal so it ignores AP's under that quality
 #define MinimumWifiSignalQuality 8

--- a/main/main.ino
+++ b/main/main.ino
@@ -985,16 +985,19 @@ void setup_wifi() {
     Log.trace(F("." CR));
     failure_number_ntwk++;
 #  if defined(ESP32) && defined(ZgatewayBT)
-    if (failure_number_ntwk > maxConnectionRetryWifi && lowpowermode)
-      lowPowerESP32();
-#  elif defined(ESP32)
-    if (failure_number_ntwk > maxRetryWatchDog && !lowpowermode) {
-      watchdogReboot(2);
-    }
-#  else
+    if (lowpowermode) {
+      if (failure_number_ntwk > maxConnectionRetryWifi) {
+        lowPowerESP32();
+      }
+    } else {
       if (failure_number_ntwk > maxRetryWatchDog) {
         watchdogReboot(2);
       }
+    }
+#  else
+    if (failure_number_ntwk > maxRetryWatchDog) {
+      watchdogReboot(2);
+    }
 #  endif
   }
   Log.notice(F("WiFi ok with manual config credentials" CR));

--- a/main/main.ino
+++ b/main/main.ino
@@ -2120,7 +2120,7 @@ String toString(uint32_t input) {
   Reason Codes
   1 - Repeated MQTT Connection Failure
   2 - Repeated WiFi Connection Failure
-  3 - Failed WiFi configuration portal
+  3 - Failed WiFiManager configuration portal
 */
 void watchdogReboot(byte reason) {
   Log.warning(F("Rebooting for reason code %d" CR), reason);

--- a/main/main.ino
+++ b/main/main.ino
@@ -561,7 +561,7 @@ void connectMQTT() {
     delay(2000);
     digitalWrite(LED_ERROR, !LED_ERROR_ON);
     delay(5000);
-    if (failure_number_mqtt > maxConnectionRetryWifi) {
+    if (failure_number_mqtt > maxRetryWatchDog) {
       watchdogReboot(1);
     }
   }
@@ -988,7 +988,7 @@ void setup_wifi() {
     if (failure_number_ntwk > maxConnectionRetryWifi && lowpowermode)
       lowPowerESP32();
 #  else
-    if (failure_number_ntwk > maxConnectionRetryWifi) {
+    if (failure_number_ntwk > maxRetryWatchDog) {
       watchdogReboot(2);
     }
 #  endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -987,10 +987,14 @@ void setup_wifi() {
 #  if defined(ESP32) && defined(ZgatewayBT)
     if (failure_number_ntwk > maxConnectionRetryWifi && lowpowermode)
       lowPowerESP32();
-#  else
+#  elif defined(ESP32)
     if (failure_number_ntwk > maxRetryWatchDog && !lowpowermode) {
       watchdogReboot(2);
     }
+#  else
+      if (failure_number_ntwk > maxRetryWatchDog) {
+        watchdogReboot(2);
+      }
 #  endif
   }
   Log.notice(F("WiFi ok with manual config credentials" CR));

--- a/main/main.ino
+++ b/main/main.ino
@@ -988,7 +988,7 @@ void setup_wifi() {
     if (failure_number_ntwk > maxConnectionRetryWifi && lowpowermode)
       lowPowerESP32();
 #  else
-    if (failure_number_ntwk > maxRetryWatchDog) {
+    if (failure_number_ntwk > maxRetryWatchDog && !lowpowermode) {
       watchdogReboot(2);
     }
 #  endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -1206,7 +1206,7 @@ void setup_wifimanager(bool reset_settings) {
     if (!wifiManager.autoConnect(WifiManager_ssid, WifiManager_password)) {
       Log.warning(F("failed to connect and hit timeout" CR));
       delay(3000);
-//reset and try again
+      //reset and try again
       watchdogReboot(3);
       delay(5000);
     }
@@ -2124,7 +2124,7 @@ String toString(uint32_t input) {
 */
 void watchdogReboot(byte reason) {
   Log.warning(F("Rebooting for reason code %d" CR), reason);
-#if defined(ESP32) 
+#if defined(ESP32)
   ESP.restart();
 #elif defined(ESP8266)
   ESP.reset();

--- a/main/main.ino
+++ b/main/main.ino
@@ -2125,7 +2125,6 @@ String toString(uint32_t input) {
   1 - Repeated MQTT Connection Failure
   2 - Repeated WiFi Connection Failure
 */
-
 void watchdogReboot(byte reason) {
   Log.warning(F("Rebooting for reason code %d" CR), reason);
 #if defined(ESP32) || defined(ESP8266)

--- a/main/main.ino
+++ b/main/main.ino
@@ -1207,11 +1207,7 @@ void setup_wifimanager(bool reset_settings) {
       Log.warning(F("failed to connect and hit timeout" CR));
       delay(3000);
 //reset and try again
-#  if defined(ESP8266)
-      ESP.reset();
-#  else
-      ESP.restart();
-#  endif
+      watchdogReboot(3);
       delay(5000);
     }
     digitalWrite(LED_ERROR, !LED_ERROR_ON);
@@ -2124,11 +2120,14 @@ String toString(uint32_t input) {
   Reason Codes
   1 - Repeated MQTT Connection Failure
   2 - Repeated WiFi Connection Failure
+  3 - Failed WiFi configuration portal
 */
 void watchdogReboot(byte reason) {
   Log.warning(F("Rebooting for reason code %d" CR), reason);
-#if defined(ESP32) || defined(ESP8266)
+#if defined(ESP32) 
   ESP.restart();
+#elif defined(ESP8266)
+  ESP.reset();
 #else // Insert other architectures here
 #endif
 }

--- a/main/main.ino
+++ b/main/main.ino
@@ -2119,13 +2119,13 @@ String toString(uint32_t input) {
 #  endif
 #endif
 
-/* 
+/*
   Reboot for repeated connection issues
   Reason Codes
   1 - Repeated MQTT Connection Failure
   2 - Repeated WiFi Connection Failure
 */
-    
+
 void watchdogReboot(byte reason) {
   Log.warning(F("Rebooting for reason code %d" CR), reason);
 #if defined(ESP32) || defined(ESP8266)


### PR DESCRIPTION
## Description:

I was looking into why all my OpenMQTTGateway devices were not responding after a recent power failure and am speculating that the ESP32 was able to restart faster than my Wifi and MQTT Server was able to restart and resume operations.  And was thinking that a generic ESP.restart may be a reasonable approach with repeated Wifi and/or MQTT connection failures.

For this I created a new variable `maxRetryWatchDog` which is set to 2 x maxConnectionRetryWifi + 1.

For the placement of the restart in the WiFi connection logic I did not want to affect the existing low power mode functionality, but would like a second opinion on this.  Also I looked at the Arduino spec and could not identify something similar. Also I don't have any in my test environment.

Am that this could be leveraged further for other retry loops that need a failsafe exit.

Also included a fix for the valueAsASubject mode when using multiple receivers.  The field `value` is null when the decoder is not PiLight.

As mentioned here https://community.openmqttgateway.com/t/behaviour-when-mqtt-and-or-wifi-is-not-available/1747

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
