### PR TITLE
Fix ir protocol name not correctly displayed on esp8266

### DIFF
--- a/main/ZgatewayIR.ino
+++ b/main/ZgatewayIR.ino
@@ -128,7 +128,8 @@ void IRtoMQTT() {
 #  if defined(ESP8266) || defined(ESP32) //resultToHexidecimal is only available with IRremoteESP8266
     String hex = resultToHexidecimal(&results);
     IRdata["hex"] = (const char*)hex.c_str();
-    IRdata["protocol_name"] = (const char*)(typeToString(results.decode_type, false)).c_str();
+    String protocol = typeToString(results.decode_type, false);
+    IRdata["protocol_name"] = (const char*)protocol.c_str();
 #  endif
     String rawCode = "";
     // Dump data
@@ -143,7 +144,6 @@ void IRtoMQTT() {
       if (i < results.rawlen - 1)
         rawCode = rawCode + ","; // ',' not needed on last one
     }
-    //trc(rawCode);
     IRdata["raw"] = rawCode;
 // if needed we directly resend the raw code
 #  ifdef RawDirectForward


### PR DESCRIPTION
## Description:
```
{"value":2172739743,"protocol":7,"bits":32,"hex":"0x8181609F","protocol_name":"x��?���?","raw":"4468,4474,558,1670,532,582,556,558,558,556,558,556,558,556,558,556,558,1670,560,1668,536,580,556,556,534,580,532,582,558,554,558,556,560,1666,560,556,558,1670,560,1668,562,552,560,554,558,556,558,554,560,554,560,1668,534,580,558,556,534,1692,560,1668,560,1668,562,1668,558,1670,560"}
```

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
