### PR TITLE
iBeacon: Flag to use UUID in topic or presence (and fixes)

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -95,20 +95,14 @@ int minRssi = abs(MinimumRSSI); //minimum rssi value
 
 void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
-    String mac_address = data["id"].as<const char*>();
-    mac_address.replace(":", "");
-    String mactopic;
+    String topic = data["id"].as<const char*>();
+    topic.replace(":", ""); // Initially publish topic ends with mac address
 #  ifdef MQTTDecodeTopic
-    if (data.containsKey("model")) {
-      mactopic = mac_address;
-    } else {
-      mactopic = MQTTDecodeTopic;
-    }
-#  else
-    mactopic = mac_address;
+    if (!data.containsKey("model"))
+      topic = MQTTDecodeTopic; // If MQTTDecodeTopic and no model, topic is changed
 #  endif
-    mactopic = subjectBTtoMQTT + String("/") + mactopic;
-    pub((char*)mactopic.c_str(), data);
+    topic = subjectBTtoMQTT + String("/") + topic;
+    pub((char*)topic.c_str(), data);
   }
   if (haPresenceEnabled && data.containsKey("distance")) {
     if (data.containsKey("servicedatauuid"))

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -97,9 +97,13 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();
     topic.replace(":", ""); // Initially publish topic ends with mac address
+#  if useBeaconUuidForTopic
+    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON")
+      topic = data["uuid"].as<const char*>(); // If model_id is IBEACON, use uuid as topic
+#  endif
 #  ifdef MQTTDecodeTopic
     if (!data.containsKey("model"))
-      topic = MQTTDecodeTopic; // If MQTTDecodeTopic and no model, topic is changed
+      topic = MQTTDecodeTopic; // If external decoder, topic is MQTTDecodeTopic
 #  endif
     topic = subjectBTtoMQTT + String("/") + topic;
     pub((char*)topic.c_str(), data);

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -114,6 +114,12 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
       data.remove("servicedatauuid");
     if (data.containsKey("servicedata"))
       data.remove("servicedata");
+#  if useBeaconUuidForPresence
+    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
+      data["mac"] = data["id"];
+      data["id"] = data["uuid"];
+    }
+#  endif
     String topic = String(Base_Topic) + "home_presence/" + String(gateway_name);
     Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
     pub_custom_topic((char*)topic.c_str(), data, false);

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -97,16 +97,17 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
     String mac_address = data["id"].as<const char*>();
     mac_address.replace(":", "");
-#  ifdef MQTTDecodeTopic
     String mactopic;
+#  ifdef MQTTDecodeTopic
     if (data.containsKey("model")) {
-      mactopic = subjectBTtoMQTT + String("/") + mac_address;
+      mactopic = mac_address;
     } else {
-      mactopic = String("/") + MQTTDecodeTopic;
+      mactopic = MQTTDecodeTopic;
     }
 #  else
-    String mactopic = subjectBTtoMQTT + String("/") + mac_address;
+    mactopic = mac_address;
 #  endif
+    mactopic = subjectBTtoMQTT + String("/") + mactopic;
     pub((char*)mactopic.c_str(), data);
   }
   if (haPresenceEnabled && data.containsKey("distance")) {

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -53,7 +53,7 @@ bool bleConnect = AttemptBLECOnnect;
 #define subjectBTtoMQTT    "/BTtoMQTT"
 #define subjectMQTTtoBTset "/commands/MQTTtoBT/config"
 // Uncomment to send undecoded device data to another gateway device for decoding
-// #define MQTTDecodeTopic    "BTtoMQTT/undecoded"
+// #define MQTTDecodeTopic    "undecoded"
 
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -90 will not be reported
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -127,6 +127,10 @@ bool hassPresence = HassPresence;
 #  define pubBLEServiceUUID false // define true if you want to publish the service UUID data
 #endif
 
+#ifndef useBeaconUuidForTopic
+#  define useBeaconUuidForTopic false // define true to use iBeacon UUID as topic, instead of sender (random) mac address
+#endif
+
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/
 #define subjectHomePresence "home_presence/" // will send Home Assistant room presence message to this topic (first part is same for all rooms, second is room name)
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -130,6 +130,10 @@ bool hassPresence = HassPresence;
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/
 #define subjectHomePresence "home_presence/" // will send Home Assistant room presence message to this topic (first part is same for all rooms, second is room name)
 
+#ifndef useBeaconUuidForPresence
+#  define useBeaconUuidForPresence false // //define true to use iBeacon UUID as for presence, instead of sender mac (random) address
+#endif
+
 /*-------------------PIN DEFINITIONS----------------------*/
 #if !defined(BT_RX) || !defined(BT_TX)
 #  ifdef ESP8266

--- a/main/main.ino
+++ b/main/main.ino
@@ -328,7 +328,7 @@ void pub(const char* topicori, JsonObject& data) {
 #  endif
 #endif
 
-#ifdef jsonPublishing
+#if jsonPublishing
   Log.trace(F("jsonPubl - ON" CR));
   pubMQTT(topic, dataAsString.c_str());
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -328,7 +328,7 @@ void pub(const char* topicori, JsonObject& data) {
 #  endif
 #endif
 
-#if jsonPublishing
+#ifdef jsonPublishing
   Log.trace(F("jsonPubl - ON" CR));
   pubMQTT(topic, dataAsString.c_str());
 #endif


### PR DESCRIPTION
## Description:
Inspired by issue https://github.com/1technophile/OpenMQTTGateway/issues/1139
Replaces PR #1220

Add compilation flags to use UUID in topic, instead of sender (random) mac address:
FLAG `useBeaconUuidForTopic` to use UUID in topic
FLAG `useBeaconUuidForPresence` to use UUID in presence
This features is disabled by default, usual behavior is maintained
_The question of whitelisting/blacklisting by UUID for a iBeacon, as exposed in the issue, is not approached in this commit.
(WhtL/BlkL is filtered prior to `pubBTMainCore()` function, so it does not seems to be as simple as this PR)_

[Change introduced regarding MQTTDecodeTopic](https://github.com/1technophile/OpenMQTTGateway/pull/1216/files#r897361158) and code refactor
Fix jsonPublishing (regarding https://github.com/1technophile/OpenMQTTGateway/issues/1141?) there is an #ifdef left [here](https://github.com/1technophile/OpenMQTTGateway/blob/e43f7b3c15c9cbb751bdd9160bdf82540341bc59/main/main.ino#L331) that should be an #if

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).

Thanks, Bad