### PR TITLE
Add missing macType param to NO_DEVICE_FOUND

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -84,6 +84,7 @@ vector<BLEdevice*> devices;
 int newDevices = 0;
 
 static BLEdevice NO_DEVICE_FOUND = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                    0,
                                     false,
                                     false,
                                     false,

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -83,7 +83,7 @@ vector<BLEAction> BLEactions;
 vector<BLEdevice*> devices;
 int newDevices = 0;
 
-static BLEdevice NO_DEVICE_FOUND = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+static BLEdevice NO_DEVICE_FOUND = {{0},
                                     0,
                                     false,
                                     false,


### PR DESCRIPTION
## Description:
This addresses an issue that was created back when the `mac_type` was first added back in January with f8b4b3ca21dc73bcb9deb06e466ed31cb14232fa, which was causing every BLE device to be marked as connectable when first detected. Combine this with `BLE_FILTER_CONNECTABLE 1` and suddenly every device is getting filtered out before OMG has the chance to initialize anything.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
