### PR TITLE
Bump theengs decoder to v0.4.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -134,7 +134,7 @@ somfy_remote=Somfy_Remote_Lib@0.3.0
 rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.0.4
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.3.0
+decoder = https://github.com/theengs/decoder.git#v0.4.0
 
 [env]
 framework = arduino


### PR DESCRIPTION
## Description:

- IBT2X(S) fix by @DigiH in https://github.com/theengs/decoder/pull/110
- Fix units for TPMS and JQJCY01YM by @emericg in https://github.com/theengs/decoder/pull/111
- Docs Links Fixes by @DigiH in https://github.com/theengs/decoder/pull/112
- Cleanup by @DigiH in https://github.com/theengs/decoder/pull/114
- Fix false positive device detection / enhance testing. by @h2zero in https://github.com/theengs/decoder/pull/115
- LYWSDCGQ-battery&Temp_only by @DigiH in https://github.com/theengs/decoder/pull/116
- Add CGDK2 cases starting by 0810 by @1technophile in https://github.com/theengs/decoder/pull/117
- Consistent quotes by @DigiH in https://github.com/theengs/decoder/pull/118
- Bit condition & Initial SwitchBot Meter by @DigiH in https://github.com/theengs/decoder/pull/119

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
