### PR TITLE
iBeacon: Flag to use UUID in topic or presence

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -94,7 +94,7 @@ int minRssi = abs(MinimumRSSI); //minimum rssi value
 void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();
-    topic.replace(":", "");
+    topic.replace(":", "");
 #  ifdef useBeaconUuidForTopic
     if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
       topic = data["uuid"].as<const char*>();

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -95,20 +95,20 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();
     topic.replace(":", "");
-#  if useBeaconUuidForTopic
-    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
-      topic = data["uuid"].as<const char*>();
+#  ifdef useBeaconUuidForTopic
+    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
+      topic = data["uuid"].as<const char*>();
     }
-#  endif
-    topic = subjectBTtoMQTT + String("/") + topic;
-    pub((char*)topic.c_str(), data);
-  }
+#  endif
+    topic = subjectBTtoMQTT + String("/") + topic;
+    pub((char*)topic.c_str(), data);
+  }
   if (haPresenceEnabled && data.containsKey("distance")) {
     if (data.containsKey("servicedatauuid"))
       data.remove("servicedatauuid");
     if (data.containsKey("servicedata"))
       data.remove("servicedata");
-#  if useBeaconUuidForPresence
+#  ifdef useBeaconUuidForPresence
     if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
       data["mac"] = data["id"];
       data["id"] = data["uuid"];

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -95,7 +95,7 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();
     topic.replace(":", "");
-#  ifdef useBeaconUuidForTopic
+#  if useBeaconUuidForTopic
     if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
       topic = data["uuid"].as<const char*>();
     }
@@ -108,7 +108,7 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
       data.remove("servicedatauuid");
     if (data.containsKey("servicedata"))
       data.remove("servicedata");
-#  ifdef useBeaconUuidForPresence
+#  if useBeaconUuidForPresence
     if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
       data["mac"] = data["id"];
       data["id"] = data["uuid"];

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -93,16 +93,27 @@ int minRssi = abs(MinimumRSSI); //minimum rssi value
 
 void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
-    String mac_address = data["id"].as<const char*>();
-    mac_address.replace(":", "");
-    String mactopic = subjectBTtoMQTT + String("/") + mac_address;
-    pub((char*)mactopic.c_str(), data);
-  }
+    String topic = data["id"].as<const char*>();
+    topic.replace(":", "");
+#  ifdef useBeaconUuidForTopic
+    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
+      topic = data["uuid"].as<const char*>();
+    }
+#  endif
+    topic = subjectBTtoMQTT + String("/") + topic;
+    pub((char*)topic.c_str(), data);
+  }
   if (haPresenceEnabled && data.containsKey("distance")) {
     if (data.containsKey("servicedatauuid"))
       data.remove("servicedatauuid");
     if (data.containsKey("servicedata"))
       data.remove("servicedata");
+#  ifdef useBeaconUuidForPresence
+    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
+      data["mac"] = data["id"];
+      data["id"] = data["uuid"];
+    }
+#  endif
     String topic = String(Base_Topic) + "home_presence/" + String(gateway_name);
     Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
     pub_custom_topic((char*)topic.c_str(), data, false);

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -124,8 +124,12 @@ bool hassPresence = HassPresence;
 #  define pubBLEServiceUUID false // define true if you want to publish the service UUID data
 #endif
 
+//#define useBeaconUuidForTopic //define this flag to use iBeacon UUID as topic, instead of sender (random) mac address
+
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/
 #define subjectHomePresence "home_presence/" // will send Home Assistant room presence message to this topic (first part is same for all rooms, second is room name)
+
+//#define useBeaconUuidForPresence //define this flag to use iBeacon UUID as for presence, instead of sender mac (random) address
 
 /*-------------------PIN DEFINITIONS----------------------*/
 #if !defined(BT_RX) || !defined(BT_TX)


### PR DESCRIPTION
## Description:
Inspired by issue https://github.com/1technophile/OpenMQTTGateway/issues/1139

Add compilation flags to use UUID in topic, instead of sender (random) mac address:
FLAG `useBeaconUuidForTopic` to use UUID in topic
FLAG `useBeaconUuidForPresence` to use UUID in presence
This features is disabled by default, usual behavior is maintained

The question of whitelisting/blacklisting by UUID for a iBeacon, as exposed in the issue, is not approached in this commit.
(WhtL/BlkL is filtered prior to `pubBTMainCore()` function, so it does not seems to be as simple as this PR)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).

Thanks, Bad