### PR TITLE
Use write with response when non-response write is not available.

### DIFF
--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -50,14 +50,14 @@ bool zBLEConnect::writeData(BLEAction* action) {
           std::string temp = action->value.substr(i, 2);
           buf.push_back((uint8_t)strtoul(temp.c_str(), nullptr, 16));
         }
-        return pChar->writeValue((const uint8_t*)&buf[0], buf.size());
+        return pChar->writeValue((const uint8_t*)&buf[0], buf.size(), !pChar->canWrite());
       }
       case BLE_VAL_INT:
-        return pChar->writeValue(strtol(action->value.c_str(), nullptr, 0));
+        return pChar->writeValue(strtol(action->value.c_str(), nullptr, 0), !pChar->canWrite());
       case BLE_VAL_FLOAT:
-        return pChar->writeValue(strtod(action->value.c_str(), nullptr));
+        return pChar->writeValue(strtod(action->value.c_str(), nullptr), !pChar->canWrite());
       default:
-        return pChar->writeValue(action->value);
+        return pChar->writeValue(action->value, !pChar->canWrite());
     }
   }
   return false;


### PR DESCRIPTION
## Description
If the BLE characteristic does not have write without response available this will default to using write with response.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
