### PR TITLE
Proposal for ble-datatest-environment

### DIFF
--- a/docs/upload/web-install.md
+++ b/docs/upload/web-install.md
@@ -44,6 +44,7 @@ The table below describes the libraries and the modules of each board configurat
 |ttgo-lora32-v1-868|ESP32 TTGO LORA V1|LORA communication 868Mhz using [arduino-LoRA](https://github.com/sandeepmistry/arduino-LoRa)|-|-|-|X|
 |ttgo-lora32-v1-915|ESP32 TTGO LORA V1|LORA communication 915Mhz using [arduino-LoRA](https://github.com/sandeepmistry/arduino-LoRa)|-|-|-|X|
 |ttgo-tbeam|ESP32 TTGO T BEAM|BLE gateway with battery holder|-|-|X|-|
+|esp32dev-ble-datatest|ESP32 dev board|Default BLE gateway with additional servicedata, manufacturerdata and service uuid for analysing decoding issues|-|-|X|-|
 |**ESP8266**|
 |nodemcuv2-2g|ESP8266 board|SMS gateway, need A6/A7 GSM module|-|-|-|-|
 |nodemcuv2-ble|ESP8266 board|BLE gateway, need HM10 Module|-|-|X|-|

--- a/platformio.ini
+++ b/platformio.ini
@@ -77,6 +77,7 @@ extra_configs =
 ;default_envs = nodemcuv2-all-test
 ;default_envs = uno-rf
 ;default_envs = uno-fastled
+;default_envs = esp32dev-ble-datatest
 ;default_envs = atmega-all-test
 ;default_envs = manual-wifi-test
 ;default_envs = openhab-test
@@ -1291,3 +1292,22 @@ build_flags =
   ${com-arduino-low-memory.build_flags}
   '-DGateway_Name="OMG_1_FL"'
   '-DZactuatorFASTLED="FASTLED"'
+
+[env:esp32dev-ble-datatest]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ble}
+  ${libraries.decoder}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayBT="BT"'
+  '-DLED_SEND_RECEIVE=2'
+  '-DLED_SEND_RECEIVE_ON=0'
+  '-DpubBLEManufacturerData=true'
+  '-DpubKnownBLEServiceData=true'
+  '-DpubBLEServiceUUID=true'
+  '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'


### PR DESCRIPTION
Suggestion for adding a BLE DataTest environment which includes servicedata, manufacturerdata and service uuid even if a device has been decoded.

For easy downloads and (web)installs for users when these infos might be necessary for issue investigations. 

While this would only apply for **esp32dev-ble** environment it would probably cover many BLE cases.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
