### PR TITLE
Add Pilight limitProtocols support

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -1,4 +1,5 @@
 
+
 # RF gateways  (433mhz/315mhz)
 
 ## Changing Active Receiver Modules
@@ -121,6 +122,29 @@ Subscribe to all the messages with mosquitto or open your MQTT client software:
 Generate your RF signals by pressing a remote button or other and you will see :
 
 ![](../img/OpenMQTTGateway_Pilight_Digoo-DG-R8S.png)
+
+### Limit Protocols
+It is possible to limit the protocols that Pilight will respond to, this can help reduce noise from unwanted devices and in some cases disable conflicting protocols.
+
+#### Available protocols
+To list the available protocols on the Serial - 
+
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols" -m '{"available":true}'`
+#### Limit protocols
+To limit the protocols, send a JSON array of protocols as below - 
+
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols -m '{"limit": ["array", "of", "protocols"]}'`
+
+eg: `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols" -m '{"limit":["tfa", "ev1527"}'`
+
+#### Reset protocols
+To reset and listen to all protocols -
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols -m '{"reset": true}`'
+
+#### Enabled protocols
+To list the enabled protocols on the Serial - 
+
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols" -m '{"enabled":true}'`
 
 ### Send data by MQTT to transmit a RF signal
 

--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -1,5 +1,4 @@
 
-
 # RF gateways  (433mhz/315mhz)
 
 ## Changing Active Receiver Modules

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -150,11 +150,11 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       success = true;
     }
     if (Pilightdata.containsKey("enabled")) {
-      Log.trace(F("PiLight protocols enabled: %s" CR),  rf.enabledProtocols().c_str());
+      Log.notice(F("PiLight protocols enabled: %s" CR),  rf.enabledProtocols().c_str());
       success = true;
     }
     if (Pilightdata.containsKey("available")) {
-      Log.trace(F("PiLight protocols available: %s" CR),  rf.availableProtocols().c_str());
+      Log.notice(F("PiLight protocols available: %s" CR),  rf.availableProtocols().c_str());
       success = true;
     }
 

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -109,25 +109,25 @@ void savePilightConfig() {
 }
 
 void loadPilightConfig() {
-    Log.trace(F("reading Pilight config file" CR));
-    File configFile = SPIFFS.open("/pilight.json", "r");
-    if (configFile) {
-      Log.trace(F("opened Pilight config file" CR));
-      DynamicJsonDocument json(configFile.size() * 4);
-      auto error = deserializeJson(json, configFile);
-      if (error) {
-        Log.error(F("deserialize config failed: %s, buffer capacity: %u" CR), error.c_str(), json.capacity());
-      }
-      serializeJson(json, Serial);
-      if (!json.isNull()) {
-        String rflimit;
-        serializeJson(json, rflimit);
-        rf.limitProtocols(rflimit);
-      } else {
-        Log.warning(F("failed to load json config" CR));
-      }
-      configFile.close();
+  Log.trace(F("reading Pilight config file" CR));
+  File configFile = SPIFFS.open("/pilight.json", "r");
+  if (configFile) {
+    Log.trace(F("opened Pilight config file" CR));
+    DynamicJsonDocument json(configFile.size() * 4);
+    auto error = deserializeJson(json, configFile);
+    if (error) {
+      Log.error(F("deserialize config failed: %s, buffer capacity: %u" CR), error.c_str(), json.capacity());
     }
+    serializeJson(json, Serial);
+    if (!json.isNull()) {
+      String rflimit;
+      serializeJson(json, rflimit);
+      rf.limitProtocols(rflimit);
+    } else {
+      Log.warning(F("failed to load json config" CR));
+    }
+    configFile.close();
+  }
 }
 
 void PilighttoMQTT() {
@@ -150,11 +150,11 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       success = true;
     }
     if (Pilightdata.containsKey("enabled")) {
-      Log.notice(F("PiLight protocols enabled: %s" CR),  rf.enabledProtocols().c_str());
+      Log.notice(F("PiLight protocols enabled: %s" CR), rf.enabledProtocols().c_str());
       success = true;
     }
     if (Pilightdata.containsKey("available")) {
-      Log.notice(F("PiLight protocols available: %s" CR),  rf.availableProtocols().c_str());
+      Log.notice(F("PiLight protocols available: %s" CR), rf.availableProtocols().c_str());
       success = true;
     }
 

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -101,10 +101,11 @@ int minimumRssi = 0;
 
 /*-------------------ESPPiLight topics & parameters----------------------*/
 //433Mhz Pilight MQTT Subjects and keys
-#define subjectMQTTtoPilight    "/commands/MQTTtoPilight"
-#define subjectPilighttoMQTT    "/PilighttoMQTT"
-#define subjectGTWPilighttoMQTT "/PilighttoMQTT"
-#define repeatPilightwMQTT      false // do we repeat a received signal by using mqtt with Pilight gateway
+#define subjectMQTTtoPilight         "/commands/MQTTtoPilight"
+#define subjectMQTTtoPilightProtocol "/commands/MQTTtoPilight/protocols"
+#define subjectPilighttoMQTT         "/PilighttoMQTT"
+#define subjectGTWPilighttoMQTT      "/PilighttoMQTT"
+#define repeatPilightwMQTT           false // do we repeat a received signal by using mqtt with Pilight gateway
 
 /*-------------------RTL_433 topics & parameters----------------------*/
 //433Mhz RTL_433 MQTT Subjects and keys


### PR DESCRIPTION
## Description:
Add ability to limit protocols used with Pilight - this helps receive some messages.

To list available protocols to Serial (MQTT packets are too short to list all protocols)

`/commands/MQTTtoPilight/protocols {"available": true}`

To list enabled protocols to Serial - 

`/commands/MQTTtoPilight/protocols {"enabled": true}`

To limit protocols:

`/commands/MQTTtoPilight/protocols {"limit": ["array", "of", "protocols"]}`

eg: ` -t "home/OpenMQTTGateway_ESP32_Pilight/commands/MQTTtoPilight/protocols" -m '{"limit":["tfa", "ev1527"}'`

To reset and listen to all protocols again:

`/commands/MQTTtoPilight/protocols {"reset": true}`

When a MQTT limit request is served, SPIFFS is used to save the protocols - this allows us to save between reboots. The list of enabled protocols could be longer than the allowed MQTT packet length. The file /pilight.json is used to store the enabled protocols. This file is also loaded any time enablePilightReceive is called.

Seems to relate to 

https://github.com/1technophile/OpenMQTTGateway/issues/802 and https://github.com/1technophile/OpenMQTTGateway/issues/573

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
