### PR TITLE
[BREAKING] Fix presence topic

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -119,7 +119,7 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
       data["id"] = data["uuid"];
     }
 #  endif
-    String topic = String(Base_Topic) + "home_presence/" + String(gateway_name);
+    String topic = String(mqtt_topic) + subjectHomePresence + String(gateway_name);
     Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
     pub_custom_topic((char*)topic.c_str(), data, false);
   }

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -132,7 +132,7 @@ bool hassPresence = HassPresence;
 #endif
 
 /*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/
-#define subjectHomePresence "home_presence/" // will send Home Assistant room presence message to this topic (first part is same for all rooms, second is room name)
+#define subjectHomePresence "presence/" // will send Home Assistant room presence message to this topic (first part is same for all rooms, second is room name)
 
 #ifndef useBeaconUuidForPresence
 #  define useBeaconUuidForPresence false // //define true to use iBeacon UUID as for presence, instead of sender mac (random) address


### PR DESCRIPTION
## Description:
As per [this Community thread](https://community.openmqttgateway.com/t/home-presence-does-not-use-mqtt-defined-prefix/1460/4), I replaced Presence MQTT prefix by OMG prefix.
And used `subjectHomePresence` preprocessor symbol (previously unused) instead of `"home_presence/"` const.
Also redefined `subjectHomePresence` with a shorter value `presence`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
