### PR TITLE
Add ability to specify pulse length in ZactuatorONOFF

### DIFF
--- a/docs/use/actuators.md
+++ b/docs/use/actuators.md
@@ -31,6 +31,14 @@ Goes ON for half a second, then back to OFF:
 Goes OFF for half a second, then back to ON:
 `mosquitto_pub -t home/OpenMQTTGateway_MEGA/commands/MQTTtoONOFF -m '{"gpio":15,"cmd":"low_pulse}"'`
 
+To specify activations other than half a second, include pulse_length and the time in ms.
+
+Goes ON for 25 ms, then back to OFF:
+`mosquitto_pub -t home/OpenMQTTGateway_MEGA/commands/MQTTtoONOFF -m '{"gpio":15,"cmd":"high_pulse","pulse_length":25}'`
+
+Goes OFF for 25 ms, then back to ON:
+`mosquitto_pub -t home/OpenMQTTGateway_MEGA/commands/MQTTtoONOFF -m '{"gpio":15,"cmd":"low_pulse","pulse_length":25}'`
+
 Be aware that outputs are OFF by default when the board first start.
 
 ## FASTLED

--- a/main/ZactuatorONOFF.ino
+++ b/main/ZactuatorONOFF.ino
@@ -47,16 +47,24 @@ void MQTTtoONOFF(char* topicOri, JsonObject& ONOFFdata) {
       if (ONOFFdata["cmd"] == "high_pulse") {
         Log.notice(F("MQTTtoONOFF high_pulse ok" CR));
         Log.notice(F("GPIO number: %d" CR), gpio);
+        int pulselength = ONOFFdata["pulse_length"];
+        if (!pulselength)
+          pulselength = 500;
+        Log.notice(F("Pulse length: %d ms" CR), pulselength);
         pinMode(gpio, OUTPUT);
         digitalWrite(gpio, HIGH);
-        delay(500);
+        delay(pulselength);
         digitalWrite(gpio, LOW);
       } else if (ONOFFdata["cmd"] == "low_pulse") {
         Log.notice(F("MQTTtoONOFF low_pulse ok" CR));
         Log.notice(F("GPIO number: %d" CR), gpio);
+        int pulselength = ONOFFdata["pulse_length"];
+        if (!pulselength)
+          pulselength = 500;
+        Log.notice(F("Pulse length: %d ms" CR), pulselength);
         pinMode(gpio, OUTPUT);
         digitalWrite(gpio, LOW);
-        delay(500);
+        delay(pulselength);
         digitalWrite(gpio, HIGH);
       } else {
         Log.error(F("MQTTtoONOFF failed json read" CR));

--- a/main/ZactuatorONOFF.ino
+++ b/main/ZactuatorONOFF.ino
@@ -47,9 +47,7 @@ void MQTTtoONOFF(char* topicOri, JsonObject& ONOFFdata) {
       if (ONOFFdata["cmd"] == "high_pulse") {
         Log.notice(F("MQTTtoONOFF high_pulse ok" CR));
         Log.notice(F("GPIO number: %d" CR), gpio);
-        int pulselength = ONOFFdata["pulse_length"];
-        if (!pulselength)
-          pulselength = 500;
+        int pulselength = ONOFFdata["pulse_length"] | 500;
         Log.notice(F("Pulse length: %d ms" CR), pulselength);
         pinMode(gpio, OUTPUT);
         digitalWrite(gpio, HIGH);
@@ -58,9 +56,7 @@ void MQTTtoONOFF(char* topicOri, JsonObject& ONOFFdata) {
       } else if (ONOFFdata["cmd"] == "low_pulse") {
         Log.notice(F("MQTTtoONOFF low_pulse ok" CR));
         Log.notice(F("GPIO number: %d" CR), gpio);
-        int pulselength = ONOFFdata["pulse_length"];
-        if (!pulselength)
-          pulselength = 500;
+        int pulselength = ONOFFdata["pulse_length"] | 500;
         Log.notice(F("Pulse length: %d ms" CR), pulselength);
         pinMode(gpio, OUTPUT);
         digitalWrite(gpio, LOW);


### PR DESCRIPTION
Add an additional parameter to the MQTT message to control the actuatorONOFF pulse length e.g. `mosquitto_pub -t home/OpenMQTTGateway_MEGA/commands/MQTTtoONOFF -m '{"gpio":15,"cmd":"high_pulse","pulse_length":25}'`

## Description:
Currently the actuatorONOFF pulse length is restricted to 500 ms. I'd like to be able to control the pulse length down to 10's of ms. I have a buzzer connected to a ESP32 port and would like to have a very short duration pulse so the buzzer produces only a short click sound. Sending a MQTT command to turn the port ON, delaying a short time, then sending a MQTT command to turn the port OFF doesn't work consistently for very short delays.

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
