### PR TITLE
[BREAKING] Differentiate WM version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -111,7 +111,8 @@ htu21 = SparkFun HTU21D Humidity and Temperature Sensor Breakout@1.1.3
 ahtx0 = Adafruit AHTX0
 ina226 = https://github.com/jarzebski/Arduino-INA226.git#968a684
 a6lib = https://github.com/h2zero/A6lib
-wifimanager = https://github.com/tzapu/WiFiManager.git#c3ff582
+wifimanager32 = https://github.com/tzapu/WiFiManager.git#c3ff582
+wifimanager8266 = https://github.com/tzapu/WiFiManager.git#0.16.0
 ethernet = Ethernet
 esp8266_mdns = esp8266_mdns
 wire = Wire
@@ -152,7 +153,6 @@ atmelavr_platform = atmelavr@3.3.0
 [com-esp]
 lib_deps =
   ${env.lib_deps}
-  ${libraries.wifimanager}
 build_flags =
   ${env.build_flags}
   '-DsimpleReceiving=true'
@@ -192,6 +192,7 @@ platform = ${com.esp8266_platform}
 board = esp8285
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.esp8266_mdns}
 build_flags =
   ${com-esp.build_flags}
@@ -204,12 +205,35 @@ board_build.flash_mode = dout
 board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad via OTA.
 ;extra_scripts = scripts/compressFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.
 
+[env:sonoff-rfbridge-direct]
+platform = espressif8266@^2
+board = esp8285
+lib_deps = 
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
+  ${libraries.esppilight}
+build_flags = 
+  ${com-esp.build_flags}
+  '-DZgatewayPilight="Pilight"'
+  '-DRF_RECEIVER_GPIO=4'
+  '-DRF_EMITTER_GPIO=5'
+  '-DLED_INFO=13'
+  '-DLED_INFO_ON=0'
+  '-DZsensorGPIOInput="GPIOInput"'
+  '-DINPUT_GPIO=0'
+  '-DGateway_Name="OpenMQTTGateway_SRFB_Direct"'
+board_build.flash_mode = dout
+board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad via OTA.
+;extra_scripts = scripts/compressFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.
+
+
 [env:esp32dev-all-test]
 platform = ${com.esp32_platform}
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.irremoteesp}
@@ -264,6 +288,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.rc-switch}
 build_flags =
   ${com-esp.build_flags}
@@ -275,6 +300,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.esppilight}
 build_flags =
   ${com-esp.build_flags}
@@ -286,6 +312,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.esppilight}
   ${libraries.smartrc-cc1101-driver-lib}
 build_flags =
@@ -299,6 +326,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.somfy_remote}
   ${libraries.smartrc-cc1101-driver-lib}
 build_flags =
@@ -312,6 +340,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.esppilight}
   ${libraries.somfy_remote}
   ${libraries.smartrc-cc1101-driver-lib}
@@ -327,6 +356,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.rfWeatherStation}
 build_flags =
   ${com-esp.build_flags}
@@ -338,6 +368,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.emodbus}
   ${libraries.gfSunInverter}  
 build_flags =
@@ -350,6 +381,7 @@ platform = ${com.esp32_platform}
 board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.irremoteesp}
 build_flags =
   ${com-esp.build_flags}
@@ -362,6 +394,7 @@ board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -377,6 +410,7 @@ board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -399,6 +433,7 @@ board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -417,6 +452,7 @@ board = featheresp32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -432,6 +468,7 @@ board = lolin32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -459,6 +496,7 @@ board = esp32-gateway
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -475,6 +513,7 @@ board = esp32-gateway
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -492,6 +531,7 @@ board = esp32-gateway
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -508,6 +548,7 @@ board = m5stack-core-esp32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.irremoteesp}
@@ -528,6 +569,7 @@ board = m5stack-core-esp32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.m5stack}
   ${libraries.ble}
   ${libraries.decoder}
@@ -549,6 +591,7 @@ board = m5stack-core-esp32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.m5tough}
   ${libraries.ble}
   ${libraries.decoder}
@@ -565,6 +608,7 @@ board = m5stick-c
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.m5stickc}
@@ -592,6 +636,7 @@ board = pico32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.m5stickcp}
@@ -619,6 +664,7 @@ board = pico32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.irremoteesp}
@@ -638,6 +684,7 @@ board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.rtl_433_ESP}
 build_flags =
   ${com-esp.build_flags}
@@ -654,6 +701,7 @@ board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.rc-switch}
   ${libraries.smartrc-cc1101-driver-lib}
   ${libraries.rtl_433_ESP}
@@ -675,6 +723,7 @@ platform = ${com.esp32_platform}
 board = ttgo-lora32-v1
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.lora}
 build_flags =
   ${com-esp.build_flags}
@@ -687,6 +736,7 @@ platform = ${com.esp32_platform}
 board = ttgo-lora32-v1
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.lora}
 build_flags =
   ${com-esp.build_flags}
@@ -702,6 +752,7 @@ board = ttgo-t-beam
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.lora}
@@ -730,6 +781,7 @@ platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.lora}
 build_flags =
   ${com-esp.build_flags}
@@ -745,6 +797,7 @@ platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
   ${libraries.lora}
 build_flags =
   ${com-esp.build_flags}
@@ -753,13 +806,27 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
   '-DLED_SEND_RECEIVE=25'
   '-DTimeLedON=0.1'
-  '-DLED_SEND_RECEIVE_ON=1' 
-  
+  '-DLED_SEND_RECEIVE_ON=1'
+
+[env:esp32dev-mqtt-fw-test]
+platform = ${com.esp32_platform}
+board = esp32dev
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+build_flags =
+  ${com-esp.build_flags}
+  '-DMQTT_HTTPS_FW_UPDATE'
+  '-DMQTT_SECURE_SELF_SIGNED'
+  '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
+board_build.flash_mode = dout
+
 [env:nodemcuv2-all-test]
 platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ;${libraries.esppilight}
   ${libraries.irremoteesp}
   ${libraries.rfm69}
@@ -815,6 +882,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.a6lib}
 build_flags =
   ${com-esp.build_flags}
@@ -827,6 +895,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.wire}
   ${libraries.esp8266_mdns}
   ${libraries.decoder}
@@ -841,6 +910,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.irremoteesp}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -854,6 +924,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.esp8266_mdns}
 build_flags =
   ${com-esp.build_flags}
@@ -867,6 +938,7 @@ board = esp01_1m
 board_build.ldscript = eagle.flash.1m64.ld
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.irremoteesp}
   ${libraries.esp8266_mdns}
 build_flags = 
@@ -886,6 +958,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.rc-switch}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -899,6 +972,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.rc-switch}
   ${libraries.smartrc-cc1101-driver-lib}
   ${libraries.esp8266_mdns}
@@ -914,6 +988,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.somfy_remote}
   ${libraries.smartrc-cc1101-driver-lib}
   ${libraries.esp8266_mdns}
@@ -929,6 +1004,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.rc-switch}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -938,24 +1014,12 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_TEST_MANUAL_WIFI"'
 board_build.flash_mode = dout
 
-[env:esp32dev-mqtt-fw-test]
-platform = ${com.esp32_platform}
-board = esp32dev
-lib_deps =
-  ${com-esp.lib_deps}
-build_flags =
-  ${com-esp.build_flags}
-  '-DMQTT_HTTPS_FW_UPDATE'
-  '-DMQTT_SECURE_SELF_SIGNED'
-  '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
-board_build.flash_mode = dout
-
-
 [env:nodemcuv2-mqtt-fw-test]
 platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
 build_flags =
   ${com-esp.build_flags}
   '-DMQTT_HTTPS_FW_UPDATE'
@@ -967,6 +1031,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.rc-switch}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -981,6 +1046,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.newremoteswitch}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -994,6 +1060,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.newremoteswitch}
   ${libraries.smartrc-cc1101-driver-lib}
   ${libraries.esp8266_mdns}
@@ -1009,6 +1076,7 @@ platform = espressif8266@^2
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.esppilight}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -1022,6 +1090,7 @@ platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.rfWeatherStation}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -1035,6 +1104,7 @@ platform = ${com.esp8266_platform}
 board = esp8285
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.esp8266_mdns}
 build_flags =
   ${com-esp.build_flags}
@@ -1053,6 +1123,7 @@ platform = ${com.esp8266_platform}
 board = esp8285
 lib_deps =
   ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
   ${libraries.rc-switch}
   ${libraries.esp8266_mdns}
 build_flags =
@@ -1145,23 +1216,3 @@ build_flags =
   ${com-arduino-low-memory.build_flags}
   '-DGateway_Name="OMG_1_FL"'
   '-DZactuatorFASTLED="FASTLED"'
-
-[env:sonoff-rfbridge-direct]
-platform = espressif8266@^2
-board = esp8285
-lib_deps = 
-	${com-esp.lib_deps}
-	${libraries.esppilight}
-build_flags = 
-	${com-esp.build_flags}
-	'-DZgatewayPilight="Pilight"'
-	'-DRF_RECEIVER_GPIO=4'
-	'-DRF_EMITTER_GPIO=5'
-	'-DLED_INFO=13'
-	'-DLED_INFO_ON=0'
-	'-DZsensorGPIOInput="GPIOInput"'
-	'-DINPUT_GPIO=0'
-	'-DGateway_Name="OpenMQTTGateway_SRFB_Direct"'
-board_build.flash_mode = dout
-board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad via OTA.
-;extra_scripts = scripts/compressFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.


### PR DESCRIPTION
## Description:
to avoid a bug that show only the SSID and the password field on the ESP8266 uC
-env.ini environments will need to be updated so as to add into their `lib_deps` section:
`${libraries.wifimanager8266}`
or
`${libraries.wifimanager32}`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
