### PR TITLE
Fix default env undecoded topic and doc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Upload OpenMQTTGateway directly from the [upload page](https://docs.openmqttgate
 
 * [List of compatible boards (Off the shelf or DIY) is available](https://compatible.openmqttgateway.com/index.php/boards/), RF Bridge, IR, BLE gateways...
 
-::: tip Running on a computer
+*Running on a computer*
 If you want to use the BLE decoding capabilities of OpenMQTTGateway with a Raspberry Pi, Windows or Unix PC you can now leverage [Theengs Gateway](https://theengs.github.io/gateway/).
-:::
 
 * [List of compatible components to build your gateway](https://compatible.openmqttgateway.com/index.php/parts/), DHT, HM10, RF, IR emitters and receivers...
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -31,7 +31,8 @@ module.exports = {
         { text: 'Community', link: 'https://community.openmqttgateway.com', target:'_self', rel:''},
         { text: 'Devices', link: 'https://compatible.openmqttgateway.com/index.php/devices', target:'_self', rel:''},
         { text: 'Boards', link: 'https://compatible.openmqttgateway.com/index.php/boards', target:'_self', rel:''},
-        { text: 'Upload', link: '/upload/web-install.html'}
+        { text: 'Upload', link: '/upload/web-install.html'},
+        { text: 'BLE2MQTT for servers', link: 'https://gateway.theengs.io/'}
       ],
       sidebar: [
         ['/','0 - What is it for 🏠'],

--- a/docs/upload/web-install.md
+++ b/docs/upload/web-install.md
@@ -26,6 +26,7 @@ The table below describes the libraries and the modules of each board configurat
 |esp32-olimex-gtw-ble-wifi|Olimex Ethernet Gateway (non POE) using wifi| BLE gateway|-|-|X|-|
 |esp32dev-ble-cont|ESP32 dev board|BLE gateway with continuous scanning, suitable in particular for door and window BLE sensors (and all the others)|-|-|X|-|
 |esp32dev-ble|ESP32 dev board|BLE gateway with one scan every 55s per default|-|-|X|-|
+|esp32dev-ble-mqtt-decode|ESP32 dev board|BLE gateway with the decoding offloaded to [Theengs Gateway](https://gateway.theengs.io/)|-|-|X|-|
 |esp32dev-gf-sun-inverter|ESP32 dev board|RS232 reading of GridFree Sun Inverter|-|-|-|-|
 |esp32dev-ir|ESP32 dev board|Infrared (Emitting and receiving) using [IRremoteESP8266](https://github.com/crankyoldgit/IRremoteESP8266)|-|X|-|-|
 |esp32dev-multi_receiver|ESP32 dev board|Multi RF library with the possibility to switch between [ESPilight](https://github.com/puuu/ESPiLight), [RTL_433_ESP](https://github.com/NorthernMan54/rtl_433_ESP), [NewRemoteSwitch](https://github.com/1technophile/NewRemoteSwitch) and [RCSwitch](https://github.com/1technophile/rc-switch), need CC1101|X|-|-|-|

--- a/platformio.ini
+++ b/platformio.ini
@@ -423,7 +423,7 @@ build_flags =
   '-DLED_SEND_RECEIVE=2'
   '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
-  '-DMQTTDecodeTopic="BTtoMQTT/undecoded"'
+  '-DMQTTDecodeTopic="undecoded"'
 
 [env:esp32dev-ble-aws]
 platform = ${com.esp32_platform}


### PR DESCRIPTION
## Description:
as BTtoMQTT is not automatically added after #1226 
+ docs changes related to theengs

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
