### PR TITLE
Add "mac_type" parameter to BLE connection commands.

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -166,6 +166,9 @@ The gateway can read and write BLE characteristics from devices and provide the 
 ::: tip
 These actions will be taken on the next BLE connection, which occurs after scanning and after the scan count is reached, [see above to set this.](#setting-the-number-of-scans-between-connection-attempts)  
 This can be overridden by providing an (optional) parameter `"immediate": true` within the command. This will cause the BLE scan to stop if currently in progress, allowing the command to be immediately processed. All other connection commands in queue will also be processed for the same device, commands for other devices will be deferred until the next normally scheduled connection.
+
+**Note** Some devices need to have the mac address type specified. You can find this type by checking the log/mqtt data and looking for "mac_type". By default the type is 0 but some devices use different type values. You must specify the correct type to connect successfully.  
+To specify the MAC address type add the parameter `"mac_type"` to the command. For example `"mac_type": 1` to connect with a device with the MAC address type of 1.
 :::
 
 ### Example write command

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -153,6 +153,7 @@ enum ble_val_type {
 struct BLEAction {
   std::string value;
   char addr[18];
+  int addr_type;
   NimBLEUUID service;
   NimBLEUUID characteristic;
   bool write;
@@ -164,6 +165,7 @@ struct BLEAction {
 
 struct BLEdevice {
   char macAdr[18];
+  int macType;
   bool isDisc;
   bool isWhtL;
   bool isBlkL;


### PR DESCRIPTION
## Description:
This allows for connecting to devices that do not use the MAC address type 0.
This also adds the logging of the "mac_type" so it is visible to users trying to connect to broadcasting devices.

Additionally this will allow for future connectable devices using a MAC address type other than 0 to be automatically connected to
when support is added for them, similar to LYWSD03MMC etc..

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
