### PR TITLE
Update ZgatewayPilight.ino - Fix for #1197 - PiLight Receive not working after PiLight transmit

### DIFF
--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -226,5 +226,6 @@ extern void enablePilightReceive() {
   rf.setCallback(pilightCallback);
   rf.initReceiver(RF_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
+  rf.enableReceiver();
 };
 #endif


### PR DESCRIPTION
## Description:

Issue was identified with PiLight module, and PiLight receiver going deaf after transmitting a PiLight signal.  This resolves #1197 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
