### PR TITLE
Add option to offload decoding to an external gateway over MQTT.

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -1,17 +1,17 @@
-/*  
-  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+/*
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation
 
-   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
    Send and receiving command by MQTT
- 
+
   This program enables to:
  - receive MQTT data from a topic and send signals corresponding to the received MQTT data
  - publish MQTT data to a different topic related to received signals
-  
+
     Copyright: (c)Florian ROBERT
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -41,11 +41,11 @@
  * - mqtt_pass
  * - mqtt_server
  * - mqtt_port
- * 
+ *
  * To completely disable WifiManager, define ESPWifiManualSetup.
  * If you do so, please don't forget to set these variables before compiling
- * 
- * Otherwise you can provide these credentials on the web interface after connecting 
+ *
+ * Otherwise you can provide these credentials on the web interface after connecting
  * to the access point with your password (SSID: WifiManager_ssid, password: WifiManager_password)
  */
 /*-------------DEFINE GATEWAY NAME BELOW IT CAN ALSO BE DEFINED IN platformio.ini----------------*/
@@ -172,6 +172,10 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #endif
 
 #if defined(ESP8266) || defined(ESP32)
+// Uncomment to use a device running TheengsGateway to decode BLE data. (https://github.com/theengs/gateway)
+// Set the topic to the subscribe topic configured in the TheengGateway
+// #define MQTTDecodeTopic "MQTTDecode"
+
 // The root ca certificate used for validating the MQTT broker
 // The certificate must be in PEM ascii format
 const char* certificate PROGMEM = R"EOF("

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -52,7 +52,10 @@ bool bleConnect = AttemptBLECOnnect;
 /*----------------------BT topics & parameters-------------------------*/
 #define subjectBTtoMQTT    "/BTtoMQTT"
 #define subjectMQTTtoBTset "/commands/MQTTtoBT/config"
-#define MinimumRSSI        -100 //default minimum rssi value, all the devices below -90 will not be reported
+// Uncomment to send undecoded device data to another gateway device for decoding
+// #define MQTTDecodeTopic    "BTtoMQTT/undecoded"
+
+#define MinimumRSSI -100 //default minimum rssi value, all the devices below -90 will not be reported
 
 #ifndef Scan_duration
 #  define Scan_duration 10000 //define the time for a scan

--- a/platformio.ini
+++ b/platformio.ini
@@ -408,6 +408,23 @@ build_flags =
   '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 
+[env:esp32dev-ble-mqtt-decode]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ble}
+  ${libraries.decoder}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayBT="BT"'
+  '-DLED_SEND_RECEIVE=2'
+  '-DLED_SEND_RECEIVE_ON=0'
+  '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
+  '-DMQTTDecodeTopic="MQTTDecode"'
+
 [env:esp32dev-ble-aws]
 platform = ${com.esp32_platform}
 board = esp32dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -423,7 +423,7 @@ build_flags =
   '-DLED_SEND_RECEIVE=2'
   '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
-  '-DMQTTDecodeTopic="MQTTDecode"'
+  '-DMQTTDecodeTopic="BTtoMQTT/undecoded"'
 
 [env:esp32dev-ble-aws]
 platform = ${com.esp32_platform}


### PR DESCRIPTION
## Description:
This adds an option to offload the decoding of BLE data to a TheengsGateway device. This uses the functionality provided by https://github.com/theengs/gateway/pull/25.

To test:
- Make sure you have set a subscribe topic in the TheengsGateway config and that you're using the code from the PR above.
- Flash your esp with this PR and set the build flag '-DMQTTDecodeTopic="YOUR_TOPIC"' in your PIO environment.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
