### PR TITLE
Mutate relevant compilation variables into config

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -97,10 +97,8 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < BTConfig.minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();
     topic.replace(":", ""); // Initially publish topic ends with MAC address
-#  if useBeaconUuidForTopic
-    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON")
+    if (BTConfig.pubBeaconUuidForTopic && data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON")
       topic = data["uuid"].as<const char*>(); // If model_id is IBEACON, use uuid as topic
-#  endif
     if (BTConfig.extDecoderEnable && !data.containsKey("model"))
       topic = BTConfig.extDecoderTopic; // If external decoder, use this topic to send data
     topic = subjectBTtoMQTT + String("/") + topic;
@@ -111,12 +109,10 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
       data.remove("servicedatauuid");
     if (data.containsKey("servicedata"))
       data.remove("servicedata");
-#  if useBeaconUuidForPresence
-    if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
+    if (BTConfig.presenceUseBeaconUuid && data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
       data["mac"] = data["id"];
       data["id"] = data["uuid"];
     }
-#  endif
     String topic = String(mqtt_topic) + BTConfig.presenceTopic + String(gateway_name);
     Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
     pub_custom_topic((char*)topic.c_str(), data, false);

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -97,7 +97,7 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < BTConfig.minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();
     topic.replace(":", ""); // Initially publish topic ends with MAC address
-    if (BTConfig.pubBeaconUuidForTopic && data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON")
+    if (BTConfig.pubBeaconUuidForTopic && !BTConfig.extDecoderEnable && data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON")
       topic = data["uuid"].as<const char*>(); // If model_id is IBEACON, use uuid as topic
     if (BTConfig.extDecoderEnable && !data.containsKey("model"))
       topic = BTConfig.extDecoderTopic; // If external decoder, use this topic to send data

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -964,24 +964,20 @@ void PublishDeviceData(JsonObject& BLEdata, bool processBLEData) {
   if (abs((int)BLEdata["rssi"] | 0) < BTConfig.minRssi) { // process only the devices close enough
     if (processBLEData) process_bledata(BLEdata);
     if (!BTConfig.pubOnlySensors || BLEdata.containsKey("model") || BLEdata.containsKey("distance")) {
-#  if !pubBLEServiceUUID
-      RemoveJsonPropertyIf(BLEdata, "servicedatauuid", BLEdata.containsKey("model") && BLEdata.containsKey("servicedatauuid"));
-#  endif
-#  if !pubKnownBLEServiceData
-      RemoveJsonPropertyIf(BLEdata, "servicedata", BLEdata.containsKey("model") && BLEdata.containsKey("servicedata"));
-#  endif
-#  if !pubBLEManufacturerData
-      RemoveJsonPropertyIf(BLEdata, "manufacturerdata", BLEdata.containsKey("model") && BLEdata.containsKey("manufacturerdata"));
-#  endif
+      if (!BTConfig.pubServiceDataUUID)
+        RemoveJsonPropertyIf(BLEdata, "servicedatauuid", BLEdata.containsKey("model") && BLEdata.containsKey("servicedatauuid"));
+      if (!BTConfig.pubKnownServiceData)
+        RemoveJsonPropertyIf(BLEdata, "servicedata", BLEdata.containsKey("model") && BLEdata.containsKey("servicedata"));
+      if (!BTConfig.pubKnownManufData)
+        RemoveJsonPropertyIf(BLEdata, "manufacturerdata", BLEdata.containsKey("model") && BLEdata.containsKey("manufacturerdata"));
       pubBT(BLEdata);
     } else {
-#  if !pubUnknownBLEServiceData
-      Log.trace(F("Unknown service data, removing it" CR));
-      RemoveJsonPropertyIf(BLEdata, "servicedata", BLEdata.containsKey("servicedata"));
-#  endif
-#  if !pubUnknownBLEManufacturerData
-      RemoveJsonPropertyIf(BLEdata, "manufacturerdata", BLEdata.containsKey("model") && BLEdata.containsKey("manufacturerdata"));
-#  endif
+      if (!BTConfig.pubUnknownServiceData) {
+        Log.trace(F("Unknown service data, removing it" CR));
+        RemoveJsonPropertyIf(BLEdata, "servicedata", BLEdata.containsKey("servicedata"));
+      }
+      if (!BTConfig.pubUnknownManufData)
+        RemoveJsonPropertyIf(BLEdata, "manufacturerdata", BLEdata.containsKey("model") && BLEdata.containsKey("manufacturerdata"));
     }
   } else if (BLEdata.containsKey("distance")) {
     pubBT(BLEdata);

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -445,12 +445,10 @@ void procBLETask(void* pvParameters) {
       Log.notice(F("Device detected: %s" CR), (char*)mac_adress.c_str());
       BLEdevice* device = getDeviceByMac(BLEdata["id"].as<const char*>());
 
-#    if BLE_FILTER_CONNECTABLE
-      if (device->connect) {
+      if (BTConfig.filterConnectable && device->connect) {
         Log.notice(F("Filtered connectable device" CR));
         continue;
       }
-#    endif
 
       if ((!oneWhite || isWhite(device)) && !isBlack(device)) { //if not black listed MAC we go AND if we have no white MAC or this MAC is  white we go out
         if (advertisedDevice->haveName())

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -92,8 +92,6 @@ static BLEdevice NO_DEVICE_FOUND = {{0},
                                     TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL};
 static bool oneWhite = false;
 
-int minRssi = abs(MinimumRSSI); //minimum rssi value
-
 void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
   if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -96,7 +96,7 @@ static BLEdevice NO_DEVICE_FOUND = {{0},
 static bool oneWhite = false;
 
 void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
-  if (abs((int)data["rssi"] | 0) < minRssi && data.containsKey("id")) {
+  if (abs((int)data["rssi"] | 0) < BTConfig.minRssi && data.containsKey("id")) {
     String topic = data["id"].as<const char*>();
     topic.replace(":", ""); // Initially publish topic ends with MAC address
 #  if useBeaconUuidForTopic
@@ -685,7 +685,7 @@ void setupBT() {
   Log.notice(F("BLE scans interval: %d" CR), BTConfig.BLEinterval);
   Log.notice(F("BLE scans number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
   Log.notice(F("Publishing only BLE sensors: %T" CR), BTConfig.pubOnlySensors);
-  Log.notice(F("minrssi: %d" CR), minRssi);
+  Log.notice(F("minrssi: %d" CR), BTConfig.minRssi);
   Log.notice(F("Low Power Mode: %d" CR), lowpowermode);
 
   atomic_init(&forceBTScan, 0); // in theory, we don't need this
@@ -746,7 +746,7 @@ void setupBT() {
   Log.notice(F("BLE interval: %d" CR), BTConfig.BLEinterval);
   Log.notice(F("BLE scans number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
   Log.notice(F("Publishing only BLE sensors: %T" CR), BTConfig.pubOnlySensors);
-  Log.notice(F("minrssi: %d" CR), minRssi);
+  Log.notice(F("minrssi: %d" CR), BTConfig.minRssi);
   softserial.begin(HMSerialSpeed);
   softserial.print(F("AT+ROLE1" CR));
   delay(100);
@@ -969,7 +969,7 @@ void launchBTDiscovery() {
 #  endif
 
 void PublishDeviceData(JsonObject& BLEdata, bool processBLEData) {
-  if (abs((int)BLEdata["rssi"] | 0) < minRssi) { // process only the devices close enough
+  if (abs((int)BLEdata["rssi"] | 0) < BTConfig.minRssi) { // process only the devices close enough
     if (processBLEData) process_bledata(BLEdata);
     if (!BTConfig.pubOnlySensors || BLEdata.containsKey("model") || BLEdata.containsKey("distance")) {
 #  if !pubBLEServiceUUID
@@ -1271,10 +1271,10 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
     // MinRSSI set
     if (BTdata.containsKey("minrssi")) {
       // storing Min RSSI for further use if needed
-      Log.trace(F("Previous minrssi: %d" CR), minRssi);
+      Log.trace(F("Previous minrssi: %d" CR), BTConfig.minRssi);
       // set Min RSSI if present if not setting default value
-      minRssi = abs((int)BTdata["minrssi"]);
-      Log.notice(F("New minrssi: %d" CR), minRssi);
+      BTConfig.minRssi = abs((int)BTdata["minrssi"]);
+      Log.notice(F("New minrssi: %d" CR), BTConfig.minRssi);
     }
     // Home Assistant presence message
     if (BTdata.containsKey("hasspresence")) {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -622,7 +622,7 @@ void coreTask(void* pvParameters) {
         int scan = atomic_exchange_explicit(&forceBTScan, 0, ::memory_order_seq_cst); // is this enough, it will wait the full deepsleep...
         if (scan == 1) BTforceScan();
       } else {
-        for (int interval = BLEinterval, waitms; interval > 0; interval -= waitms) {
+        for (int interval = BTConfig.BLEinterval, waitms; interval > 0; interval -= waitms) {
           int scan = atomic_exchange_explicit(&forceBTScan, 0, ::memory_order_seq_cst);
           if (scan == 1) BTforceScan(); // should we break after this?
           delay(waitms = interval > 100 ? 100 : interval); // 100ms
@@ -637,8 +637,8 @@ void coreTask(void* pvParameters) {
 
 void lowPowerESP32() // low power mode
 {
-  Log.trace(F("Going to deep sleep for: %l s" CR), (BLEinterval / 1000));
-  deepSleep(BLEinterval * 1000);
+  Log.trace(F("Going to deep sleep for: %l s" CR), (BTConfig.BLEinterval / 1000));
+  deepSleep(BTConfig.BLEinterval * 1000);
 }
 
 void deepSleep(uint64_t time_in_us) {
@@ -682,7 +682,7 @@ void changelowpowermode(int newLowPowerMode) {
 }
 
 void setupBT() {
-  Log.notice(F("BLE scans interval: %d" CR), BLEinterval);
+  Log.notice(F("BLE scans interval: %d" CR), BTConfig.BLEinterval);
   Log.notice(F("BLE scans number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
   Log.notice(F("Publishing only BLE sensors: %T" CR), publishOnlySensors);
   Log.notice(F("minrssi: %d" CR), minRssi);
@@ -743,7 +743,7 @@ unsigned long timebt = 0;
 struct decompose d[6] = {{0, 12, true}, {12, 2, false}, {14, 2, false}, {16, 2, false}, {28, 4, true}, {32, 60, false}};
 
 void setupBT() {
-  Log.notice(F("BLE interval: %d" CR), BLEinterval);
+  Log.notice(F("BLE interval: %d" CR), BTConfig.BLEinterval);
   Log.notice(F("BLE scans number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
   Log.notice(F("Publishing only BLE sensors: %T" CR), publishOnlySensors);
   Log.notice(F("minrssi: %d" CR), minRssi);
@@ -774,7 +774,7 @@ bool BTtoMQTT() {
     returnedString += String(a, HEX);
   }
 
-  if (millis() > (timebt + BLEinterval)) { //retrieving data
+  if (millis() > (timebt + BTConfig.BLEinterval)) { //retrieving data
     timebt = millis();
     returnedString.remove(0); //init data string
     softserial.print(F(QUESTION_MSG)); //start new discovery
@@ -1235,9 +1235,9 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
         BTforceScan();
 #  endif
       } else {
-        Log.trace(F("Previous interval: %d ms" CR), BLEinterval);
-        BLEinterval = interval;
-        Log.notice(F("New interval: %d ms" CR), BLEinterval);
+        Log.trace(F("Previous interval: %d ms" CR), BTConfig.BLEinterval);
+        BTConfig.BLEinterval = interval;
+        Log.notice(F("New interval: %d ms" CR), BTConfig.BLEinterval);
       }
     }
     // Number of scan before a connect set

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -609,7 +609,7 @@ void coreTask(void* pvParameters) {
         if (xSemaphoreTake(semaphoreBLEOperation, pdMS_TO_TICKS(30000)) == pdTRUE) {
           BLEscan();
           // Launching a connect every BLEscanBeforeConnect
-          if ((!(scanCount % BLEscanBeforeConnect) || scanCount == 1) && BTConfig.bleConnect)
+          if ((!(scanCount % BTConfig.BLEscanBeforeConnect) || scanCount == 1) && BTConfig.bleConnect)
             BLEconnect();
           dumpDevices();
           xSemaphoreGive(semaphoreBLEOperation);
@@ -683,7 +683,7 @@ void changelowpowermode(int newLowPowerMode) {
 
 void setupBT() {
   Log.notice(F("BLE scans interval: %d" CR), BLEinterval);
-  Log.notice(F("BLE scans number before connect: %d" CR), BLEscanBeforeConnect);
+  Log.notice(F("BLE scans number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
   Log.notice(F("Publishing only BLE sensors: %T" CR), publishOnlySensors);
   Log.notice(F("minrssi: %d" CR), minRssi);
   Log.notice(F("Low Power Mode: %d" CR), lowpowermode);
@@ -744,7 +744,7 @@ struct decompose d[6] = {{0, 12, true}, {12, 2, false}, {14, 2, false}, {16, 2, 
 
 void setupBT() {
   Log.notice(F("BLE interval: %d" CR), BLEinterval);
-  Log.notice(F("BLE scans number before connect: %d" CR), BLEscanBeforeConnect);
+  Log.notice(F("BLE scans number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
   Log.notice(F("Publishing only BLE sensors: %T" CR), publishOnlySensors);
   Log.notice(F("minrssi: %d" CR), minRssi);
   softserial.begin(HMSerialSpeed);
@@ -1106,7 +1106,7 @@ void immediateBTAction(void* pvParameters) {
       std::swap(BLEactions, act_swap);
 
       // If we stopped the scheduled connect for this action, do the scheduled now
-      if ((!(scanCount % BLEscanBeforeConnect) || scanCount == 1) && BTConfig.bleConnect)
+      if ((!(scanCount % BTConfig.BLEscanBeforeConnect) || scanCount == 1) && BTConfig.bleConnect)
         BLEconnect();
       xSemaphoreGive(semaphoreBLEOperation);
     } else {
@@ -1243,9 +1243,9 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
     // Number of scan before a connect set
     if (BTdata.containsKey("scanbcnct")) {
       Log.trace(F("BLE scans number before a connect setup" CR));
-      Log.trace(F("Previous number: %d" CR), BLEscanBeforeConnect);
-      BLEscanBeforeConnect = (unsigned int)BTdata["scanbcnct"];
-      Log.notice(F("New scan number before connect: %d" CR), BLEscanBeforeConnect);
+      Log.trace(F("Previous number: %d" CR), BTConfig.BLEscanBeforeConnect);
+      BTConfig.BLEscanBeforeConnect = (unsigned int)BTdata["scanbcnct"];
+      Log.notice(F("New scan number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
     }
     // publish all BLE devices discovered or  only the identified sensors (like temperature sensors)
     if (BTdata.containsKey("onlysensors")) {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -121,7 +121,7 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
       data["id"] = data["uuid"];
     }
 #  endif
-    String topic = String(mqtt_topic) + subjectHomePresence + String(gateway_name);
+    String topic = String(mqtt_topic) + BTConfig.presenceTopic + String(gateway_name);
     Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
     pub_custom_topic((char*)topic.c_str(), data, false);
   }

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -66,7 +66,7 @@ using namespace std;
 #  define device_flags_isBlackL 1 << 2
 #  define device_flags_connect  1 << 3
 
-#  ifndef MQTTDecodeTopic
+#  if !UseExtDecoder
 TheengsDecoder decoder;
 #  endif
 
@@ -100,7 +100,7 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
     if (data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON")
       topic = data["uuid"].as<const char*>(); // If model_id is IBEACON, use uuid as topic
 #  endif
-#  ifdef MQTTDecodeTopic
+#  if UseExtDecoder
     if (!data.containsKey("model"))
       topic = MQTTDecodeTopic; // If external decoder, topic is MQTTDecodeTopic
 #  endif
@@ -885,7 +885,7 @@ void launchBTDiscovery() {
         p->sensorModel_id != TheengsDecoder::BLE_ID_NUM::GAEN) {
       String macWOdots = String(p->macAdr);
       macWOdots.replace(":", "");
-#    ifndef MQTTDecodeTopic
+#    if !UseExtDecoder
       if (p->sensorModel_id > TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL &&
           p->sensorModel_id < TheengsDecoder::BLE_ID_NUM::BLE_ID_MAX &&
           p->sensorModel_id != TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC) { // Exception on HHCCJCY01HHCC as this one is discoverable and connectable for battery retrieving
@@ -999,7 +999,7 @@ void process_bledata(JsonObject& BLEdata) {
   const char* mac = BLEdata["id"].as<const char*>();
   int model_id = -1;
   int mac_type = BLEdata["mac_type"].as<int>();
-#  ifndef MQTTDecodeTopic
+#  if !UseExtDecoder
   model_id = decoder.decodeBLEJson(BLEdata);
   if (model_id >= 0) { // Broadcaster devices
     Log.trace(F("Decoder found device: %s" CR), BLEdata["model_id"].as<const char*>());
@@ -1027,7 +1027,7 @@ void process_bledata(JsonObject& BLEdata) {
         createOrUpdateDevice(mac, device_flags_connect, model_id, mac_type);
       }
     }
-#  ifdef MQTTDecodeTopic
+#  if UseExtDecoder
     else if (model_id < 0 && BLEdata.containsKey("servicedata")) {
       const char* service_data = (const char*)(BLEdata["servicedata"] | "");
       if (strstr(service_data, "209800") != NULL) {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -105,7 +105,7 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
 #  endif
 #  if UseExtDecoder
     if (!data.containsKey("model"))
-      topic = MQTTDecodeTopic; // If external decoder, topic is MQTTDecodeTopic
+      topic = BTConfig.extDecoderTopic; // If external decoder, use this topic to send data
 #  endif
     topic = subjectBTtoMQTT + String("/") + topic;
     pub((char*)topic.c_str(), data);

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -468,7 +468,7 @@ void procBLETask(void* pvParameters) {
           BLEdata["rssi"] = (int)advertisedDevice->getRSSI();
         if (advertisedDevice->haveTXPower())
           BLEdata["txpower"] = (int8_t)advertisedDevice->getTXPower();
-        if (advertisedDevice->haveRSSI() && !BTConfig.pubOnlySensors && hassPresence) {
+        if (advertisedDevice->haveRSSI() && !BTConfig.pubOnlySensors && BTConfig.presenceEnable) {
           hass_presence(BLEdata); // this device has an rssi and we don't want only sensors so in consequence we can use it for home assistant room presence component
         }
         if (advertisedDevice->haveServiceData()) {
@@ -834,7 +834,7 @@ bool BTtoMQTT() {
           return false; //if we have at least one white MAC and this MAC is not white we go out
 
         BLEdata["rssi"] = (int)rssi;
-        if (!BTConfig.pubOnlySensors && hassPresence)
+        if (!BTConfig.pubOnlySensors && BTConfig.presenceEnable)
           hass_presence(BLEdata); // this device has an rssi and we don't want only sensors so in consequence we can use it for home assistant room presence component
         Log.trace(F("Service data: %s" CR), restData.c_str());
         BLEdata["servicedata"] = restData.c_str();
@@ -1279,10 +1279,10 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
     // Home Assistant presence message
     if (BTdata.containsKey("hasspresence")) {
       // storing Min RSSI for further use if needed
-      Log.trace(F("Previous hasspresence: %T" CR), hassPresence);
+      Log.trace(F("Previous hasspresence: %T" CR), BTConfig.presenceEnable);
       // set Min RSSI if present if not setting default value
-      hassPresence = (bool)BTdata["hasspresence"];
-      Log.notice(F("New hasspresence: %T" CR), hassPresence);
+      BTConfig.presenceEnable = (bool)BTdata["hasspresence"];
+      Log.notice(F("New hasspresence: %T" CR), BTConfig.presenceEnable);
     }
   }
 }

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -95,7 +95,6 @@ int minRssi = abs(MinimumRSSI); //minimum rssi value
 #ifndef HassPresence
 #  define HassPresence false //false if we publish into Home Assistant presence topic
 #endif
-bool hassPresence = HassPresence;
 
 #ifndef BTQueueSize
 #  define BTQueueSize 4 // lockless queue size for multi core cases (ESP32 currently)
@@ -152,11 +151,13 @@ struct BTConfig_s {
   unsigned int           BLEinterval;                     // Time between 2 scans
   unsigned int           BLEscanBeforeConnect;            // Number of BLE scans between connection cycles
   bool                   pubOnlySensors;                  // Publish only the identified sensors (like temperature sensors)
+  bool                   presenceEnable;                  // Publish into Home Assistant presence topic
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
   .BLEinterval                 = TimeBtwRead,
   .BLEscanBeforeConnect        = ScanBeforeConnect,
   .pubOnlySensors              = PublishOnlySensors,
+  .presenceEnable              = HassPresence,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -145,41 +145,41 @@ unsigned long scanCount = 0;
 
 /*----------------CONFIGURABLE PARAMETERS-----------------*/
 struct BTConfig_s {
-  bool                   bleConnect;                      // Attempt a BLE connection to sensors with ESP32
-  unsigned int           BLEinterval;                     // Time between 2 scans
-  unsigned int           BLEscanBeforeConnect;            // Number of BLE scans between connection cycles
-  bool                   pubOnlySensors;                  // Publish only the identified sensors (like temperature sensors)
-  bool                   presenceEnable;                  // Publish into Home Assistant presence topic
-  String                 presenceTopic;                   // Home Assistant presence topic to publish on
-  bool                   presenceUseBeaconUuid;           // Use iBeacon UUID as for presence, instead of sender MAC (random) address
-  int                    minRssi;                         // Minimum rssi value, all the devices below will not be reported
-  bool                   extDecoderEnable;                // Send undecoded device data to another gateway device for decoding
-  String                 extDecoderTopic;                 // Topic to send undecoded device data on
-  bool                   filterConnectable;               // Sets whether to filter publishing of scanned devices that require a connection.
-  bool                   pubKnownServiceData;             // Publish service data belonging to recognised sensors
-  bool                   pubUnknownServiceData;           // Publish service data belonging to unrecognised sensors (in case you are having too heavy service data) https://github.com/1technophile/OpenMQTTGateway/issues/318#issuecomment-446064707
-  bool                   pubKnownManufData;               // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
-  bool                   pubUnknownManufData;             // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
-  bool                   pubServiceDataUUID;              // Publish the service UUID data
-  bool                   pubBeaconUuidForTopic;           // Use iBeacon UUID as topic, instead of sender (random) MAC address
+  bool bleConnect; // Attempt a BLE connection to sensors with ESP32
+  unsigned int BLEinterval; // Time between 2 scans
+  unsigned int BLEscanBeforeConnect; // Number of BLE scans between connection cycles
+  bool pubOnlySensors; // Publish only the identified sensors (like temperature sensors)
+  bool presenceEnable; // Publish into Home Assistant presence topic
+  String presenceTopic; // Home Assistant presence topic to publish on
+  bool presenceUseBeaconUuid; // Use iBeacon UUID as for presence, instead of sender MAC (random) address
+  int minRssi; // Minimum rssi value, all the devices below will not be reported
+  bool extDecoderEnable; // Send undecoded device data to another gateway device for decoding
+  String extDecoderTopic; // Topic to send undecoded device data on
+  bool filterConnectable; // Sets whether to filter publishing of scanned devices that require a connection.
+  bool pubKnownServiceData; // Publish service data belonging to recognised sensors
+  bool pubUnknownServiceData; // Publish service data belonging to unrecognised sensors (in case you are having too heavy service data) https://github.com/1technophile/OpenMQTTGateway/issues/318#issuecomment-446064707
+  bool pubKnownManufData; // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
+  bool pubUnknownManufData; // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
+  bool pubServiceDataUUID; // Publish the service UUID data
+  bool pubBeaconUuidForTopic; // Use iBeacon UUID as topic, instead of sender (random) MAC address
 } BTConfig_default = {
-  .bleConnect                  = AttemptBLEConnect,
-  .BLEinterval                 = TimeBtwRead,
-  .BLEscanBeforeConnect        = ScanBeforeConnect,
-  .pubOnlySensors              = PublishOnlySensors,
-  .presenceEnable              = HassPresence,
-  .presenceTopic               = subjectHomePresence,
-  .presenceUseBeaconUuid       = useBeaconUuidForPresence,
-  .minRssi                     = abs(MinimumRSSI),
-  .extDecoderEnable            = UseExtDecoder,
-  .extDecoderTopic             = MQTTDecodeTopic,
-  .filterConnectable           = BLE_FILTER_CONNECTABLE,
-  .pubKnownServiceData         = pubKnownBLEServiceData,
-  .pubUnknownServiceData       = pubUnknownBLEServiceData,
-  .pubKnownManufData           = pubBLEManufacturerData,
-  .pubUnknownManufData         = pubUnknownBLEManufacturerData,
-  .pubServiceDataUUID          = pubBLEServiceUUID,
-  .pubBeaconUuidForTopic       = useBeaconUuidForTopic,
+    .bleConnect = AttemptBLEConnect,
+    .BLEinterval = TimeBtwRead,
+    .BLEscanBeforeConnect = ScanBeforeConnect,
+    .pubOnlySensors = PublishOnlySensors,
+    .presenceEnable = HassPresence,
+    .presenceTopic = subjectHomePresence,
+    .presenceUseBeaconUuid = useBeaconUuidForPresence,
+    .minRssi = abs(MinimumRSSI),
+    .extDecoderEnable = UseExtDecoder,
+    .extDecoderTopic = MQTTDecodeTopic,
+    .filterConnectable = BLE_FILTER_CONNECTABLE,
+    .pubKnownServiceData = pubKnownBLEServiceData,
+    .pubUnknownServiceData = pubUnknownBLEServiceData,
+    .pubKnownManufData = pubBLEManufacturerData,
+    .pubUnknownManufData = pubUnknownBLEManufacturerData,
+    .pubServiceDataUUID = pubBLEServiceUUID,
+    .pubBeaconUuidForTopic = useBeaconUuidForTopic,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -155,6 +155,11 @@ struct BTConfig_s {
   bool                   extDecoderEnable;                // Send undecoded device data to another gateway device for decoding
   String                 extDecoderTopic;                 // Topic to send undecoded device data on
   bool                   filterConnectable;               // Sets whether to filter publishing of scanned devices that require a connection.
+  bool                   pubKnownServiceData;             // Publish service data belonging to recognised sensors
+  bool                   pubUnknownServiceData;           // Publish service data belonging to unrecognised sensors (in case you are having too heavy service data) https://github.com/1technophile/OpenMQTTGateway/issues/318#issuecomment-446064707
+  bool                   pubKnownManufData;               // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
+  bool                   pubUnknownManufData;             // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
+  bool                   pubServiceDataUUID;              // Publish the service UUID data
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
   .BLEinterval                 = TimeBtwRead,
@@ -166,6 +171,11 @@ struct BTConfig_s {
   .extDecoderEnable            = UseExtDecoder,
   .extDecoderTopic             = MQTTDecodeTopic,
   .filterConnectable           = BLE_FILTER_CONNECTABLE,
+  .pubKnownServiceData         = pubKnownBLEServiceData,
+  .pubUnknownServiceData       = pubUnknownBLEServiceData,
+  .pubKnownManufData           = pubBLEManufacturerData,
+  .pubUnknownManufData         = pubUnknownBLEManufacturerData,
+  .pubServiceDataUUID          = pubBLEServiceUUID,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -63,7 +63,6 @@ extern int btQueueLengthCount;
 
 
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -90 will not be reported
-int minRssi = abs(MinimumRSSI); //minimum rssi value
 
 #ifndef Scan_duration
 #  define Scan_duration 10000 //define the time for a scan
@@ -152,12 +151,14 @@ struct BTConfig_s {
   unsigned int           BLEscanBeforeConnect;            // Number of BLE scans between connection cycles
   bool                   pubOnlySensors;                  // Publish only the identified sensors (like temperature sensors)
   bool                   presenceEnable;                  // Publish into Home Assistant presence topic
+  int                    minRssi;                         // Minimum rssi value, all the devices below will not be reported
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
   .BLEinterval                 = TimeBtwRead,
   .BLEscanBeforeConnect        = ScanBeforeConnect,
   .pubOnlySensors              = PublishOnlySensors,
   .presenceEnable              = HassPresence,
+  .minRssi                     = abs(MinimumRSSI),
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -59,6 +59,10 @@ extern int btQueueLengthCount;
 #  else
 #    define UseExtDecoder false
 #  endif
+#else
+#  if UseExtDecoder
+#    define MQTTDecodeTopic "undecoded"
+#  endif
 #endif
 
 
@@ -153,6 +157,7 @@ struct BTConfig_s {
   bool                   presenceEnable;                  // Publish into Home Assistant presence topic
   String                 presenceTopic;                   // Home Assistant presence topic to publish on
   int                    minRssi;                         // Minimum rssi value, all the devices below will not be reported
+  String                 extDecoderTopic;                 // Topic to send undecoded device data on
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
   .BLEinterval                 = TimeBtwRead,
@@ -161,6 +166,7 @@ struct BTConfig_s {
   .presenceEnable              = HassPresence,
   .presenceTopic               = subjectHomePresence,
   .minRssi                     = abs(MinimumRSSI),
+  .extDecoderTopic             = MQTTDecodeTopic,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -91,7 +91,6 @@ int minRssi = abs(MinimumRSSI); //minimum rssi value
 #ifndef PublishOnlySensors
 #  define PublishOnlySensors false //false if we publish all BLE devices discovered or true only the identified sensors (like temperature sensors)
 #endif
-bool publishOnlySensors = PublishOnlySensors;
 
 #ifndef HassPresence
 #  define HassPresence false //false if we publish into Home Assistant presence topic
@@ -152,10 +151,12 @@ struct BTConfig_s {
   bool                   bleConnect;                      // Attempt a BLE connection to sensors with ESP32
   unsigned int           BLEinterval;                     // Time between 2 scans
   unsigned int           BLEscanBeforeConnect;            // Number of BLE scans between connection cycles
+  bool                   pubOnlySensors;                  // Publish only the identified sensors (like temperature sensors)
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
   .BLEinterval                 = TimeBtwRead,
   .BLEscanBeforeConnect        = ScanBeforeConnect,
+  .pubOnlySensors              = PublishOnlySensors,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -59,10 +59,9 @@ extern int btQueueLengthCount;
 #  else
 #    define UseExtDecoder false
 #  endif
-#else
-#  if UseExtDecoder
-#    define MQTTDecodeTopic "undecoded"
-#  endif
+#endif
+#ifndef MQTTDecodeTopic
+#  define MQTTDecodeTopic "undecoded"
 #endif
 
 
@@ -157,6 +156,7 @@ struct BTConfig_s {
   bool                   presenceEnable;                  // Publish into Home Assistant presence topic
   String                 presenceTopic;                   // Home Assistant presence topic to publish on
   int                    minRssi;                         // Minimum rssi value, all the devices below will not be reported
+  bool                   extDecoderEnable;                // Send undecoded device data to another gateway device for decoding
   String                 extDecoderTopic;                 // Topic to send undecoded device data on
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
@@ -166,6 +166,7 @@ struct BTConfig_s {
   .presenceEnable              = HassPresence,
   .presenceTopic               = subjectHomePresence,
   .minRssi                     = abs(MinimumRSSI),
+  .extDecoderEnable            = UseExtDecoder,
   .extDecoderTopic             = MQTTDecodeTopic,
 };
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -39,7 +39,6 @@ extern int btQueueLengthCount;
 #  ifndef AttemptBLEConnect
 #    define AttemptBLEConnect true //do we by default attempt a BLE connection to sensors with ESP32
 #  endif
-bool bleConnect = AttemptBLEConnect;
 
 // Sets whether to filter publishing of scanned devices that require a connection.
 // Setting this to 1 prevents overwriting the publication of the device connection data with the advertised data (Recommended for use with OpenHAB).
@@ -149,6 +148,16 @@ unsigned long scanCount = 0;
 #ifndef useBeaconUuidForPresence
 #  define useBeaconUuidForPresence false // //define true to use iBeacon UUID as for presence, instead of sender MAC (random) address
 #endif
+
+/*----------------CONFIGURABLE PARAMETERS-----------------*/
+struct BTConfig_s {
+  bool                   bleConnect;                      // Attempt a BLE connection to sensors with ESP32
+} BTConfig_default = {
+  .bleConnect                  = AttemptBLEConnect
+};
+
+// Global struct to store live BT configuration data
+extern BTConfig_s BTConfig;
 
 /*-------------------PIN DEFINITIONS----------------------*/
 #if !defined(BT_RX) || !defined(BT_TX)

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -49,13 +49,14 @@ bool bleConnect = AttemptBLECOnnect;
 #  include "NimBLEDevice.h"
 #endif
 
-/*----------------------BT topics & parameters-------------------------*/
+/*-----------BT TOPICS & COMPILATION PARAMETERS-----------*/
 #define subjectBTtoMQTT    "/BTtoMQTT"
 #define subjectMQTTtoBTset "/commands/MQTTtoBT/config"
 // Uncomment to send undecoded device data to another gateway device for decoding
 // #define MQTTDecodeTopic    "undecoded"
 
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -90 will not be reported
+int minRssi = abs(MinimumRSSI); //minimum rssi value
 
 #ifndef Scan_duration
 #  define Scan_duration 10000 //define the time for a scan
@@ -72,18 +73,25 @@ bool bleConnect = AttemptBLECOnnect;
 #ifndef ScanBeforeConnect
 #  define ScanBeforeConnect 10 //define number of scans before connecting to BLE devices (ESP32 only, minimum 1)
 #endif
+unsigned int BLEscanBeforeConnect = ScanBeforeConnect; //Number of BLE scans between connection cycles
+
 #ifndef BLEScanDuplicateCacheSize
 #  define BLEScanDuplicateCacheSize 200
 #endif
 #ifndef TimeBtwRead
 #  define TimeBtwRead 55555 //define default time between 2 scans
 #endif
+unsigned int BLEinterval = TimeBtwRead; //time between 2 scans
+
 #ifndef PublishOnlySensors
 #  define PublishOnlySensors false //false if we publish all BLE devices discovered or true only the identified sensors (like temperature sensors)
 #endif
+bool publishOnlySensors = PublishOnlySensors;
+
 #ifndef HassPresence
 #  define HassPresence false //false if we publish into Home Assistant presence topic
 #endif
+bool hassPresence = HassPresence;
 
 #ifndef BTQueueSize
 #  define BTQueueSize 4 // lockless queue size for multi core cases (ESP32 currently)
@@ -101,11 +109,7 @@ bool bleConnect = AttemptBLECOnnect;
 
 #define ServicedataMinLength 27
 
-unsigned int BLEinterval = TimeBtwRead; //time between 2 scans
-unsigned int BLEscanBeforeConnect = ScanBeforeConnect; //Number of BLE scans between connection cycles
 unsigned long scanCount = 0;
-bool publishOnlySensors = PublishOnlySensors;
-bool hassPresence = HassPresence;
 
 #ifndef pubKnownBLEServiceData
 #  define pubKnownBLEServiceData false // define true if you want to publish service data belonging to recognised sensors
@@ -131,7 +135,7 @@ bool hassPresence = HassPresence;
 #  define useBeaconUuidForTopic false // define true to use iBeacon UUID as topic, instead of sender (random) MAC address
 #endif
 
-/*-------------------HOME ASSISTANT ROOM PRESENCE ----------------------*/
+/*--------------HOME ASSISTANT ROOM PRESENCE--------------*/
 #define subjectHomePresence "presence/" // will send Home Assistant room presence message to this topic (first part is same for all rooms, second is room name)
 
 #ifndef useBeaconUuidForPresence

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -151,6 +151,7 @@ struct BTConfig_s {
   bool                   pubOnlySensors;                  // Publish only the identified sensors (like temperature sensors)
   bool                   presenceEnable;                  // Publish into Home Assistant presence topic
   String                 presenceTopic;                   // Home Assistant presence topic to publish on
+  bool                   presenceUseBeaconUuid;           // Use iBeacon UUID as for presence, instead of sender MAC (random) address
   int                    minRssi;                         // Minimum rssi value, all the devices below will not be reported
   bool                   extDecoderEnable;                // Send undecoded device data to another gateway device for decoding
   String                 extDecoderTopic;                 // Topic to send undecoded device data on
@@ -160,6 +161,7 @@ struct BTConfig_s {
   bool                   pubKnownManufData;               // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
   bool                   pubUnknownManufData;             // Publish the manufacturer's data (sometimes contains characters that aren't valid with receiving client)
   bool                   pubServiceDataUUID;              // Publish the service UUID data
+  bool                   pubBeaconUuidForTopic;           // Use iBeacon UUID as topic, instead of sender (random) MAC address
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
   .BLEinterval                 = TimeBtwRead,
@@ -167,6 +169,7 @@ struct BTConfig_s {
   .pubOnlySensors              = PublishOnlySensors,
   .presenceEnable              = HassPresence,
   .presenceTopic               = subjectHomePresence,
+  .presenceUseBeaconUuid       = useBeaconUuidForPresence,
   .minRssi                     = abs(MinimumRSSI),
   .extDecoderEnable            = UseExtDecoder,
   .extDecoderTopic             = MQTTDecodeTopic,
@@ -176,6 +179,7 @@ struct BTConfig_s {
   .pubKnownManufData           = pubBLEManufacturerData,
   .pubUnknownManufData         = pubUnknownBLEManufacturerData,
   .pubServiceDataUUID          = pubBLEServiceUUID,
+  .pubBeaconUuidForTopic       = useBeaconUuidForTopic,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -87,7 +87,6 @@ int minRssi = abs(MinimumRSSI); //minimum rssi value
 #ifndef TimeBtwRead
 #  define TimeBtwRead 55555 //define default time between 2 scans
 #endif
-unsigned int BLEinterval = TimeBtwRead; //time between 2 scans
 
 #ifndef PublishOnlySensors
 #  define PublishOnlySensors false //false if we publish all BLE devices discovered or true only the identified sensors (like temperature sensors)
@@ -151,9 +150,11 @@ unsigned long scanCount = 0;
 /*----------------CONFIGURABLE PARAMETERS-----------------*/
 struct BTConfig_s {
   bool                   bleConnect;                      // Attempt a BLE connection to sensors with ESP32
+  unsigned int           BLEinterval;                     // Time between 2 scans
   unsigned int           BLEscanBeforeConnect;            // Number of BLE scans between connection cycles
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
+  .BLEinterval                 = TimeBtwRead,
   .BLEscanBeforeConnect        = ScanBeforeConnect,
 };
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -36,10 +36,10 @@ extern void launchBTDiscovery();
 extern int btQueueBlocked;
 extern int btQueueLengthSum;
 extern int btQueueLengthCount;
-#  ifndef AttemptBLECOnnect
-#    define AttemptBLECOnnect true //do we by default attempt a BLE connection to sensors with ESP32
+#  ifndef AttemptBLEConnect
+#    define AttemptBLEConnect true //do we by default attempt a BLE connection to sensors with ESP32
 #  endif
-bool bleConnect = AttemptBLECOnnect;
+bool bleConnect = AttemptBLEConnect;
 
 // Sets whether to filter publishing of scanned devices that require a connection.
 // Setting this to 1 prevents overwriting the publication of the device connection data with the advertised data (Recommended for use with OpenHAB).

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -36,15 +36,6 @@ extern void launchBTDiscovery();
 extern int btQueueBlocked;
 extern int btQueueLengthSum;
 extern int btQueueLengthCount;
-#  ifndef AttemptBLEConnect
-#    define AttemptBLEConnect true //do we by default attempt a BLE connection to sensors with ESP32
-#  endif
-
-// Sets whether to filter publishing of scanned devices that require a connection.
-// Setting this to 1 prevents overwriting the publication of the device connection data with the advertised data (Recommended for use with OpenHAB).
-#  ifndef BLE_FILTER_CONNECTABLE
-#    define BLE_FILTER_CONNECTABLE 0
-#  endif
 #  include "NimBLEDevice.h"
 #endif
 
@@ -64,6 +55,13 @@ extern int btQueueLengthCount;
 #  define MQTTDecodeTopic "undecoded"
 #endif
 
+#ifndef AttemptBLEConnect
+#  define AttemptBLEConnect true //do we by default attempt a BLE connection to sensors with ESP32
+#endif
+
+#ifndef BLE_FILTER_CONNECTABLE
+#  define BLE_FILTER_CONNECTABLE 0 // Sets whether to filter publishing of scanned devices that require a connection.
+#endif // Setting this to 1 prevents overwriting the publication of the device connection data with the advertised data (Recommended for use with OpenHAB).
 
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -90 will not be reported
 
@@ -111,8 +109,6 @@ extern int btQueueLengthCount;
 #define CRLR               "0d0a"
 #define CRLR_Length        4
 #define BLE_CNCT_TIMEOUT   3000
-
-#define ServicedataMinLength 27
 
 unsigned long scanCount = 0;
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -80,7 +80,6 @@ int minRssi = abs(MinimumRSSI); //minimum rssi value
 #ifndef ScanBeforeConnect
 #  define ScanBeforeConnect 10 //define number of scans before connecting to BLE devices (ESP32 only, minimum 1)
 #endif
-unsigned int BLEscanBeforeConnect = ScanBeforeConnect; //Number of BLE scans between connection cycles
 
 #ifndef BLEScanDuplicateCacheSize
 #  define BLEScanDuplicateCacheSize 200
@@ -152,8 +151,10 @@ unsigned long scanCount = 0;
 /*----------------CONFIGURABLE PARAMETERS-----------------*/
 struct BTConfig_s {
   bool                   bleConnect;                      // Attempt a BLE connection to sensors with ESP32
+  unsigned int           BLEscanBeforeConnect;            // Number of BLE scans between connection cycles
 } BTConfig_default = {
-  .bleConnect                  = AttemptBLEConnect
+  .bleConnect                  = AttemptBLEConnect,
+  .BLEscanBeforeConnect        = ScanBeforeConnect,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -154,6 +154,7 @@ struct BTConfig_s {
   int                    minRssi;                         // Minimum rssi value, all the devices below will not be reported
   bool                   extDecoderEnable;                // Send undecoded device data to another gateway device for decoding
   String                 extDecoderTopic;                 // Topic to send undecoded device data on
+  bool                   filterConnectable;               // Sets whether to filter publishing of scanned devices that require a connection.
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
   .BLEinterval                 = TimeBtwRead,
@@ -164,6 +165,7 @@ struct BTConfig_s {
   .minRssi                     = abs(MinimumRSSI),
   .extDecoderEnable            = UseExtDecoder,
   .extDecoderTopic             = MQTTDecodeTopic,
+  .filterConnectable           = BLE_FILTER_CONNECTABLE,
 };
 
 // Global struct to store live BT configuration data

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -151,6 +151,7 @@ struct BTConfig_s {
   unsigned int           BLEscanBeforeConnect;            // Number of BLE scans between connection cycles
   bool                   pubOnlySensors;                  // Publish only the identified sensors (like temperature sensors)
   bool                   presenceEnable;                  // Publish into Home Assistant presence topic
+  String                 presenceTopic;                   // Home Assistant presence topic to publish on
   int                    minRssi;                         // Minimum rssi value, all the devices below will not be reported
 } BTConfig_default = {
   .bleConnect                  = AttemptBLEConnect,
@@ -158,6 +159,7 @@ struct BTConfig_s {
   .BLEscanBeforeConnect        = ScanBeforeConnect,
   .pubOnlySensors              = PublishOnlySensors,
   .presenceEnable              = HassPresence,
+  .presenceTopic               = subjectHomePresence,
   .minRssi                     = abs(MinimumRSSI),
 };
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -54,6 +54,14 @@ bool bleConnect = AttemptBLECOnnect;
 #define subjectMQTTtoBTset "/commands/MQTTtoBT/config"
 // Uncomment to send undecoded device data to another gateway device for decoding
 // #define MQTTDecodeTopic    "undecoded"
+#ifndef UseExtDecoder
+#  ifdef MQTTDecodeTopic
+#    define UseExtDecoder true
+#  else
+#    define UseExtDecoder false
+#  endif
+#endif
+
 
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -90 will not be reported
 int minRssi = abs(MinimumRSSI); //minimum rssi value

--- a/main/main.ino
+++ b/main/main.ino
@@ -1576,7 +1576,7 @@ void stateMeasures() {
   SYSdata["btqavg"] = (btQueueLengthCount > 0 ? btQueueLengthSum / (float)btQueueLengthCount : 0);
 #    endif
   SYSdata["interval"] = BLEinterval;
-  SYSdata["scanbcnct"] = BLEscanBeforeConnect;
+  SYSdata["scanbcnct"] = BTConfig.BLEscanBeforeConnect;
   SYSdata["scnct"] = scanCount;
 #  endif
 #  ifdef ZboardM5STACK

--- a/main/main.ino
+++ b/main/main.ino
@@ -1575,7 +1575,7 @@ void stateMeasures() {
   SYSdata["btqsnd"] = btQueueLengthCount;
   SYSdata["btqavg"] = (btQueueLengthCount > 0 ? btQueueLengthSum / (float)btQueueLengthCount : 0);
 #    endif
-  SYSdata["interval"] = BLEinterval;
+  SYSdata["interval"] = BTConfig.BLEinterval;
   SYSdata["scanbcnct"] = BTConfig.BLEscanBeforeConnect;
   SYSdata["scnct"] = scanCount;
 #  endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -482,7 +482,7 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_C"'
   '-DTimeBtwRead=0'
   '-DScan_duration=1000'
-  '-DAttemptBLECOnnect=false'
+  '-DAttemptBLEConnect=false'
 
 [env:esp32feather-ble]
 platform = ${com.esp32_platform}
@@ -519,7 +519,7 @@ build_flags =
 ;  '-DDEFAULT_LOW_POWER_MODE=2'
 ;  '-DTimeBtwRead=155000'
 ;  '-DScan_duration=2000'
-;  '-DAttemptBLECOnnect=false'
+;  '-DAttemptBLEConnect=false'
 ;  '-DActiveBLEScan=false'
 ;  '-DESPWifiManualSetup=true'
 ;  '-DMQTT_USER="lolin-esp32"'


### PR DESCRIPTION
Hello Team,

## Description:
As per issue #1240, this PR removes major non-hardware dependent compilation variables from ZgatewayBT.ino.

To achieve this, the following changes have been made:
- Move variable `minRssi` in config_BT.h,
- Create a struct (BTConfig_s) for BT configuration data,
- Create a default config for BTConfig_s (BTConfig_default) based on defines,
- Create a global variable (BTConfig) to hold live BT configuration data and initialize it,
- Move global variables `bleConnect`, `BLEscanBeforeConnect`, `BLEinterval`, `PublishOnlySensors`, `hassPresence`, `minRssi` into struct BTConfig_s,
- Add `presenceTopic` into BTConfig_s,
- Move `MQTTDecodeTopic` as `extDecoderTopic` into BTConfig_s,
- Move `UseExtDecoder`, `BLE_FILTER_CONNECTABLE`, `pubKnownBLEServiceData`, `pubUnknownBLEServiceData`, `pubBLEManufacturerData`, `pubUnknownBLEManufacturerData`, `pubBLEServiceUUID`, `useBeaconUuidForTopic`, `useBeaconUuidForPresence as runtime var into BTConfig_s

Also compilation variable `AttemptBLECOnnect` has been renamed `AttemptBLEConnect`, **which could be A BREAKING CHANGE**.
And compilation variable `ServicedataMinLength` has been removed (unused).

The next steps are:
1. Provide the ability to modify those configurations with mqtt payloads on `MQTTtoBT` topic,
2. Review White/Black-lists to handle "wildcard" mac adresses/uuid (point raised in issues #1139, #1226 and PR #919 for ZgatewayRF) and add a parameter to disable black/white-listing (point raised in issue #331 and PR #615),
3. Persist configuration change in SPIFFS instead of having to retain the configuration in the Broker.

Tell me if this is going the right way for you.

Bad

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
