### PR TITLE
Bump Theengs Decoder to v0.6.2

### DIFF
--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -18,10 +18,12 @@ Added to that it retrieves the measures from the devices below. By default the d
 
 |Devices|Model|Measurements|
 |-|:-:|:-:|
+| Amazfit Smart Watch(1)||steps, heart rate|
 | ATorch Battery Capacity Monitor (c)|DT24|volt/amp/watt|
 | BLE watches with fixed MAC||rssi for presence detection|
 | BLE beacons keychains||rssi for presence detection|
 | BlueMaestro|TempoDisc|temperature/humidity/duepoint/voltage|
+| BM2 Battery Monitor|BM2|battery|
 | ClearGrass |CGG1|temperature/humidity/battery|
 | ClearGrass alarm clock|CGD1|temperature/humidity|
 | ClearGrass with atmospheric pressure |CGP1W|temperature/humidity/air pressure|
@@ -34,7 +36,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | HONEYWELL |JQJCY01YM|formaldehyde/temperature/humidity/battery|
 | Ibeacon|protocol|UUID/MFID/Major/Minor/Power|
 | INKBIRD (1)|IBS-TH1|temperature/humidity/battery|
-| INKBIRD (1)|IBS-TH2|temperature/battery|
+| INKBIRD (1)|IBS-TH2/P01B|temperature/battery|
 | INKBIRD (1)|IBT-2X|temperature1/temperature2|
 | INKBIRD (1)|IBT-4XS|temperature1/temperature2/temperature3/temperature4|
 | INKBIRD (1)|IBT-6XS|temperature1/temperature2/temperature3/temperature4/temperature5/temperature6|
@@ -44,9 +46,15 @@ Added to that it retrieves the measures from the devices below. By default the d
 | Qingping |CGDK2|temperature/humidity|
 | Qingping |CGH1|open|
 | Qingping |CGPR1|presence/luminance|
+| RBaron |b-parasite|moisture, temperature, humidity, luminance (v1.1.0+), voltage|
 | RuuviTag Raw V1|RuuviTag|temperature/humidity/pressure/acceleration/volt|
 | RuuviTag Raw V2|RuuviTag|temperature/humidity/pressure/acceleration/volt/TX power/movement/counter/sequence number|
-| Switchbot(c)|S1|mode/state/battery|
+| SmartDry|Laundry Sensor|temperature/humidity/shake/voltage/wake|
+| Switchbot|Bot(c)|mode/state/battery|
+| Switchbot|Motion Sensor|movement/light level/sensing distance/led/scope tested/battery|
+| Switchbot|Contact Sensor|contact/movement/scope tested/light level/battery|
+| Switchbot|Curtain|motion state/position/light level/battery/calibration state|
+| Switchbot|Meter (Plus)|temperature/humidity/battery|
 | Thermobeacon|WS02|temperature/humidity/volt|
 | Thermobeacon|WS08|temperature/humidity/volt|
 | TPMS|TPMS|temperature/pressure/battery/alarm/count|
@@ -54,15 +62,16 @@ Added to that it retrieves the measures from the devices below. By default the d
 | XIAOMI Mi Flora |HHCCJCY01HHCC|temperature/moisture/luminance/fertility/battery(1)(c)|
 | XIAOMI Ropot |HHCCPOT002|temperature/moisture/fertility|
 | XIAOMI Mi Jia |LYWSDCGO|temperature/humidity/battery|
+| XIAOMI Mi Jia |LYWSD02|temperature/humidity/battery|
 | XIAOMI Mi Jia 2 (1)(c)|LYWSD03MMC|temperature/humidity/battery/volt|
 | XIAOMI Mi Jia 2 custom firmware (2)|LYWSD03MMC ATC|temperature/humidity/battery/volt|
 | XIAOMI Mi Jia 2 custom firmware (3)|LYWSD03MMC PVVX|temperature/humidity/battery/volt|
 | XIAOMI Mi Lamp |MUE4094RT|presence|
-| XIAOMI Mi Scale v1 (1)|XMTZC04HM|weight|
-| XIAOMI Mi Scale v2 (1)|XMTZC05HM|weight|
+| XIAOMI Mi Smart Scale (1)|XMTZC01HM/XMTZC04HM|weighing mode/unit/weight|
+| XIAOMI Mi Body Composition Scale (1)|XMTZC02HM/XMTZC05HM|weighing mode/unit/weight/impedance|
 | XIAOMI Mi Temp/Humidity v1 (1)(c)|MHO-C401|temperature/humidity/battery/volt|
 | XIAOMI Mi Temp/Humidity v2 (1)(c)|XMWSDJ04MMC|temperature/humidity/battery/volt|
-| XIAOMI Mi band (1)||steps|
+| XIAOMI |Mi band(1)|steps, heart rate|
 
 Exhaustive list [here](https://compatible.openmqttgateway.com/index.php/devices/ble-devices/)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,8 +121,8 @@ wifimanager8266 = https://github.com/tzapu/WiFiManager.git#2.0.5-beta
 ethernet = Ethernet
 esp8266_mdns = esp8266_mdns
 wire = Wire
-fastled = FastLED@3.3.2
-onewire = OneWire
+fastled = fastled/FastLED@3.3.2
+onewire = paulstoffregen/OneWire@2.3.7
 dallastemperature = DallasTemperature
 m5stickc = M5StickC@0.2.0
 m5stickcp = https://github.com/m5stack/M5StickC-Plus.git#0.0.2
@@ -135,7 +135,7 @@ somfy_remote=Somfy_Remote_Lib@0.3.0
 rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.0.4
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.4.0
+decoder = https://github.com/theengs/decoder.git#v0.6.1
 
 [env]
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -75,6 +75,7 @@ extra_configs =
 ;default_envs = nodemcuv2-ble
 ;default_envs = nodemcuv2-2g
 ;default_envs = nodemcuv2-all-test
+;default_envs = nodemcuv2-fastled-test
 ;default_envs = uno-rf
 ;default_envs = uno-fastled
 ;default_envs = esp32dev-ble-datatest
@@ -920,7 +921,7 @@ build_flags =
   '-DZgatewayBT="BT"'
 ;  '-DZgatewayPilight="Pilight"'
   '-DZactuatorONOFF="ONOFF"'
-  '-DZactuatorFASTLED="FASTLED"'
+ ; '-DZactuatorFASTLED="FASTLED"'
   ;'-DZactuatorPWM="PWM"'
   ;'-DZsensorINA226="INA226"'
   '-DZsensorHCSR501="HCSR501"'
@@ -939,6 +940,20 @@ build_flags =
   ;'-DZgatewayWeatherStation="WeatherStation"'
   '-DsimplePublishing=true'
   '-DGateway_Name="OpenMQTTGateway_ESP8266_ALL"'
+board_build.flash_mode = dout
+
+[env:nodemcuv2-fastled-test]
+platform = ${com.esp8266_platform}
+board = nodemcuv2
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
+  ${libraries.fastled}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZactuatorFASTLED="FASTLED"'
+  '-DsimplePublishing=true'
+  '-DGateway_Name="OpenMQTTGateway_ESP8266_FASTLED"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-2g]

--- a/platformio.ini
+++ b/platformio.ini
@@ -911,13 +911,11 @@ lib_deps =
   ${libraries.onewire}
   ${libraries.dallastemperature}
   ;${libraries.rfWeatherStation}
-  ${libraries.decoder}
 build_flags =
   ${com-esp.build_flags}
 ;  '-DZgatewayRF="RF"'
 ;  '-DZgatewayRF2="RF2"'
   '-DZgatewayIR="IR"'
-  '-DZgatewayBT="BT"'
 ;  '-DZgatewayPilight="Pilight"'
   '-DZactuatorONOFF="ONOFF"'
   '-DZactuatorFASTLED="FASTLED"'

--- a/platformio.ini
+++ b/platformio.ini
@@ -136,7 +136,7 @@ somfy_remote=Somfy_Remote_Lib@0.3.0
 rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.0.4
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.6.1
+decoder = https://github.com/theengs/decoder.git#v0.6.2
 
 [env]
 framework = arduino


### PR DESCRIPTION
## Description:
Bump Theengs Decoder from v0.4.0 to v0.6.2

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
