### PR TITLE
Add secure option for BLE connections.

### DIFF
--- a/main/ZgatewayBLEConnect.h
+++ b/main/ZgatewayBLEConnect.h
@@ -8,20 +8,38 @@
 
 extern void pubBT(JsonObject& data);
 
+class ClientCallbacks : public NimBLEClientCallbacks {
+  uint32_t onPassKeyRequest() {
+    return m_passkey;
+  }
+
+  bool onConfirmPIN(uint32_t pass_key) {
+    return true;
+  }
+
+  friend class zBLEConnect;
+  uint32_t m_passkey;
+};
+
 class zBLEConnect {
 public:
   NimBLEClient* m_pClient;
+  ClientCallbacks m_callbacks;
   TaskHandle_t m_taskHandle = nullptr;
   zBLEConnect(NimBLEAddress& addr) {
     m_pClient = NimBLEDevice::createClient(addr);
     m_pClient->setConnectTimeout(5);
+    m_pClient->setClientCallbacks(&m_callbacks);
   }
   virtual ~zBLEConnect() { NimBLEDevice::deleteClient(m_pClient); }
   virtual bool writeData(BLEAction* action);
   virtual bool readData(BLEAction* action);
   virtual bool processActions(std::vector<BLEAction>& actions);
   virtual void publishData() {}
-  virtual NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID& service, const NimBLEUUID& characteristic);
+  virtual NimBLERemoteCharacteristic* getCharacteristic(const NimBLEUUID& service,
+                                                        const NimBLEUUID& characteristic,
+                                                        bool secure = false,
+                                                        uint32_t passkey = 123456);
 };
 
 class LYWSD03MMC_connect : public zBLEConnect {

--- a/main/ZgatewayBLEConnect.h
+++ b/main/ZgatewayBLEConnect.h
@@ -29,7 +29,7 @@ public:
   zBLEConnect(NimBLEAddress& addr) {
     m_pClient = NimBLEDevice::createClient(addr);
     m_pClient->setConnectTimeout(5);
-    m_pClient->setClientCallbacks(&m_callbacks);
+    m_pClient->setClientCallbacks(&m_callbacks, false);
   }
   virtual ~zBLEConnect() { NimBLEDevice::deleteClient(m_pClient); }
   virtual bool writeData(BLEAction* action);

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -21,6 +21,7 @@ NimBLERemoteCharacteristic* zBLEConnect::getCharacteristic(const NimBLEUUID& ser
     Log.error(F("Connect to: %s failed" CR), m_pClient->getPeerAddress().toString().c_str());
   } else {
     if (secure && !m_pClient->getConnInfo().isEncrypted()) {
+      NimBLEDevice::setSecurityIOCap(BLE_HS_IO_KEYBOARD_DISPLAY);
       NimBLEDevice::setSecurityAuth(true, true, true);
       m_callbacks.m_passkey = passkey;
       m_pClient->secureConnection();

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1149,6 +1149,8 @@ void MQTTtoBTAction(JsonObject& BTdata) {
     return;
   }
 
+  action.secure = BTdata.containsKey("secure") ? BTdata["secure"].as<bool>() : 0;
+  action.passkey = BTdata.containsKey("passkey") ? BTdata["passkey"].as<uint32_t>() : 123456;
   action.ttl = BTdata.containsKey("ttl") ? (uint8_t)BTdata["ttl"] : 1;
   action.addr_type = BTdata.containsKey("mac_type") ? BTdata["mac_type"].as<int>() : 0;
   action.value_type = BLE_VAL_STRING;

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -1,15 +1,15 @@
-/*  
-  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+/*
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation
 
-   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
    Send and receiving command by MQTT
- 
+
    This files enables to set your parameter for the bluetooth low energy gateway (beacons detection)
-  
+
     Copyright: (c)Florian ROBERT
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -167,6 +167,8 @@ struct BLEAction {
   int addr_type;
   NimBLEUUID service;
   NimBLEUUID characteristic;
+  uint32_t passkey;
+  bool secure;
   bool write;
   bool complete;
   uint8_t ttl;


### PR DESCRIPTION
## Description:
This will allow for connecting to devices that require pairing/bonding before permitting read/write operations.

To use this simply add {"secure": true} and optionally {"passkey":123456} (substitute with correct key) to the BLE read/write command.

Example:
```
 home/OpenMQTTGateway_ESP32_BLE/commands/MQTTtoBT/config {
   "ble_read_address":"AA:BB:CC:DD:EE:FF",
   "mac_type": 1,
   "ble_read_service":"932c32bd-0000-47a2-835a-a8d455b859dd",
   "ble_read_char":"932c32bd-0002-47a2-835a-a8d455b859dd",
   "value_type":"HEX",
   "ttl":4,
   "immediate":true,
   "secure":true,
   "passkey":123456 }
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
