### PR TITLE
Update ZgatewayRF2.ino

### DIFF
--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -81,7 +81,7 @@ void RF2toMQTTdiscovery(JsonObject& data) {
   data["switchType"] = 1; // switchtype = 1 turns switch on.
   serializeJson(data, payloadonstr);
   data["switchType"] = 0; // switchtype = 0 turns switch off.
-  serializeJson(data, payloadonstr);
+  serializeJson(data, payloadoffstr);
   data["switchType"] = org_switchtype; // Restore original switchvalue
 
   String switchname;


### PR DESCRIPTION
kaku devices don't have an OFF  payload

## Description:


## Checklist:
  - [y ] The pull request is done against the latest development branch
  - y[ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [y ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
