### PR TITLE
[BREAKING] Change unique id structure for HASS discovery

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -843,7 +843,7 @@ void launchBTDiscovery() {
           Log.trace("Name: %s", prop.value()["name"].as<const char*>());
           String discovery_topic = String(subjectBTtoMQTT) + "/" + macWOdots;
           String entity_name = String(model_id.c_str()) + "-" + String(prop.key().c_str());
-          String unique_id = macWOdots + "-" + entity_name;
+          String unique_id = macWOdots + "-" + String(prop.key().c_str());
 #    if OpenHABDiscovery
           String value_template = "{{ value_json." + String(prop.key().c_str()) + "}}";
 #    else

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -43,7 +43,7 @@ String getMacAddress() {
 }
 
 String getUniqueId(String name, String sufix) {
-  String uniqueId = (String)getMacAddress() + name + sufix;
+  String uniqueId = (String)getMacAddress() + "-" + name + sufix;
   return String(uniqueId);
 }
 


### PR DESCRIPTION
## Description:

Now:
"uniq_id":"882D777014C-pres"
before it was:
"uniq_id":"882D7770014C-CLEARGRASSTRHKPA-pres"
This will impact BLE and gateways entities.

A new MQTT discovery message will be published to the broker, it will not replace the previous one. So your auto-discovered gateway and BLE entities and automation will still work until your next MQTT broker restart.
If you want to keep the previously-stored Unique_ID definition at the broker level I advise activating persistence on your mosquitto before upgrading OMG, this will keep the discovery message even if you restart.

Discussion topic:
https://community.openmqttgateway.com/t/hass-duplicate-ble-entities-creation-for-existing-users-v0-9-9-and-auto-discovery/1776

Why doing this:
-Unique id should contain minimal information to preserve unicity and the combination between the MAC address and the key answer to this criteria, the model is not required on a technical ID like the unique_id

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
