### PR TITLE
Typo in doc for ESP32 config

### DIFF
--- a/docs/use/gateway.md
+++ b/docs/use/gateway.md
@@ -73,7 +73,7 @@ If the new connection fails the gateway will fallback to the previous connection
 mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m
 '{
   "mqtt_topic": "topic/",
-  "gateway_name: "name"
+  "gateway_name": "name"
 }'
 ```
 ::: info


### PR DESCRIPTION
## Description:
Typo in doc [Change the MQTT main topic and or gateway name](https://docs.openmqttgateway.com/use/gateway.html#change-the-mqtt-broker-credentials).

Missing `"` (double quote) makes the json invalid.

By the way (just writing this here):
In v0.9.13, if `mqtt_topic` and `gateway_name` are changed at the same time, then only `gateway_name` is set, 
Resulting in base topic `<gateway_name>/`, instead of `<mqtt_topic>/<gateway_name>/`.
(Sorry I had no more time to open a second issue or PR)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).

Bad