### PR TITLE
Rf simple filter

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -160,7 +160,7 @@ void RFtoMQTT() {
 // RF simple filter to restrict reporting of RFdata if RFReceiveProtocol1, 
 // RFReceiveBitLength1, RFReceiveProtocol2, RFReceiveBitlength2, RFReceiveProtocol3,
 // RFReceiveBitlength3, RFReceiveProtocol4 and/or RFReceiveProtocol4 are defined
-// This filters by one or more RF Protocols and/or RF BitLengths not by RF values
+// This filters by one or more RF Protocols and/or RF Bitlengths not by RF values
 //
 #  if defined RFReceiveProtocol1 || defined RFReceiveBitlength1 || defined RFReceiveProtocol2 || defined RFReceiveBitlength2 || defined RFReceiveProtocol3 || defined RFReceiveBitlength3 || defined RFReceiveProtocol4 || defined RFReceiveBitlength4
     while (true) {

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -157,59 +157,59 @@ void RFtoMQTT() {
     mySwitch.resetAvailable();
 
 //
-// RF simple filter to restrict reporting of RFdata if RFReceiveProtocol1, 
+// RF simple filter to restrict reporting of RFdata if RFReceiveProtocol1,
 // RFReceiveBitLength1, RFReceiveProtocol2, RFReceiveBitlength2, RFReceiveProtocol3,
 // RFReceiveBitlength3, RFReceiveProtocol4 and/or RFReceiveProtocol4 are defined
 // This filters by one or more RF Protocols and/or RF Bitlengths not by RF values
 //
 #  if defined RFReceiveProtocol1 || defined RFReceiveBitlength1 || defined RFReceiveProtocol2 || defined RFReceiveBitlength2 || defined RFReceiveProtocol3 || defined RFReceiveBitlength3 || defined RFReceiveProtocol4 || defined RFReceiveBitlength4
     while (true) {
-#  if defined RFReceiveProtocol1 && defined RFReceiveBitlength1
+#    if defined RFReceiveProtocol1 && defined RFReceiveBitlength1
       // RFReceiveProtocol1 and RFReceiveBitlength1 must both match if both are defined
       if (mySwitch.getReceivedProtocol() == RFReceiveProtocol1 && mySwitch.getReceivedBitlength() == RFReceiveBitlength1)
         break;
-#  elif defined RFReceiveProtocol1 // RFReceiveProtocol1 is defined without RFReceiveBitlength1
+#    elif defined RFReceiveProtocol1 // RFReceiveProtocol1 is defined without RFReceiveBitlength1
       if (mySwitch.getReceivedProtocol() == RFReceiveProtocol1)
         break;
-#  elif defined RFReceiveBitlength1 // RFReceiveBitlength1 is defined without RFReceiveProtocol1
+#    elif defined RFReceiveBitlength1 // RFReceiveBitlength1 is defined without RFReceiveProtocol1
       if (mySwitch.getReceivedBitlength() == RFReceiveBitlength1)
         break;
-#  endif
-#  if defined RFReceiveProtocol2 && defined RFReceiveBitlength2
+#    endif
+#    if defined RFReceiveProtocol2 && defined RFReceiveBitlength2
       if (mySwitch.getReceivedProtocol() == RFReceiveProtocol2 && mySwitch.getReceivedBitlength() == RFReceiveBitlength2)
         break;
-#  elif defined RFReceiveProtocol2
+#    elif defined RFReceiveProtocol2
       if (mySwitch.getReceivedProtocol() == RFReceiveProtocol2)
         break;
-#  elif defined RFReceiveBitlength2
+#    elif defined RFReceiveBitlength2
       if (mySwitch.getReceivedBitlength() == RFReceiveBitlength2)
         break;
-#  endif
-#  if defined RFReceiveProtocol3 && defined RFReceiveBitlength3
+#    endif
+#    if defined RFReceiveProtocol3 && defined RFReceiveBitlength3
       if (mySwitch.getReceivedProtocol() == RFReceiveProtocol3 && mySwitch.getReceivedBitlength() == RFReceiveBitlength3)
         break;
-#  elif defined RFReceiveProtocol3
-     if (mySwitch.getReceivedProtocol() == RFReceiveProtocol3)
+#    elif defined RFReceiveProtocol3
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol3)
         break;
-#  elif defined RFReceiveBitlength3
+#    elif defined RFReceiveBitlength3
       if (mySwitch.getReceivedBitlength() == RFReceiveBitlength3)
         break;
-#  endif
-#  if defined RFReceiveProtocol4 && defined RFReceiveBitlength4
+#    endif
+#    if defined RFReceiveProtocol4 && defined RFReceiveBitlength4
       if (mySwitch.getReceivedProtocol() == RFReceiveProtocol4 && mySwitch.getReceivedBitlength() == ZRFReceiveBitlength4)
         break;
-#  elif defined RFReceiveProtocol4
+#    elif defined RFReceiveProtocol4
       if (mySwitch.getReceivedProtocol() == RFReceiveProtocol4)
         break;
-#  elif defined RFReceiveBitlength4
+#    elif defined RFReceiveBitlength4
       if (mySwitch.getReceivedBitlength() == RFReceiveBitlength4)
         break;
-#  endif
-      // if reach here, no matches were found, so don't report as a RF switch
-      Log.trace(F("ZgatewayRF ignoring RFdata, didn't pass the RF simple filters" CR));
+#    endif
+      // If reach here, nothing matched, don't report as a RF switch, just return
+      Log.notice(F("ZgatewayRF ignoring RF Value %u, RF Protocol %u, RF Bitlength %u" CR), (unsigned long)MQTTvalue, (int)mySwitch.getReceivedProtocol(), (int)mySwitch.getReceivedBitlength());
       return;
     }
-#   endif
+#  endif
 
     if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of RF -->MQTT
 #  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT) && defined(RFmqttDiscovery) //component creation for HA

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -156,6 +156,61 @@ void RFtoMQTT() {
 #  endif
     mySwitch.resetAvailable();
 
+//
+// RF simple filter to restrict reporting of RFdata if RFReceiveProtocol1, 
+// RFReceiveBitLength1, RFReceiveProtocol2, RFReceiveBitlength2, RFReceiveProtocol3,
+// RFReceiveBitlength3, RFReceiveProtocol4 and/or RFReceiveProtocol4 are defined
+// This filters by one or more RF Protocols and/or RF BitLengths not by RF values
+//
+#  if defined RFReceiveProtocol1 || defined RFReceiveBitlength1 || defined RFReceiveProtocol2 || defined RFReceiveBitlength2 || defined RFReceiveProtocol3 || defined RFReceiveBitlength3 || defined RFReceiveProtocol4 || defined RFReceiveBitlength4
+    while (true) {
+#  if defined RFReceiveProtocol1 && defined RFReceiveBitlength1
+      // RFReceiveProtocol1 and RFReceiveBitlength1 must both match if both are defined
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol1 && mySwitch.getReceivedBitlength() == RFReceiveBitlength1)
+        break;
+#  elif defined RFReceiveProtocol1 // RFReceiveProtocol1 is defined without RFReceiveBitlength1
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol1)
+        break;
+#  elif defined RFReceiveBitlength1 // RFReceiveBitlength1 is defined without RFReceiveProtocol1
+      if (mySwitch.getReceivedBitlength() == RFReceiveBitlength1)
+        break;
+#  endif
+#  if defined RFReceiveProtocol2 && defined RFReceiveBitlength2
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol2 && mySwitch.getReceivedBitlength() == RFReceiveBitlength2)
+        break;
+#  elif defined RFReceiveProtocol2
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol2)
+        break;
+#  elif defined RFReceiveBitlength2
+      if (mySwitch.getReceivedBitlength() == RFReceiveBitlength2)
+        break;
+#  endif
+#  if defined RFReceiveProtocol3 && defined RFReceiveBitlength3
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol3 && mySwitch.getReceivedBitlength() == RFReceiveBitlength3)
+        break;
+#  elif defined RFReceiveProtocol3
+     if (mySwitch.getReceivedProtocol() == RFReceiveProtocol3)
+        break;
+#  elif defined RFReceiveBitlength3
+      if (mySwitch.getReceivedBitlength() == RFReceiveBitlength3)
+        break;
+#  endif
+#  if defined RFReceiveProtocol4 && defined RFReceiveBitlength4
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol4 && mySwitch.getReceivedBitlength() == ZRFReceiveBitlength4)
+        break;
+#  elif defined RFReceiveProtocol4
+      if (mySwitch.getReceivedProtocol() == RFReceiveProtocol4)
+        break;
+#  elif defined RFReceiveBitlength4
+      if (mySwitch.getReceivedBitlength() == RFReceiveBitlength4)
+        break;
+#  endif
+      // if reach here, no matches were found, so don't report as a RF switch
+      Log.trace(F("ZgatewayRF ignoring RFdata, didn't pass the RF simple filters" CR));
+      return;
+    }
+#   endif
+
     if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of RF -->MQTT
 #  if defined(ZmqttDiscovery) && !defined(RF_DISABLE_TRANSMIT) && defined(RFmqttDiscovery) //component creation for HA
       if (disc)

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,6 +33,7 @@ extra_configs =
 ;default_envs = rfbridge
 ;default_envs = esp32dev-all-test
 ;default_envs = esp32dev-rf
+;default-envs = esp32dev-rf-simple-filter
 ;default_envs = esp32dev-pilight
 ;default_envs = esp32dev-pilight-cc1101
 ;default_envs = esp32dev-somfy-cc1101
@@ -298,6 +299,22 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
   '-DGateway_Name="OpenMQTTGateway_ESP32_RF"'
+
+[env:esp32dev-rf-simple-filter]
+platform = ${com.esp32_platform}
+board = esp32dev
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.rc-switch}
+build_flags = 
+  ${com-esp.build_flags}
+  '-DZgatewayRF="RF"'
+  '-DRFReceiveProtocol1=1'
+  '-DRFReceiveBitlength1=24' ; accept RF data with RF Protocol=1 AND RF Bitlength=24
+  '-DRFReceiveProtocol2=3'   ; also accept all RF data with RF Protocol=3 without regard to RF Bitlength
+  '-DRFReceiveBitlength3=48' ; also accept all RF data with Bitlength=48 without regard to RF Protocol
+  '-DGateway_Name="OpenMQTTGateway_ESP32_RFSimpleFilter"'
 
 [env:esp32dev-pilight]
 platform = ${com.esp32_platform}

--- a/prod_env.ini.example
+++ b/prod_env.ini.example
@@ -57,9 +57,9 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
   '-DRFReceiveProtocol1=1'
-  '-DRFReceiveBitlength1=24' ; accept RF data with RF Protocol=1 AND RF BitLength=24
-  '-DRFReceiveProtocol2=3'   ; also accept all RF data with RF Protocol=3 without regard to RF BitLength
-  '-DRFReceiveBitlength3=48' ; also accept all RF data with BitLength=48 without regard to RF Protocol
+  '-DRFReceiveBitlength1=24' ; accept RF data with RF Protocol=1 AND RF Bitlength=24
+  '-DRFReceiveProtocol2=3'   ; also accept all RF data with RF Protocol=3 without regard to RF Bitlength
+  '-DRFReceiveBitlength3=48' ; also accept all RF data with Bitlength=48 without regard to RF Protocol
   '-DGateway_Name="OpenMQTTGateway_ESP32_RFSimpleFilter"'
 upload_protocol = espota
 upload_port = 192.168.1.144

--- a/prod_env.ini.example
+++ b/prod_env.ini.example
@@ -51,8 +51,8 @@ board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp.lib_deps}
-  ${libraries.rc-switch}
   ${libraries.wifimanager32}
+  ${libraries.rc-switch}
 build_flags = 
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'

--- a/prod_env.ini.example
+++ b/prod_env.ini.example
@@ -2,6 +2,7 @@
 default_envs = 
   esp32dev-ble-1
   esp32dev-ble-2
+  esp32dev-rf-simple-filter
   env:nodemcuv2-ONOFFPILIGHT
 
 ;esp32 1
@@ -38,6 +39,30 @@ build_flags =
   ;-DCORE_DEBUG_LEVEL=4
 upload_protocol = espota
 upload_port = 192.168.1.111
+upload_flags =
+  --auth=OTAPASSWORD
+upload_speed = 512000
+monitor_speed = 115200
+
+;esp32 3
+[env:esp32dev-rf-simple-filter]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.rc-switch}
+  ${libraries.wifimanager32}
+build_flags = 
+  ${com-esp.build_flags}
+  '-DZgatewayRF="RF"'
+  '-DRFReceiveProtocol1=1'
+  '-DRFReceiveBitlength1=24' ; accept RF data with RF Protocol=1 AND RF BitLength=24
+  '-DRFReceiveProtocol2=3'   ; also accept all RF data with RF Protocol=3 without regard to RF BitLength
+  '-DRFReceiveBitlength3=48' ; also accept all RF data with BitLength=48 without regard to RF Protocol
+  '-DGateway_Name="OpenMQTTGateway_ESP32_RFSimpleFilter"'
+upload_protocol = espota
+upload_port = 192.168.1.144
 upload_flags =
   --auth=OTAPASSWORD
 upload_speed = 512000


### PR DESCRIPTION
## Description:
Implement a RF Simple Filter

Restrict reporting of RF data by RF Protocol and/or RF Bitlength.  This is an attempt to prevent RF noise from creating so many false RF switches.  This does not filter by RF value.

For example when LOG_LEVEL=LOG_LEVEL_NOTICE then the filtered out RF data is reported as:
N: ZgatewayRF ignoring RF Value 131071, RF Protocol 29, RF Bitlength 16
N: ZgatewayRF ignoring RF Value 3894, RF Protocol 10, RF Bitlength 13
N: ZgatewayRF ignoring RF Value 1, RF Protocol 26, RF Bitlength 12
N: ZgatewayRF ignoring RF Value 6381, RF Protocol 26, RF Bitlength 13


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
