### PR TITLE
Add TinyPICO board

### DIFF
--- a/docs/upload/web-install.md
+++ b/docs/upload/web-install.md
@@ -36,6 +36,7 @@ The table below describes the libraries and the modules of each board configurat
 |esp32feather-ble|ESP32 Feather Adafruit|BLE for the Adafruit Feather board|-|-|X|-|
 |heltec-wifi-lora32-868|ESP32 HELTEC LORA V2|LORA communication 868Mhz  using [arduino-LoRA](https://github.com/sandeepmistry/arduino-LoRa) |-|-|-|X|
 |heltec-wifi-lora32-915|ESP32 HELTEC LORA V2|LORA communication 915Mhz using [arduino-LoRA](https://github.com/sandeepmistry/arduino-LoRa)|-|-|-|X|
+|tinypico-ble|ESP32 TinyPICO|BLE Gateway|-|-|X|-|
 |ttgo-lora32-v1-868|ESP32 TTGO LORA V1|LORA communication 868Mhz using [arduino-LoRA](https://github.com/sandeepmistry/arduino-LoRa)|-|-|-|X|
 |ttgo-lora32-v1-915|ESP32 TTGO LORA V1|LORA communication 915Mhz using [arduino-LoRA](https://github.com/sandeepmistry/arduino-LoRa)|-|-|-|X|
 |ttgo-tbeam|ESP32 TTGO T BEAM|BLE gateway with battery holder|-|-|X|-|

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,6 +54,7 @@ extra_configs =
 ;default_envs = esp32-m5stick-c-ble
 ;default_envs = esp32-m5stick-cp-ble
 ;default_envs = esp32-m5atom
+;default_envs = tinypico-ble
 ;default_envs = ttgo-lora32-v1-868
 ;default_envs = ttgo-lora32-v1-915
 ;default_envs = ttgo-t-beam
@@ -718,6 +719,21 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_multi_receiver"'
   '-DvalueAsASubject=true'  ; mqtt topic includes model and device (rtl_433) or protocol and id ( RF and PiLight )
 ;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
+
+[env:tinypico-ble]
+platform = ${com.esp32_platform}
+board = tinypico
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ble}
+  ${libraries.decoder}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayBT="BT"'
+  '-DGateway_Name="OpenMQTTGateway_ESP32_TINYPICO_BLE"'
+board_build.flash_mode = dio
 
 [env:ttgo-lora32-v1-868]
 platform = ${com.esp32_platform}


### PR DESCRIPTION
## Description:
Adds support for the [TinyPICO](https://www.tinypico.com/) dev board. The board does have a built-in RGB LED, however RAM is at a premium on this device and I wasn't able to get it working correctly with the fastled actuator, so I've left that out of the config for now.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
