### PR TITLE
Additional units

### DIFF
--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -237,9 +237,16 @@ const char* availableHASSUnits[] = {"W",
                                     "µS/cm",
                                     "ppm",
                                     "μg/m³",
+                                    "m³",
+                                    "mg/m³",
+                                    "m/s²",
                                     "lx",
+                                    "Ω",
                                     "%",
+                                    "bar",
+                                    "bpm",
                                     "dB",
+                                    "dBm",
                                     "B"};
 
 #endif


### PR DESCRIPTION
Additional units from decoders.

As discussed. Leaving it as draft to see if any further are needed, and if "Ohm" or "Ω" should be used, with the latter also needing a decoder change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
