### PR TITLE
Add immediate parameter to BLE connection commands.

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -164,7 +164,8 @@ The default value is set into config_BT.h
 
 The gateway can read and write BLE characteristics from devices and provide the results in an MQTT message.  
 ::: tip
-These actions will be taken on the next BLE connection, which occurs after scanning and after the scan count is reached, [see above to set this.](#setting-the-number-of-scans-between-connection-attempts)
+These actions will be taken on the next BLE connection, which occurs after scanning and after the scan count is reached, [see above to set this.](#setting-the-number-of-scans-between-connection-attempts)  
+This can be overridden by providing an (optional) parameter `"immediate": true` within the command. This will cause the BLE scan to stop if currently in progress, allowing the command to be immediately processed. All other connection commands in queue will also be processed for the same device, commands for other devices will be deferred until the next normally scheduled connection.
 :::
 
 ### Example write command
@@ -175,7 +176,8 @@ mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
   "ble_write_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
   "ble_write_value":"TEST",
   "value_type":"STRING",
-  "ttl":4 }'
+  "ttl":4,
+  "immediate":true }'
 ```
 Response:
 ```

--- a/main/ZgatewayBLEConnect.h
+++ b/main/ZgatewayBLEConnect.h
@@ -12,7 +12,10 @@ class zBLEConnect {
 public:
   NimBLEClient* m_pClient;
   TaskHandle_t m_taskHandle = nullptr;
-  zBLEConnect(NimBLEAddress& addr) { m_pClient = NimBLEDevice::createClient(addr); }
+  zBLEConnect(NimBLEAddress& addr) {
+    m_pClient = NimBLEDevice::createClient(addr);
+    m_pClient->setConnectTimeout(5);
+  }
   virtual ~zBLEConnect() { NimBLEDevice::deleteClient(m_pClient); }
   virtual bool writeData(BLEAction* action);
   virtual bool readData(BLEAction* action);

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -117,9 +117,11 @@ bool zBLEConnect::processActions(std::vector<BLEAction>& actions) {
           }
         }
 
-        it.complete = true;
+        it.complete = result;
         BLEresult["success"] = result;
-        pubBT(BLEresult);
+        if (result || it.ttl <= 1) {
+          pubBT(BLEresult);
+        }
       }
     }
   }

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -50,14 +50,14 @@ bool zBLEConnect::writeData(BLEAction* action) {
           std::string temp = action->value.substr(i, 2);
           buf.push_back((uint8_t)strtoul(temp.c_str(), nullptr, 16));
         }
-        return pChar->writeValue((const uint8_t*)&buf[0], buf.size(), !pChar->canWrite());
+        return pChar->writeValue((const uint8_t*)&buf[0], buf.size(), !pChar->canWriteNoResponse());
       }
       case BLE_VAL_INT:
-        return pChar->writeValue(strtol(action->value.c_str(), nullptr, 0), !pChar->canWrite());
+        return pChar->writeValue(strtol(action->value.c_str(), nullptr, 0), !pChar->canWriteNoResponse());
       case BLE_VAL_FLOAT:
-        return pChar->writeValue(strtod(action->value.c_str(), nullptr), !pChar->canWrite());
+        return pChar->writeValue(strtod(action->value.c_str(), nullptr), !pChar->canWriteNoResponse());
       default:
-        return pChar->writeValue(action->value, !pChar->canWrite());
+        return pChar->writeValue(action->value, !pChar->canWriteNoResponse());
     }
   }
   return false;

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -82,12 +82,12 @@ bool zBLEConnect::processActions(std::vector<BLEAction>& actions) {
       if (NimBLEAddress(it.addr) == m_pClient->getPeerAddress()) {
         JsonObject BLEresult = getBTJsonObject();
         BLEresult["id"] = it.addr;
-        BLEresult["service"] = (char*)it.service.toString().c_str();
-        BLEresult["characteristic"] = (char*)it.characteristic.toString().c_str();
+        BLEresult["service"] = it.service.toString();
+        BLEresult["characteristic"] = it.characteristic.toString();
 
         if (it.write) {
           Log.trace(F("processing BLE write" CR));
-          BLEresult["write"] = it.value.c_str();
+          BLEresult["write"] = it.value;
           result = writeData(&it);
         } else {
           Log.trace(F("processing BLE read" CR));

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -480,6 +480,9 @@ void BLEconnect() {
         } else {
           GENERIC_connect BLEclient(addr);
           BLEclient.processActions(BLEactions);
+          // If we don't regularly connect to this, disable connections so advertisements
+          // won't be filtered if BLE_FILTER_CONNECTABLE is set.
+          p->connect = false;
         }
         if (BLEactions.size() > 0) {
           std::vector<BLEAction> swap;

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1017,6 +1017,9 @@ void MQTTtoBTAction(JsonObject& BTdata) {
       // back to normal
       std::swap(devices, dev_swap);
       std::swap(BLEactions, act_swap);
+      // If we stopped the scheduled connect for this action, do the scheduled now
+      if ((!(scanCount % BLEscanBeforeConnect) || scanCount == 1) && bleConnect)
+        BLEconnect();
       xSemaphoreGive(semaphoreBLEOperation);
     } else {
       Log.error(F("BLE busy - command not sent" CR));

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -461,7 +461,7 @@ void BLEscan() {
 void BLEconnect() {
   if (!ProcessLock) {
     Log.notice(F("BLE Connect begin" CR));
-    while (BLEactions.size() > 0) {
+    do {
       for (vector<BLEdevice*>::iterator it = devices.begin(); it != devices.end(); ++it) {
         BLEdevice* p = *it;
         if (p->connect) {
@@ -506,7 +506,7 @@ void BLEconnect() {
           }
         }
       }
-    }
+    } while (BLEactions.size() > 0);
     Log.notice(F("BLE Connect end" CR));
   }
 }


### PR DESCRIPTION
## Description:

When sending a command to read/write a characteristic on a BLE server this adds a new parameter to cause the action to be
performed immediately. This will stop the scan in progress to perform the actions queued.

Example use:
```
mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
  "ble_write_address":"AA:BB:CC:DD:EE:FF",
  "ble_write_service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
  "ble_write_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
  "ble_write_value":"TEST",
  "value_type":"STRING",
  "ttl":4,
  "immediate":true }'
```

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
