### PR TITLE
Fix some incorrect timeouts when taking semaphores.

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -795,7 +795,7 @@ void launchBTDiscovery() {
   if (newDevices == 0)
     return;
 #    ifdef ESP32
-  if (xSemaphoreTake(semaphoreCreateOrUpdateDevice, pdMS_TO_TICKS(1000) == pdFALSE)) {
+  if (xSemaphoreTake(semaphoreCreateOrUpdateDevice, pdMS_TO_TICKS(1000)) == pdFALSE) {
     Log.error(F("Semaphore NOT taken" CR));
     return;
   }
@@ -1045,7 +1045,7 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
 
     if (WorBupdated) {
 #  ifdef ESP32
-      if (xSemaphoreTake(semaphoreCreateOrUpdateDevice, pdMS_TO_TICKS(1000) == pdTRUE)) {
+      if (xSemaphoreTake(semaphoreCreateOrUpdateDevice, pdMS_TO_TICKS(1000)) == pdTRUE) {
         dumpDevices();
         xSemaphoreGive(semaphoreCreateOrUpdateDevice);
       }


### PR DESCRIPTION
## Description:
The `xSemaphoreTake` calls fixed here were not actually using the timeout setting but instead using a boolean value as the ticks to wait (0 or 1). This corrects them to use the time specified.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
