### PR TITLE
Configure LoRA gateway parameters at startup

### DIFF
--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -49,6 +49,12 @@ void setupLORA() {
   Log.notice(F("LORA_SS: %d" CR), LORA_SS);
   Log.notice(F("LORA_RST: %d" CR), LORA_RST);
   Log.notice(F("LORA_DI0: %d" CR), LORA_DI0);
+  LoRa.setTxPower(LORA_TX_POWER);
+  LoRa.setSpreadingFactor(LORA_SPREADING_FACTOR);
+  LoRa.setSignalBandwidth(LORA_SIGNAL_BANDWIDTH);
+  LoRa.setCodingRate4(LORA_CODING_RATE);
+  LoRa.setPreambleLength(LORA_PREAMBLE_LENGTH);
+  LoRa.setSyncWord(LORA_SYNC_WORD);
   Log.trace(F("ZgatewayLORA setup done" CR));
 }
 


### PR DESCRIPTION
Without this (and without sending an initial MQTT message to the gateway
to configure it) messages are not necessarily received if parameters are
different from firmware defaults.

This patch helped at least two users:
- https://community.home-assistant.io/t/awesome-lora-soil-sensor/304351/23
- https://community.home-assistant.io/t/awesome-lora-soil-sensor/304351/18

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
