### PR TITLE
Lora band define

### DIFF
--- a/main/config_LORA.h
+++ b/main/config_LORA.h
@@ -36,7 +36,9 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 #define subjectGTWLORAtoMQTT "/LORAtoMQTT"
 
 //Default parameters used when the parameters are not set in the json data
-#define LORA_BAND             868E6
+#ifndef LORA_BAND
+#  define LORA_BAND 868E6
+#endif
 #define LORA_SIGNAL_BANDWIDTH 125E3
 #define LORA_TX_POWER         17
 #define LORA_SPREADING_FACTOR 7


### PR DESCRIPTION
This should fix the LORA_BAND defines working properly in the platformio.ini environments and binary builds, not being overwritten by the default define in config_LORA.h, as pointed out in the forum

https://community.openmqttgateway.com/t/heltec-wifi-lora-32-915-option-1-upload-from-the-web-gateway-appears-to-be-set-to-the-wrong-frequency/1933/5

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
