### PR TITLE
Update of rtl_433_ESP to version 0.1.3 - Support for SX127X transceiver module

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Upload OpenMQTTGateway directly from the [upload page](https://docs.openmqttgate
 *Running on a computer*
 If you want to use the BLE decoding capabilities of OpenMQTTGateway with a Raspberry Pi, Windows or Unix PC you can now leverage [Theengs Gateway](https://theengs.github.io/gateway/).
 
-* [List of compatible components to build your gateway](https://compatible.openmqttgateway.com/index.php/parts/), DHT, HM10, RF, IR emitters and receivers...
+* [List of compatible components to build your gateway](https://compatible.openmqttgateway.com/index.php/parts/), DHT, RF, IR emitters and receivers...
 
 ## Compatible controllers, saas or software
 

--- a/docs/participate/adding-protocols.md
+++ b/docs/participate/adding-protocols.md
@@ -1,12 +1,12 @@
 # Adding protocols
 
-Adding your device protocol to OpenMQTTGateway enable to increase interoperability and to create new use cases with your device. You will find below some guidance to do that. 
+Adding your device protocol to OpenMQTTGateway enables it to increase interoperability and to create new use cases with your device. Below you will find some guidance to do that. 
 
 ## RF or IR
-For adding RF and IR protocols to OpenMQTTGateway the best way is to do a pull request to [RCSwitch](https://github.com/1technophile/rc-switch), [Pilight](https://github.com/pilight/pilight) for RF and [IRRemoteESP8266](https://github.com/crankyoldgit/IRremoteESP8266) for IR.
+For adding RF and IR protocols to OpenMQTTGateway the best way is to do a pull request to [RCSwitch](https://github.com/1technophile/rc-switch), [Pilight](https://github.com/pilight/pilight) for RF, and [IRRemoteESP8266](https://github.com/crankyoldgit/IRremoteESP8266) for IR.
 
 ## BLE
-For BLE devices you can do a pull request directly to the [OpenMQTTGateway](https://github.com/1technophile/OpenMQTTGateway) repository.
+For BLE message decoding OpenMQTTGateway uses the [Theengs Decoder](https://decoder.theengs.io/) library. New device decoder pull requests can be submitted directly to the [GitHub repository](https://github.com/theengs/decoder).
 
-Currently we support the reading of advertizing BLE devices, advertizing means that the BLE device broadcast regularly its sensor data without the need of a BLE connection.
+Currently we support the reading of advertizing BLE devices, advertizing means that the BLE device broadcasts regularly its sensor data without the need of a BLE connection.
 

--- a/docs/prerequisites/board.md
+++ b/docs/prerequisites/board.md
@@ -44,13 +44,13 @@ The boards below need hardware [parts](parts.md) and electronic/hardware compete
 |DIY boards|RF|IR|BLE|LORA|GSM|Button|Relay|
 |-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 |Arduino UNO|X|X(limited compared to ESP)|-|-|-|X|X|
-|Arduino MEGA|X|X(limited compared to ESP)|X|-|-|X|X|
+|Arduino MEGA|X|X(limited compared to ESP)|-|-|-|X|X|
 |ESP32|X|X|X|X|not tested|X|X|
-|ESP8266|X|X|X|not tested|X|X|X|
+|ESP8266|X|X|-|not tested|X|X|X|
 
 ::: tip
 Pilight is only supported on ESP, Arduino UNO handle only 32bits values in our context.
-Setup based on HM10 doesn't support some BLE [devices](devices.md#for-ble-devices).
+HM10 is no longer supported by OpenMQTTGateway
 :::
 
 ![boards](../img/OpenMQTTGateway_boards.png)

--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -35,6 +35,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | GOVEE|H5072|temperature/humidity/battery|
 | GOVEE|H5102|temperature/humidity/battery|
 | HONEYWELL|JQJCY01YM|formaldehyde/temperature/humidity/battery|
+| Hydractiva Digital | Amphiro/Oras|sessions/time/litres/temperature/energy|
 | iBeacon|protocol|uuid/mfid/major/minor/txpower @ 1 m/voltage|
 | INKBIRD (1)|IBS-TH1|temperature/humidity/battery|
 | INKBIRD (1)|IBS-TH2/P01B|temperature/battery|
@@ -42,16 +43,17 @@ Added to that it retrieves the measures from the devices below. By default the d
 | INKBIRD (1)|IBT-4XS|temperature1/temperature2/temperature3/temperature4|
 | INKBIRD (1)|IBT-6XS|temperature1/temperature2/temperature3/temperature4/temperature5/temperature6|
 | iNode|Energy Meter (1)|Current average and aggregate kW(h)/m³/battery|
-| Mokosmart (1)|M1|x_axis/y_axis/z_axis/battery|
+| Oria/Brifit/SigmaWit/SensorPro|TH Sensor|temperature/humidity/battery|
+| Mokosmart (1)|M1|acceleration x/y/z-axis/battery|
 | Mokosmart (1)|H4|temperature/humidity/voltage|
 | Qingping|CGDK2|temperature/humidity|
 | Qingping|CGH1|open|
-| Qingping|CGPR1|presence/luminance|
+| Qingping|CGPR1|presence/luminance/battery|
 | Qingping|CGDN1|temperature/humidity/PM2.5/PM10/carbon dioxide|
-| RDL52832||mfid/uuid/minor/major/txpower @ 1 m/temperature/humidity/acceleration|
+| RDL52832||mfid/uuid/minor/major/txpower @ 1 m/temperature/humidity/acceleration x/y/z-axis|
 | RBaron|b-parasite|moisture/temperature/humidity/luminance (v1.1.0+)/voltage|
-| RuuviTag Raw V1|RuuviTag|temperature/humidity/pressure/acceleration/voltage|
-| RuuviTag Raw V2|RuuviTag|temperature/humidity/pressure/acceleration/voltage/TX power/movement/counter/sequence number|
+| RuuviTag Raw V1|RuuviTag|temperature/humidity/pressure/acceleration x/y/z-axis/voltage|
+| RuuviTag Raw V2|RuuviTag|temperature/humidity/pressure/acceleration x/y/z-axis/voltage/TX power/movement/counter/sequence number|
 | SmartDry|Laundry Sensor|temperature/humidity/shake/voltage/wake|
 | Switchbot|Bot (c)|mode/state/battery|
 | Switchbot|Motion Sensor|movement/light level/sensing distance/led/scope tested/battery|
@@ -60,6 +62,8 @@ Added to that it retrieves the measures from the devices below. By default the d
 | Switchbot|Meter (Plus)|temperature/humidity/battery|
 | Thermobeacon|WS02|temperature/humidity/voltage/timestamp/maximum temperature/maximum temperature timestamp/minimum temperature/minimum temperature timestamp|
 | Thermobeacon|WS08|temperature/humidity/voltage/timestamp/maximum temperature/maximum temperature timestamp/minimum temperature/minimum temperature timestamp|
+| ThermoPro|TP357|temperature/humidity|
+| ThermoPro|TP358|temperature/humidity|
 | TPMS|TPMS|temperature/pressure/battery/alarm/count|
 | Vegtrug||temperature/moisture/luminance/fertility|
 | XIAOMI Mi Flora|HHCCJCY01HHCC|temperature/moisture/luminance/fertility/battery(1)(c)|

--- a/docs/prerequisites/parts.md
+++ b/docs/prerequisites/parts.md
@@ -10,7 +10,6 @@ Here is below the main parts reference.
 |-|:-:|:-:|:-:|:-:|:-:|
 |SRX882 / STX882|X|-||-|-|
 |CC1101|X|-|-|-|-|
-|HM10|-|-|X|-|-|
 |38KHz IR emitter and receiver|-|X|-|-|-|
 |SX1276|-|-|-|X|-|
 |A6/A7|-|-|-|-|X|

--- a/docs/setitup/ble.md
+++ b/docs/setitup/ble.md
@@ -7,31 +7,4 @@ You can use a barebone ESP32 or some nice looking products like the ones below (
 ![](../img/OpenMQTTgateway_M5_Atom_Board.png)
 ![](../img/OpenMQTTgateway_M5_Stack_Board_Display_Text.png)
 
-For Arduino and ESP8266 you can use an HM10 or HM11 below.
-|Module|Purpose|Where to Buy|
-|-|-|-|
-|HM 10 Keyes bluetooth module|Bluetooth|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-
-## Pinout
-|Module Pin|Board RX Pin|Board TX Pin|
-|-|:-:|:-:|
-|Arduino|D6 to HM10 RX|D5 to HM10 TX|
-|ESP8266|D6 to HM10 RX|D7 to HM10 TX|
-
-Vcc pin of the board and the HM10 Module to a 5V supply source.
-Ground pins of the board and the HM10 Module to the ground of the supply source.
-
-### Debugging the HM10
-So as to communicate directly with the HM10 you may use [this program](https://github.com/1technophile/serial_modules_debug) from Martin Currey, you can upload it to your ESP board and it will enable without an FTDI to write and read commands directly to the HM10 through the ESP. You may use the Arduino IDE Serial Monitor to read and send the commands.
-The baud rate of the HM10/11 module must be set to 9600 bauds , the command `AT+BAUD?` enables to know at which speed the module is set.
-So as to set it to 9600 that you may use `AT+BAUD0` command.
-
-The HM10/11 firmware version must be >= V709 the command `AT+VERS?` enables to know the firmware version.
-
-## Arduino Hardware setup
-![BLE Arduino](../img/OpenMQTTgateway_Arduino_Addon_BT.png)
-
-## ESP8266 Hardware setup
-![BLE ESP8266](../img/OpenMQTTgateway_ESP8266_Addon_BT.png)
-
-The implementation with the HM10 module would not have been possible without the work of [Martin Currey]( http://www.martyncurrey.com), thanks!
+For Arduino and ESP8266, we previously used HM10, this module is no longer supported by OpenMQTTGateway, prefer an ESP32.

--- a/docs/upload/web-install.md
+++ b/docs/upload/web-install.md
@@ -53,7 +53,6 @@ The table below describes the libraries and the modules of each board configurat
 |esp32dev-ble-datatest|ESP32 dev board|Default BLE gateway with additional servicedata, manufacturerdata and service uuid for analysing decoding issues|-|-|X|-|
 |**ESP8266**|
 |nodemcuv2-2g|ESP8266 board|SMS gateway, need A6/A7 GSM module|-|-|-|-|
-|nodemcuv2-ble|ESP8266 board|BLE gateway, need HM10 Module|-|-|X|-|
 |nodemcuv2-ir|ESP8266 board|Infrared gateway using [IRremoteESP8266](https://github.com/crankyoldgit/IRremoteESP8266)|-|X|-|-|
 |nodemcuv2-rf-cc1101|ESP8266 board|RF gateway using [RCSwitch](https://github.com/1technophile/rc-switch) library, need CC1101|X|-|-|-|
 |nodemcuv2-rf|ESP8266 board|RF gateway using [RCSwitch](https://github.com/1technophile/rc-switch) library|X|-|-|-|

--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -33,7 +33,7 @@ iOS version >=10 devices advertise without an extra app MAC address, nevertheles
 
 
 ## Receiving signals from BLE devices Mi Flora, Mi jia, LYWDS02, LYWSD03MMC, ClearGrass, Mi scale and [many more](https://compatible.openmqttgateway.com/index.php/devices/ble-devices/)
-So as to receive BLE sensors data you need either a simple ESP32 either an ESP8266/Arduino + HM10/11 with firmware >= v601
+So as to receive BLE sensors data you need a simple ESP32
 The mi flora supported firmware is >3.1.8
 
 Verify that your sensor is working with the App and update it with the last software version.
@@ -59,11 +59,10 @@ The infos will appear like this on your MQTT broker:
 
 `home/OpenMQTTGateway/BTtoMQTT/4C33A6603C79 {"hum":"52.6","tempc":"19.2","tempf":"66.56"}`
 
-More info are available on [my blog](https://1technophile.blogspot.fr/2017/11/mi-flora-integration-to-openmqttgateway.html)  (especially about how it was implemented with HM10)
+More info are available on [my blog](https://1technophile.blogspot.fr/2017/11/mi-flora-integration-to-openmqttgateway.html) 
 
 ::: tip
-The HM10 module doesn't read enough information (servicedata UUID is missing) to support Mi Scale and Mi Band. They are supported nevertheless with ESP32.
-OpenMQTTGateway publish the servicedata field of your BLE devices, with HM10 this field can be longer compared to ESP32 if the device is not recognised.
+OpenMQTTGateway publish the servicedata field of your BLE devices.
 :::
 
 ## Setting a white or black list
@@ -352,10 +351,3 @@ Response (assuming success):
   "state":"on"
 }
 ```
-
-## Other
-
-To check your hm10 firmware version upload a serial sketch to the nodemcu (this will enable communication directly with the hm10) and launch the command:
-`AT+VERR?`
-
-More info about HM-10 is [available here](http://www.martyncurrey.com/hm-10-bluetooth-4ble-modules/)

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -478,7 +478,7 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #  define STRTO_UL_ULL       strtoul
 #endif
 
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
 // variable to avoid duplicates
 #  ifndef time_avoid_duplicate
 #    define time_avoid_duplicate 3000 // if you want to avoid duplicate MQTT message received set this to > 0, the value is the time in milliseconds during which we don't publish duplicates
@@ -495,5 +495,10 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #ifndef LOG_LEVEL
 #  define LOG_LEVEL LOG_LEVEL_NOTICE
 #endif
+
+/*-----------PLACEHOLDERS FOR OLED/LCD DISPLAY--------------*/
+// The real definitions are in config_M5.h / config_HELTEC.h
+#define displayPrint(...)   // only print if not in low power mode
+#define lpDisplayPrint(...) // print in low power mode
 
 #endif

--- a/main/ZboardHeltec.ino
+++ b/main/ZboardHeltec.ino
@@ -1,0 +1,258 @@
+/*
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
+   Send and receiving command by MQTT
+
+    HELTEC ESP32 LORA - SSD1306 / Onboard 0.96-inch 128*64 dot matrix OLED display
+
+    Copyright: (c)Florian ROBERT
+
+    Contributors:
+    - 1technophile
+    - NorthernMan54
+
+    This file is part of OpenMQTTGateway.
+
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "User_config.h"
+#if defined(ZboardHELTEC)
+#  include "ArduinoLog.h"
+#  include "config_HELTEC.h"
+// #  include "heltec.h"
+
+void logToLCD(bool display) {
+  display ? Log.begin(LOG_LEVEL_LCD, &Oled) : Log.begin(LOG_LEVEL, &Serial); // Log on LCD following LOG_LEVEL_LCD
+}
+
+void setupHELTEC() {
+  Log.trace(F("Setup HELTEC Display" CR));
+  Oled.begin();
+  Log.notice(F("Setup HELTEC Display end" CR));
+
+#  if LOG_TO_LCD
+  Log.begin(LOG_LEVEL_LCD, &Oled); // Log on LCD following LOG_LEVEL_LCD
+#  endif
+}
+
+void loopHELTEC() {
+  static int previousLogLevel;
+  int currentLogLevel = Log.getLastMsgLevel();
+  if (previousLogLevel != currentLogLevel && lowpowermode != 2) {
+    switch (currentLogLevel) {
+      case 1:
+      case 2:
+        //        wakeScreen(NORMAL_LCD_BRIGHTNESS);
+        //        M5.Lcd.fillScreen(TFT_RED); // FATAL, ERROR
+        //        M5.Lcd.setTextColor(TFT_BLACK, TFT_RED);
+        break;
+      case 3:
+        //        wakeScreen(NORMAL_LCD_BRIGHTNESS);
+        //        M5.Lcd.fillScreen(TFT_ORANGE); // WARNING
+        //        M5.Lcd.setTextColor(TFT_BLACK, TFT_ORANGE);
+        break;
+      default:
+        //        wakeScreen(SLEEP_LCD_BRIGHTNESS);
+        //       M5.Lcd.fillScreen(TFT_WHITE);
+        Oled.fillScreen(WHITE);
+        Oled.drawLogo((int)OLED_WIDTH * 0.24, (int)(OLED_WIDTH / 2) - OLED_WIDTH * 0.2, (int)(OLED_HEIGHT / 2) + OLED_HEIGHT * 0.2, true, true, true, true, true, true); // Name
+        break;
+    }
+  }
+  previousLogLevel = currentLogLevel;
+}
+
+void MQTTtoHELTEC(char* topicOri, JsonObject& HELTECdata) { // json object decoding
+  if (cmpToMainTopic(topicOri, subjectMQTTtoHELTECset)) {
+    Log.trace(F("MQTTtoHELTEC json set" CR));
+    // Log display set between HELTEC lcd (true) and serial monitor (false)
+    if (HELTECdata.containsKey("log-lcd")) {
+      bool displayOnLCD = HELTECdata["log-lcd"];
+      Log.notice(F("Set lcd log: %T" CR), displayOnLCD);
+      logToLCD(displayOnLCD);
+    }
+  }
+}
+
+// Simple print methonds
+
+void heltecPrint(char* line1, char* line2, char* line3) {
+  Oled.println(line1);
+  Oled.println(line2);
+  Oled.println(line3);
+  delay(2000);
+}
+
+void heltecPrint(char* line1, char* line2) {
+  Oled.println(line1);
+  Oled.println(line2);
+  delay(2000);
+}
+
+void heltecPrint(char* line1) {
+  Oled.println(line1);
+  delay(2000);
+}
+
+// This pattern was borrowed from HardwareSerial and modified to support the ssd1306 display
+
+OledSerial Oled(0); // Not sure about this, came from Hardwareserial
+OledSerial::OledSerial(int x) {
+  pinMode(RST_OLED, OUTPUT);
+  digitalWrite(RST_OLED, LOW);
+  delay(50);
+  digitalWrite(RST_OLED, HIGH);
+
+#  if defined(WIFI_Kit_32) || defined(WIFI_LoRa_32) || defined(WIFI_LoRa_32_V2)
+  display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, GEOMETRY_128_64);
+#  elif defined(Wireless_Stick)
+  display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, GEOMETRY_64_32);
+#  endif
+} // Not sure about this, came from Hardwareserial
+
+void OledSerial::begin() {
+  // Heltec.begin(); // User OMG serial support
+  display->init();
+  display->flipScreenVertically();
+  display->setFont(ArialMT_Plain_10);
+
+  display->setColor(WHITE);
+  display->fillRect(0, 0, OLED_WIDTH, OLED_HEIGHT);
+  display->display();
+  displayIntro(OLED_WIDTH * 0.24, (OLED_WIDTH / 2) - OLED_WIDTH * 0.2, (OLED_HEIGHT / 2) + OLED_HEIGHT * 0.2);
+  display->setLogBuffer(OLED_TEXT_ROWS, OLED_TEXT_BUFFER);
+  delay(1000);
+}
+
+// Dummy virtual's from Serial
+
+int OledSerial::available(void) {
+}
+
+int OledSerial::peek(void) {
+}
+
+int OledSerial::read(void) {
+}
+
+void OledSerial::flush(void) {
+}
+
+void OledSerial::fillScreen(OLEDDISPLAY_COLOR color) {
+  display->clear();
+  display->setColor(color);
+  display->fillRect(0, 0, OLED_WIDTH, OLED_HEIGHT);
+}
+
+size_t OledSerial::write(uint8_t c) {
+  display->clear();
+  display->setColor(WHITE);
+  display->setFont(ArialMT_Plain_10);
+
+  display->write((char)c);
+  display->drawLogBuffer(0, 0);
+  display->display();
+  return 1;
+}
+
+size_t OledSerial::write(const uint8_t* buffer, size_t size) {
+  display->clear();
+  display->setColor(WHITE);
+  display->setFont(ArialMT_Plain_10);
+  while (size) {
+    display->write((char)*buffer++);
+    size--;
+  }
+  display->drawLogBuffer(0, 0);
+  display->display();
+  return size;
+}
+
+/*
+Display OpenMQTTGateway logo - borrowed from ZboardM5.ino and tweaked for ssd1306 display ( removed color and tweaked size/location )
+*/
+
+void OledSerial::displayIntro(int scale, int displayWidth, int displayHeight) {
+  drawLogo(scale, displayWidth, displayHeight, false, true, false, false, false, false); // Circle 2
+  drawLogo(scale, displayWidth, displayHeight, false, false, true, false, false, false); // Circle 3
+  drawLogo(scale, displayWidth, displayHeight, false, true, true, true, false, false); // Line 1
+  drawLogo(scale, displayWidth, displayHeight, false, true, true, false, true, false); // Line 2
+  drawLogo(scale, displayWidth, displayHeight, true, true, true, true, true, false); // Circle 1
+  drawLogo(scale, displayWidth, displayHeight, true, true, true, true, true, true); // Name
+}
+
+void OledSerial::drawLogo(int logoSize, int circle1X, int circle1Y, bool circle1, bool circle2, bool circle3, bool line1, bool line2, bool name) {
+  int circle1T = logoSize / 15;
+  int circle2T = logoSize / 25;
+  int circle3T = logoSize / 30;
+
+  int circle3Y = circle1Y - (logoSize * 1.2);
+  int circle3X = circle1X - (logoSize * 0.13);
+  int circle2X = circle1X - (logoSize * 1.05);
+  int circle2Y = circle1Y - (logoSize * 0.8);
+
+  if (line1) {
+    display->setColor(BLACK);
+    display->drawLine(circle1X - 2, circle1Y, circle2X - 2, circle2Y);
+    display->drawLine(circle1X - 1, circle1Y, circle2X - 1, circle2Y);
+    display->drawLine(circle1X, circle1Y, circle2X, circle2Y);
+    display->drawLine(circle1X + 1, circle1Y, circle2X + 1, circle2Y);
+    display->drawLine(circle1X + 2, circle1Y, circle2X + 2, circle2Y);
+    display->setColor(WHITE);
+    display->fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T * 2); // , WHITE);
+  }
+  if (line2) {
+    display->setColor(BLACK);
+    display->drawLine(circle1X - 2, circle1Y, circle3X - 2, circle3Y);
+    display->drawLine(circle1X - 1, circle1Y, circle3X - 1, circle3Y);
+    display->drawLine(circle1X, circle1Y, circle3X, circle3Y);
+    display->drawLine(circle1X + 1, circle1Y, circle3X + 1, circle3Y);
+    display->setColor(WHITE);
+    display->fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T * 2); // , WHITE);
+  }
+  if (circle1) {
+    display->setColor(WHITE);
+    display->fillCircle(circle1X, circle1Y, logoSize / 2); // , WHITE);
+    display->setColor(BLACK);
+    display->fillCircle(circle1X, circle1Y, logoSize / 2 - circle1T); // , TFT_GREEN);
+    display->setColor(WHITE);
+    display->fillCircle(circle1X, circle1Y, logoSize / 2 - circle1T * 2); // , WHITE);
+  }
+  if (circle2) {
+    display->setColor(WHITE);
+    display->fillCircle(circle2X, circle2Y, logoSize / 3); // , WHITE);
+    display->setColor(BLACK);
+    display->fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T); // , TFT_ORANGE);
+    display->setColor(WHITE);
+    display->fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T * 2); // , WHITE);
+  }
+  if (circle3) {
+    display->setColor(WHITE);
+    display->fillCircle(circle3X, circle3Y, logoSize / 4); // , WHITE);
+    display->setColor(BLACK);
+    display->fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T); // , TFT_PINK);
+    display->setColor(WHITE);
+    display->fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T * 2); // , WHITE);
+  }
+  if (name) {
+    display->setColor(BLACK);
+    display->drawString(circle1X + (circle1X * 0.27), circle1Y, "penMQTTGateway");
+  }
+  display->display();
+  delay(50);
+}
+
+#endif

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -187,7 +187,10 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       int msgLength = rf.stringToPulseTrain(raw, codes, MAXPULSESTREAMLENGTH);
       if (msgLength > 0) {
 #  ifdef ZradioCC1101
-        ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
+        disableActiveReceiver();
+        ELECHOUSE_cc1101.Init();
+        pinMode(RF_EMITTER_GPIO, OUTPUT);
+        ELECHOUSE_cc1101.SetTx(receiveMhz); // set Transmit on
         rf.disableReceiver();
 #  endif
         rf.sendPulseTrain(codes, msgLength, repeats);
@@ -215,7 +218,10 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
     if (message && protocol) {
       Log.trace(F("MQTTtoPilight msg & protocol ok" CR));
 #  ifdef ZradioCC1101
-      ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
+      disableActiveReceiver();
+      ELECHOUSE_cc1101.Init();
+      pinMode(RF_EMITTER_GPIO, OUTPUT);
+      ELECHOUSE_cc1101.SetTx(receiveMhz); // set Transmit on
       rf.disableReceiver();
 #  endif
       int msgLength = rf.send(protocol, message);
@@ -287,6 +293,7 @@ extern void enablePilightReceive() {
 #  endif
 
 #  ifdef ZradioCC1101
+  ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
   rf.setCallback(pilightCallback);

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -176,6 +176,7 @@ void RFtoMQTT() {
 #  if simpleReceiving
 void MQTTtoRF(char* topicOri, char* datacallback) {
 #    ifdef ZradioCC1101 // set Receive off and Transmitt on
+  disableActiveReceiver();
   ELECHOUSE_cc1101.SetTx(receiveMhz);
 #    endif
   mySwitch.disableReceive();
@@ -251,6 +252,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
 #    ifdef ZradioCC1101 // set Receive off and Transmitt on
       float trMhz = RFdata["mhz"] | CC1101_FREQUENCY;
       if (validFrequency((int)trMhz)) {
+        disableActiveReceiver();
         ELECHOUSE_cc1101.SetTx(trMhz);
         Log.notice(F("Transmit mhz: %F" CR), trMhz);
       }
@@ -321,6 +323,7 @@ void enableRFReceive() {
 #  endif
 
 #  ifdef ZradioCC1101 // set Receive on and Transmitt off
+  ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz);
 #  endif
   mySwitch.disableTransmit();

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -152,6 +152,9 @@ void rf2Callback(unsigned int period, unsigned long address, unsigned long group
 void MQTTtoRF2(char* topicOri, char* datacallback) {
 #    ifdef ZradioCC1101
   NewRemoteReceiver::disable();
+  disableActiveReceiver();
+  ELECHOUSE_cc1101.Init();
+  pinMode(RF_EMITTER_GPIO, OUTPUT);
   ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
 #    endif
 
@@ -268,6 +271,9 @@ void MQTTtoRF2(char* topicOri, JsonObject& RF2data) { // json object decoding
     if (boolSWITCHTYPE != 99) {
 #    ifdef ZradioCC1101
       NewRemoteReceiver::disable();
+      disableActiveReceiver();
+      ELECHOUSE_cc1101.Init();
+      pinMode(RF_EMITTER_GPIO, OUTPUT);
       ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
 #    endif
       Log.trace(F("MQTTtoRF2 switch type ok" CR));
@@ -356,10 +362,11 @@ void enableRF2Receive() {
   disableRFReceive();
 #  endif
 
-  NewRemoteReceiver::init(RF_RECEIVER_GPIO, 2, rf2Callback);
 #  ifdef ZradioCC1101
+  ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
+  NewRemoteReceiver::init(RF_RECEIVER_GPIO, 2, rf2Callback);
 }
 
 #endif

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -28,17 +28,12 @@
 */
 #include "User_config.h"
 #ifdef ZgatewayRTL_433
-#  ifndef ZradioCC1101
-#    error "CC1101 is the only supported receiver module for RTL_433 and needs to be enabled."
-#  endif
 
 #  include <rtl_433_ESP.h>
 
 char messageBuffer[JSON_MSG_BUFFER];
 
-rtl_433_ESP rtl_433(-1); // use -1 to disable transmitter
-
-#  include <ELECHOUSE_CC1101_SRC_DRV.h>
+rtl_433_ESP rtl_433(-1);
 
 void rtl_433_Callback(char* message) {
   DynamicJsonDocument jsonBuffer2(JSON_MSG_BUFFER);
@@ -49,6 +44,7 @@ void rtl_433_Callback(char* message) {
     return;
   }
 
+  unsigned long MQTTvalue = (int)RFrtl_433_ESPdata["id"] + round(RFrtl_433_ESPdata["temperature_C"]);
   String topic = String(subjectRTL_433toMQTT);
 #  if valueAsATopic
   String model = RFrtl_433_ESPdata["model"];
@@ -61,14 +57,16 @@ void rtl_433_Callback(char* message) {
   }
 #  endif
 
-  pub((char*)topic.c_str(), RFrtl_433_ESPdata);
+  if (!isAduplicateSignal(MQTTvalue)) {
+    pub((char*)topic.c_str(), RFrtl_433_ESPdata);
+    storeSignalValue(MQTTvalue);
+  }
 #  ifdef MEMORY_DEBUG
   Log.trace(F("Post rtl_433_Callback: %d" CR), ESP.getFreeHeap());
 #  endif
 }
 
 void setupRTL_433() {
-  rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
   rtl_433.setCallback(rtl_433_Callback, messageBuffer, JSON_MSG_BUFFER);
   Log.trace(F("ZgatewayRTL_433 command topic: %s%s%s" CR), mqtt_topic, gateway_name, subjectMQTTtoRTL_433);
   Log.notice(F("ZgatewayRTL_433 setup done " CR));
@@ -93,16 +91,24 @@ extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
       success = true;
     }
     if (RTLdata.containsKey("rssi")) {
-      int minimumRssi = RTLdata["rssi"] | 0;
-      Log.notice(F("RTL_433 minimum RSSI: %d" CR), minimumRssi);
-      rtl_433.setMinimumRSSI(minimumRssi);
+      int rssiThreshold = RTLdata["rssi"] | 0;
+      Log.notice(F("RTL_433 RSSI Threshold Delta: %d " CR), rssiThreshold);
+      rtl_433.setRSSIThreshold(rssiThreshold);
       success = true;
     }
+#  if defined(RF_SX1276) || defined(RF_SX1278)
+    if (RTLdata.containsKey("ookThreshold")) {
+      int newOokThreshold = RTLdata["ookThreshold"] | 0;
+      Log.notice(F("RTL_433 ookThreshold %d" CR), newOokThreshold);
+      rtl_433.setOOKThreshold(newOokThreshold);
+      success = true;
+    }
+#  endif
     if (RTLdata.containsKey("debug")) {
       int debug = RTLdata["debug"] | -1;
       Log.notice(F("RTL_433 set debug: %d" CR), debug);
-      rtl_433.setDebug(debug);
-      rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
+      // rtl_433.setDebug(debug);
+      rtl_433.initReceiver(RF_MODULE_RECEIVER_GPIO, receiveMhz);
       success = true;
     }
     if (RTLdata.containsKey("status")) {
@@ -131,9 +137,9 @@ extern void enableRTLreceive() {
 #  ifdef ZgatewayPilight
   disablePilightReceive();
 #  endif
-  ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
-  rtl_433.enableReceiver(RF_RECEIVER_GPIO);
-  pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
+
+  rtl_433.initReceiver(RF_MODULE_RECEIVER_GPIO, receiveMhz);
+  rtl_433.enableReceiver(RF_MODULE_RECEIVER_GPIO);
 }
 
 extern void disableRTLreceive() {
@@ -142,8 +148,12 @@ extern void disableRTLreceive() {
   rtl_433.disableReceiver();
 }
 
-extern int getRTLMinimumRSSI() {
-  return rtl_433.minimumRssi;
+extern int getRTLrssiThreshold() {
+  return rtl_433.rssiThreshold;
+}
+
+extern int getRTLAverageRSSI() {
+  return rtl_433.averageRssi;
 }
 
 extern int getRTLCurrentRSSI() {
@@ -153,5 +163,11 @@ extern int getRTLCurrentRSSI() {
 extern int getRTLMessageCount() {
   return rtl_433.messageCount;
 }
+
+#  if defined(RF_SX1276) || defined(RF_SX1278)
+extern int getOOKThresh() {
+  return rtl_433.OokFixedThreshold;
+}
+#  endif
 
 #endif

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -333,7 +333,8 @@ void createDiscovery(const char* sensor_type,
     }
 
     if (device_name[0]) {
-      device["name"] = device_name;
+      // generate unique device name by adding the second half of the device_mac
+      device["name"] = device_name + String("-") + String(device_mac + 6);
     }
 
     device["via_device"] = String(gateway_name); //device name of the board
@@ -399,6 +400,7 @@ void pubMqttDiscovery() {
 #    endif
 #  endif
 #  ifdef ESP32
+#    ifdef ZgatewayBT
   createDiscovery("sensor", //set Type
                   subjectSYStoMQTT, "SYS: Low Power Mode", (char*)getUniqueId("lowpowermode", "").c_str(), //set state_topic,name,uniqueId
                   "", "", "{{ value_json.lowpowermode }}", //set availability_topic,device_class,value_template,
@@ -408,6 +410,7 @@ void pubMqttDiscovery() {
                   "", "", "", "", false, // device name, device manufacturer, device model, device MAC
                   stateClassNone //State Class
   );
+#    endif
 #    if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5TOUGH)
   createDiscovery("sensor", //set Type
                   subjectSYStoMQTT, "SYS: Bat voltage", (char*)getUniqueId("m5batvoltage", "").c_str(), //set state_topic,name,uniqueId

--- a/main/config_HELTEC.h
+++ b/main/config_HELTEC.h
@@ -1,0 +1,116 @@
+/*  
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
+   Send and receiving command by MQTT
+
+    HELTEC ESP32 LORA - SSD1306 / Onboard 0.96-inch 128*64 dot matrix OLED display
+
+    Copyright: (c)Florian ROBERT
+
+    Contributors:
+    - 1technophile
+    - NorthernMan54
+
+    This file is part of OpenMQTTGateway.
+
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef config_HELTEC_h
+#define config_HELTEC_h
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "SSD1306Wire.h"
+
+#ifdef ZboardHELTEC
+#  define OLED_WIDTH       128
+#  define OLED_HEIGHT      64
+#  define OLED_TEXT_BUFFER 1000
+#  define OLED_TEXT_ROWS   5
+#endif
+
+extern void setupHELTEC();
+extern void loopHELTEC();
+size_t OledPrint(String msg);
+
+/*-------------------DEFINE LOG LEVEL----------------------*/
+#ifndef LOG_LEVEL_LCD
+#  define LOG_LEVEL_LCD LOG_LEVEL_WARNING // Default to only display Notice level messages
+#endif
+#ifndef LOG_TO_LCD
+#  define LOG_TO_LCD false // Default to not display log messages on display
+#endif
+/*-------------------DEFINE MQTT TOPIC FOR CONFIG----------------------*/
+#define subjectMQTTtoHELTECset "/commands/MQTTtoHELTEC/config"
+
+// Simple construct for displaying message in lcd and oled displays
+
+#define displayPrint(...) \
+  if (lowpowermode < 2) heltecPrint(__VA_ARGS__) // only print if not in low power mode
+#define lpDisplayPrint(...) heltecPrint(__VA_ARGS__) // print in low power mode
+
+void heltecPrint(char*, char*, char*);
+void heltecPrint(char*, char*);
+void heltecPrint(char*);
+
+// This pattern was borrowed from HardwareSerial and modified to support the ssd1306 display
+
+class OledSerial : public Stream {
+private:
+  void displayIntro(int scale, int displayWidth, int displayHeight);
+
+public:
+  OledSerial(int);
+  void begin();
+  void drawLogo(int logoSize, int circle1X, int circle1Y, bool circle1, bool circle2, bool circle3, bool line1, bool line2, bool name);
+
+  SSD1306Wire* display;
+
+  int available(void); // Dummy functions
+  int peek(void); // Dummy functions
+  int read(void); // Dummy functions
+  void flush(void); // Dummy functions
+
+  void fillScreen(OLEDDISPLAY_COLOR); // fillScreen display and set color
+
+  size_t write(uint8_t);
+  size_t write(const uint8_t* buffer, size_t size);
+  inline size_t write(const char* buffer, size_t size) {
+    return write((uint8_t*)buffer, size);
+  }
+  inline size_t write(const char* s) {
+    return write((uint8_t*)s, strlen(s));
+  }
+  inline size_t write(unsigned long n) {
+    return write((uint8_t)n);
+  }
+  inline size_t write(long n) {
+    return write((uint8_t)n);
+  }
+  inline size_t write(unsigned int n) {
+    return write((uint8_t)n);
+  }
+  inline size_t write(int n) {
+    return write((uint8_t)n);
+  }
+
+protected:
+};
+
+extern OledSerial Oled;
+
+#endif

--- a/main/config_M5.h
+++ b/main/config_M5.h
@@ -65,4 +65,14 @@ extern void loopM5();
 /*-------------------DEFINE MQTT TOPIC FOR CONFIG----------------------*/
 #define subjectMQTTtoM5set "/commands/MQTTtoM5/config"
 
+// Simple print macro
+
+// Simple construct for displaying message in lcd and oled displays
+
+#define displayPrint(...) \
+  if (lowpowermode < 2) M5Print(__VA_ARGS__) // only print if not in low power mode
+#define lpDisplayPrint(...) M5Print(__VA_ARGS__) // print in low power mode
+
+void M5Print(char*, char* = "", char* = "");
+
 #endif

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -261,6 +261,37 @@ void enableActiveReceiver(bool isBoot) {
   }
   currentReceiver = activeReceiver;
 }
+
+void disableActiveReceiver() {
+  Log.trace(F("disableActiveReceiver: %d" CR), activeReceiver);
+  switch (activeReceiver) {
+#  ifdef ZgatewayPilight
+    case ACTIVE_PILIGHT:
+      disablePilightReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRF
+    case ACTIVE_RF:
+      disableRFReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRTL_433
+    case ACTIVE_RTL:
+      disableRTLreceive();
+      break;
+#  endif
+#  ifdef ZgatewayRF2
+    case ACTIVE_RF2:
+      disableRF2Receive();
+      break;
+#  endif
+#  ifndef ARDUINO_AVR_UNO // Space issues with the UNO
+    default:
+      Log.error(F("ERROR: unsupported receiver %d" CR), activeReceiver);
+#  endif
+  }
+}
+
 #endif
 
 #endif

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -63,13 +63,9 @@ extern void setupRTL_433();
 extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata);
 extern void enableRTLreceive();
 extern void disableRTLreceive();
-extern int getRTLMinimumRSSI();
+extern int getRTLrssiThreshold();
 extern int getRTLCurrentRSSI();
 extern int getRTLMessageCount();
-/**
- * minimumRssi minimum RSSI value to enable receiver
- */
-int minimumRssi = 0;
 #endif
 /*-------------------RF topics & parameters----------------------*/
 //433Mhz MQTT Subjects and keys
@@ -118,7 +114,7 @@ int minimumRssi = 0;
 #  define CC1101_FREQUENCY 433.92
 #endif
 // Allow ZGatewayRF Module to change receive frequency of CC1101 Transceiver module
-#ifdef ZradioCC1101
+#if defined(ZradioCC1101) || defined(ZradioSX127x)
 float receiveMhz = CC1101_FREQUENCY;
 #endif
 
@@ -164,7 +160,7 @@ int activeReceiver = 0;
 #  define ACTIVE_RTL      3
 #  define ACTIVE_RF2      4
 
-#  ifdef ZradioCC1101
+#  if defined(ZradioCC1101) || defined(ZradioSX127x)
 bool validFrequency(float mhz) {
   //  CC1101 valid frequencies 300-348 MHZ, 387-464MHZ and 779-928MHZ.
   if (mhz >= 300 && mhz <= 348)
@@ -265,6 +261,37 @@ void enableActiveReceiver(bool isBoot) {
   }
   currentReceiver = activeReceiver;
 }
+
+void disableActiveReceiver() {
+  Log.trace(F("disableActiveReceiver: %d" CR), activeReceiver);
+  switch (activeReceiver) {
+#  ifdef ZgatewayPilight
+    case ACTIVE_PILIGHT:
+      disablePilightReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRF
+    case ACTIVE_RF:
+      disableRFReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRTL_433
+    case ACTIVE_RTL:
+      disableRTLreceive();
+      break;
+#  endif
+#  ifdef ZgatewayRF2
+    case ACTIVE_RF2:
+      disableRF2Receive();
+      break;
+#  endif
+#  ifndef ARDUINO_AVR_UNO // Space issues with the UNO
+    default:
+      Log.error(F("ERROR: unsupported receiver %d" CR), activeReceiver);
+#  endif
+  }
+}
+
 #endif
 
 #endif

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -63,13 +63,9 @@ extern void setupRTL_433();
 extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata);
 extern void enableRTLreceive();
 extern void disableRTLreceive();
-extern int getRTLMinimumRSSI();
+extern int getRTLrssiThreshold();
 extern int getRTLCurrentRSSI();
 extern int getRTLMessageCount();
-/**
- * minimumRssi minimum RSSI value to enable receiver
- */
-int minimumRssi = 0;
 #endif
 /*-------------------RF topics & parameters----------------------*/
 //433Mhz MQTT Subjects and keys
@@ -118,7 +114,7 @@ int minimumRssi = 0;
 #  define CC1101_FREQUENCY 433.92
 #endif
 // Allow ZGatewayRF Module to change receive frequency of CC1101 Transceiver module
-#ifdef ZradioCC1101
+#if defined(ZradioCC1101) || defined(ZradioSX127x)
 float receiveMhz = CC1101_FREQUENCY;
 #endif
 
@@ -164,7 +160,7 @@ int activeReceiver = 0;
 #  define ACTIVE_RTL      3
 #  define ACTIVE_RF2      4
 
-#  ifdef ZradioCC1101
+#  if defined(ZradioCC1101) || defined(ZradioSX127x)
 bool validFrequency(float mhz) {
   //  CC1101 valid frequencies 300-348 MHZ, 387-464MHZ and 779-928MHZ.
   if (mhz >= 300 && mhz <= 348)

--- a/main/main.ino
+++ b/main/main.ino
@@ -1609,14 +1609,18 @@ void stateMeasures() {
 #  if defined(ZgatewayRF) || defined(ZgatewayPilight) || defined(ZgatewayRTL_433) || defined(ZgatewayRF2)
   SYSdata["actRec"] = (int)activeReceiver;
 #  endif
-#  ifdef ZradioCC1101
+#  if defined(ZradioCC1101) || defined(ZradioSX127x)
   SYSdata["mhz"] = (float)receiveMhz;
 #  endif
 #  if defined(ZgatewayRTL_433)
   if (activeReceiver == ACTIVE_RTL) {
-    SYSdata["RTLminRssi"] = (int)getRTLMinimumRSSI();
+    SYSdata["RTLRssiThresh"] = (int)getRTLrssiThreshold();
     SYSdata["RTLRssi"] = (int)getRTLCurrentRSSI();
+    SYSdata["RTLAVGRssi"] = (int)getRTLAverageRSSI();
     SYSdata["RTLCnt"] = (int)getRTLMessageCount();
+#    ifdef ZradioSX127x
+    SYSdata["RTLOOKThresh"] = (int)getOOKThresh();
+#    endif
   }
 #  endif
   SYSdata["modules"] = modules;

--- a/main/main.ino
+++ b/main/main.ino
@@ -28,7 +28,7 @@
 #include "User_config.h"
 
 // Macros and structure to enable the duplicates removing on the following gateways
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
 // array to store previous received RFs, IRs codes and their timestamps
 struct ReceivedSignal {
   SIGNAL_SIZE_UL_ULL value;
@@ -153,6 +153,9 @@ struct GfSun2000Data {};
 #if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
 #  include "config_M5.h"
 #endif
+#if defined(ZboardHELTEC)
+#  include "config_HELTEC.h"
+#endif
 #if defined(ZgatewayRS232)
 #  include "config_RS232.h"
 #endif
@@ -257,7 +260,7 @@ void revert_hex_data(const char* in, char* out, int l) {
   out[l - 1] = '\0';
 }
 
-/** 
+/**
  * Retrieve an unsigned long value from a char array extract representing hexadecimal data, reversed or not,
  * This value can represent a negative value if canBeNegative is set to true
  */
@@ -292,10 +295,10 @@ bool to_bool(String const& s) { // thanks Chris Jester-Young from stackoverflow
 
 /**
  * @brief Publish the payload on default MQTT topic.
- * 
+ *
  * @param topicori suffix to add on default MQTT Topic
  * @param payload  the message to sends
- * @param retainFlag true if you what a retain 
+ * @param retainFlag true if you what a retain
  */
 void pub(const char* topicori, const char* payload, bool retainFlag) {
   String topic = String(mqtt_topic) + String(gateway_name) + String(topicori);
@@ -304,7 +307,7 @@ void pub(const char* topicori, const char* payload, bool retainFlag) {
 
 /**
  * @brief Publish the payload on default MQTT topic
- * 
+ *
  * @param topicori suffix to add on default MQTT Topic
  * @param data The Json Object that rapresent the message
  */
@@ -360,7 +363,7 @@ void pub(const char* topicori, JsonObject& data) {
 
 /**
  * @brief Publish the payload on default MQTT topic
- * 
+ *
  * @param topicori suffix to add on default MQTT Topic
  * @param payload the message to sends
  */
@@ -371,10 +374,10 @@ void pub(const char* topicori, const char* payload) {
 
 /**
  * @brief Publish the payload on the topic with a retantion
- * 
+ *
  * @param topic  The topic where to publish
  * @param data   The Json Object that rapresent the message
- * @param retain true if you what a retain 
+ * @param retain true if you what a retain
  */
 void pub_custom_topic(const char* topic, JsonObject& data, boolean retain) {
   String buffer = "";
@@ -384,7 +387,7 @@ void pub_custom_topic(const char* topic, JsonObject& data, boolean retain) {
 
 /**
  * @brief Low level MQTT functions without retain
- * 
+ *
  * @param topic  the topic
  * @param payload  the payload
  */
@@ -394,8 +397,8 @@ void pubMQTT(const char* topic, const char* payload) {
 
 /**
  * @brief Very Low level MQTT functions with retain Flag
- * 
- * @param topic the topic 
+ *
+ * @param topic the topic
  * @param payload the payload
  * @param retainFlag  true if retain the retain Flag
  */
@@ -524,10 +527,8 @@ void connectMQTT() {
 #else
   if (client.connect(gateway_name, mqtt_user, mqtt_pass, topic, will_QoS, will_Retain, will_Message)) {
 #endif
-#if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-    if (lowpowermode < 2)
-      M5Print("MQTT connected", "", "");
-#endif
+
+    displayPrint("MQTT connected");
     Log.notice(F("Connected to broker" CR));
     failure_number_mqtt = 0;
     // Once connected, publish an announcement...
@@ -620,6 +621,10 @@ void setup() {
   preferences.end();
 #    if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
   setupM5();
+#    endif
+#    if defined(ZboardHELTEC)
+  setupHELTEC();
+  modules.add(ZboardHELTEC);
 #    endif
   Log.notice(F("OpenMQTTGateway Version: " OMG_VERSION CR));
 #  endif
@@ -873,9 +878,7 @@ void setOTA() {
 #  if defined(ZgatewayBT) && defined(ESP32)
     stopProcessing();
 #  endif
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-    M5Print("OTA in progress", "", "");
-#  endif
+    lpDisplayPrint("OTA in progress");
   });
   ArduinoOTA.onEnd([]() {
     Log.trace(F("\nOTA done" CR));
@@ -884,9 +887,7 @@ void setOTA() {
 #  if defined(ZgatewayBT) && defined(ESP32)
     startProcessing();
 #  endif
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-    M5Print("OTA done", "", "");
-#  endif
+    lpDisplayPrint("OTA done");
   });
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
     Log.trace(F("Progress: %u%%\r" CR), (progress / (total / 100)));
@@ -1200,9 +1201,7 @@ void setup_wifimanager(bool reset_settings) {
   {
 #  ifdef ESP32
     if (lowpowermode < 2) {
-#    if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-      M5Print("Connect your phone to WIFI AP:", WifiManager_ssid, WifiManager_password);
-#    endif
+      displayPrint("Connect your phone to WIFI AP:", WifiManager_ssid, WifiManager_password);
     } else { // in case of low power mode we put the ESP to sleep again if we didn't get connected (typical in case the wifi is down)
 #    ifdef ZgatewayBT
       lowPowerESP32();
@@ -1227,10 +1226,7 @@ void setup_wifimanager(bool reset_settings) {
     digitalWrite(LED_INFO, !LED_INFO_ON);
   }
 
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-  if (lowpowermode < 2)
-    M5Print("Wifi connected", "", "");
-#  endif
+  displayPrint("Wifi connected");
 
   if (shouldSaveConfig) {
     //read updated parameters
@@ -1525,9 +1521,12 @@ void loop() {
 #if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
   loopM5();
 #endif
+#if defined(ZboardHELTEC)
+  loopHELTEC();
+#endif
 }
 
-/** 
+/**
  * Calculate uptime and take into account the millis() rollover
  */
 unsigned long uptime() {
@@ -1628,8 +1627,8 @@ void stateMeasures() {
 }
 #endif
 
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
-/** 
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
+/**
  * Store signal values from RF, IR, SRFB or Weather stations so as to avoid duplicates
  */
 void storeSignalValue(SIGNAL_SIZE_UL_ULL MQTTvalue) {
@@ -1649,7 +1648,7 @@ void storeSignalValue(SIGNAL_SIZE_UL_ULL MQTTvalue) {
   }
 }
 
-/** 
+/**
  * get oldest time index from the values array from RF, IR, SRFB or Weather stations so as to avoid duplicates
  */
 int getMin() {
@@ -1664,7 +1663,7 @@ int getMin() {
   return minindex;
 }
 
-/** 
+/**
  * Check if signal values from RF, IR, SRFB or Weather stations are duplicates
  */
 bool isAduplicateSignal(SIGNAL_SIZE_UL_ULL value) {
@@ -1673,7 +1672,7 @@ bool isAduplicateSignal(SIGNAL_SIZE_UL_ULL value) {
     if (receivedSignal[i].value == value) {
       unsigned long now = millis();
       if (now - receivedSignal[i].time < time_avoid_duplicate) { // change
-        Log.notice(F("no pub. dupl" CR));
+        Log.trace(F("no pub. dupl" CR));
         return true;
       }
     }
@@ -1745,6 +1744,9 @@ void receivingMQTT(char* topicOri, char* datacallback) {
 #  endif
 #  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
     MQTTtoM5(topicOri, jsondata);
+#  endif
+#  if defined(ZboardHELTEC)
+    MQTTtoHELTEC(topicOri, jsondata);
 #  endif
 #  ifdef ZactuatorONOFF
     MQTTtoONOFF(topicOri, jsondata);

--- a/main/main.ino
+++ b/main/main.ino
@@ -28,7 +28,7 @@
 #include "User_config.h"
 
 // Macros and structure to enable the duplicates removing on the following gateways
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
 // array to store previous received RFs, IRs codes and their timestamps
 struct ReceivedSignal {
   SIGNAL_SIZE_UL_ULL value;
@@ -153,6 +153,9 @@ struct GfSun2000Data {};
 #if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
 #  include "config_M5.h"
 #endif
+#if defined(ZboardHELTEC)
+#  include "config_HELTEC.h"
+#endif
 #if defined(ZgatewayRS232)
 #  include "config_RS232.h"
 #endif
@@ -257,7 +260,7 @@ void revert_hex_data(const char* in, char* out, int l) {
   out[l - 1] = '\0';
 }
 
-/** 
+/**
  * Retrieve an unsigned long value from a char array extract representing hexadecimal data, reversed or not,
  * This value can represent a negative value if canBeNegative is set to true
  */
@@ -292,10 +295,10 @@ bool to_bool(String const& s) { // thanks Chris Jester-Young from stackoverflow
 
 /**
  * @brief Publish the payload on default MQTT topic.
- * 
+ *
  * @param topicori suffix to add on default MQTT Topic
  * @param payload  the message to sends
- * @param retainFlag true if you what a retain 
+ * @param retainFlag true if you what a retain
  */
 void pub(const char* topicori, const char* payload, bool retainFlag) {
   String topic = String(mqtt_topic) + String(gateway_name) + String(topicori);
@@ -304,7 +307,7 @@ void pub(const char* topicori, const char* payload, bool retainFlag) {
 
 /**
  * @brief Publish the payload on default MQTT topic
- * 
+ *
  * @param topicori suffix to add on default MQTT Topic
  * @param data The Json Object that rapresent the message
  */
@@ -360,7 +363,7 @@ void pub(const char* topicori, JsonObject& data) {
 
 /**
  * @brief Publish the payload on default MQTT topic
- * 
+ *
  * @param topicori suffix to add on default MQTT Topic
  * @param payload the message to sends
  */
@@ -371,10 +374,10 @@ void pub(const char* topicori, const char* payload) {
 
 /**
  * @brief Publish the payload on the topic with a retantion
- * 
+ *
  * @param topic  The topic where to publish
  * @param data   The Json Object that rapresent the message
- * @param retain true if you what a retain 
+ * @param retain true if you what a retain
  */
 void pub_custom_topic(const char* topic, JsonObject& data, boolean retain) {
   String buffer = "";
@@ -384,7 +387,7 @@ void pub_custom_topic(const char* topic, JsonObject& data, boolean retain) {
 
 /**
  * @brief Low level MQTT functions without retain
- * 
+ *
  * @param topic  the topic
  * @param payload  the payload
  */
@@ -394,8 +397,8 @@ void pubMQTT(const char* topic, const char* payload) {
 
 /**
  * @brief Very Low level MQTT functions with retain Flag
- * 
- * @param topic the topic 
+ *
+ * @param topic the topic
  * @param payload the payload
  * @param retainFlag  true if retain the retain Flag
  */
@@ -524,10 +527,8 @@ void connectMQTT() {
 #else
   if (client.connect(gateway_name, mqtt_user, mqtt_pass, topic, will_QoS, will_Retain, will_Message)) {
 #endif
-#if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-    if (lowpowermode < 2)
-      M5Print("MQTT connected", "", "");
-#endif
+
+    displayPrint("MQTT connected");
     Log.notice(F("Connected to broker" CR));
     failure_number_mqtt = 0;
     // Once connected, publish an announcement...
@@ -620,6 +621,10 @@ void setup() {
   preferences.end();
 #    if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
   setupM5();
+#    endif
+#    if defined(ZboardHELTEC)
+  setupHELTEC();
+  modules.add(ZboardHELTEC);
 #    endif
   Log.notice(F("OpenMQTTGateway Version: " OMG_VERSION CR));
 #  endif
@@ -873,9 +878,7 @@ void setOTA() {
 #  if defined(ZgatewayBT) && defined(ESP32)
     stopProcessing();
 #  endif
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-    M5Print("OTA in progress", "", "");
-#  endif
+    lpDisplayPrint("OTA in progress");
   });
   ArduinoOTA.onEnd([]() {
     Log.trace(F("\nOTA done" CR));
@@ -884,9 +887,7 @@ void setOTA() {
 #  if defined(ZgatewayBT) && defined(ESP32)
     startProcessing();
 #  endif
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-    M5Print("OTA done", "", "");
-#  endif
+    lpDisplayPrint("OTA done");
   });
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
     Log.trace(F("Progress: %u%%\r" CR), (progress / (total / 100)));
@@ -1200,9 +1201,7 @@ void setup_wifimanager(bool reset_settings) {
   {
 #  ifdef ESP32
     if (lowpowermode < 2) {
-#    if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-      M5Print("Connect your phone to WIFI AP:", WifiManager_ssid, WifiManager_password);
-#    endif
+      displayPrint("Connect your phone to WIFI AP:", WifiManager_ssid, WifiManager_password);
     } else { // in case of low power mode we put the ESP to sleep again if we didn't get connected (typical in case the wifi is down)
 #    ifdef ZgatewayBT
       lowPowerESP32();
@@ -1227,10 +1226,7 @@ void setup_wifimanager(bool reset_settings) {
     digitalWrite(LED_INFO, !LED_INFO_ON);
   }
 
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
-  if (lowpowermode < 2)
-    M5Print("Wifi connected", "", "");
-#  endif
+  displayPrint("Wifi connected");
 
   if (shouldSaveConfig) {
     //read updated parameters
@@ -1525,9 +1521,12 @@ void loop() {
 #if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
   loopM5();
 #endif
+#if defined(ZboardHELTEC)
+  loopHELTEC();
+#endif
 }
 
-/** 
+/**
  * Calculate uptime and take into account the millis() rollover
  */
 unsigned long uptime() {
@@ -1609,14 +1608,18 @@ void stateMeasures() {
 #  if defined(ZgatewayRF) || defined(ZgatewayPilight) || defined(ZgatewayRTL_433) || defined(ZgatewayRF2)
   SYSdata["actRec"] = (int)activeReceiver;
 #  endif
-#  ifdef ZradioCC1101
+#  if defined(ZradioCC1101) || defined(ZradioSX127x)
   SYSdata["mhz"] = (float)receiveMhz;
 #  endif
 #  if defined(ZgatewayRTL_433)
   if (activeReceiver == ACTIVE_RTL) {
-    SYSdata["RTLminRssi"] = (int)getRTLMinimumRSSI();
+    SYSdata["RTLRssiThresh"] = (int)getRTLrssiThreshold();
     SYSdata["RTLRssi"] = (int)getRTLCurrentRSSI();
+    SYSdata["RTLAVGRssi"] = (int)getRTLAverageRSSI();
     SYSdata["RTLCnt"] = (int)getRTLMessageCount();
+#    ifdef ZradioSX127x
+    SYSdata["RTLOOKThresh"] = (int)getOOKThresh();
+#    endif
   }
 #  endif
   SYSdata["modules"] = modules;
@@ -1624,8 +1627,8 @@ void stateMeasures() {
 }
 #endif
 
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
-/** 
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
+/**
  * Store signal values from RF, IR, SRFB or Weather stations so as to avoid duplicates
  */
 void storeSignalValue(SIGNAL_SIZE_UL_ULL MQTTvalue) {
@@ -1645,7 +1648,7 @@ void storeSignalValue(SIGNAL_SIZE_UL_ULL MQTTvalue) {
   }
 }
 
-/** 
+/**
  * get oldest time index from the values array from RF, IR, SRFB or Weather stations so as to avoid duplicates
  */
 int getMin() {
@@ -1660,7 +1663,7 @@ int getMin() {
   return minindex;
 }
 
-/** 
+/**
  * Check if signal values from RF, IR, SRFB or Weather stations are duplicates
  */
 bool isAduplicateSignal(SIGNAL_SIZE_UL_ULL value) {
@@ -1669,7 +1672,7 @@ bool isAduplicateSignal(SIGNAL_SIZE_UL_ULL value) {
     if (receivedSignal[i].value == value) {
       unsigned long now = millis();
       if (now - receivedSignal[i].time < time_avoid_duplicate) { // change
-        Log.notice(F("no pub. dupl" CR));
+        Log.trace(F("no pub. dupl" CR));
         return true;
       }
     }
@@ -1741,6 +1744,9 @@ void receivingMQTT(char* topicOri, char* datacallback) {
 #  endif
 #  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
     MQTTtoM5(topicOri, jsondata);
+#  endif
+#  if defined(ZboardHELTEC)
+    MQTTtoHELTEC(topicOri, jsondata);
 #  endif
 #  ifdef ZactuatorONOFF
     MQTTtoONOFF(topicOri, jsondata);

--- a/platformio.ini
+++ b/platformio.ini
@@ -134,7 +134,7 @@ smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.7
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
 shtc3 = https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library
 somfy_remote=Somfy_Remote_Lib@0.3.0
-rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.0.4
+rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.1.2
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
 decoder = https://github.com/theengs/decoder.git#v0.8.0
@@ -757,12 +757,43 @@ lib_deps =
   ${libraries.rtl_433_ESP}
 build_flags =
   ${com-esp.build_flags}
-  '-DZradioCC1101="CC1101"'
-  '-DZgatewayRTL_433="rtl_433"'
-  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
+; *** OpenMQTTGateway Config ***
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
   '-DvalueAsATopic=true'    ; MQTT topic includes model and device
-;  '-DPUBLISH_UNPARSED=true'  ; Publish details of undecoded signals
-;  '-DRTL_DEBUG=4'            ; enable rtl_433 verbose device decode
+  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
+  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DZradioSX127x="SX127x"'
+  '-DLED_ERROR=25'
+; *** rtl_433_ESP Options ***
+;  '-DRTL_DEBUG=4'           ; rtl_433 verbose mode
+;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
+;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
+;  '-DMEMORY_DEBUG=true'   ; display memory usage information
+;  '-DDEMOD_DEBUG=true'  ; display signal debug info
+;  '-DMY_DEVICES=true'		; subset of devices
+;  '-DPUBLISH_UNPARSED=true'   ; publish unparsed signal details
+;  '-DRSSI_THRESHOLD=12'         ; Apply a delta of 12
+  '-DOOK_FIXED_THRESHOLD=0x50'  ; Inital OOK Threhold - Only for SX127X
+;  '-DAVERAGE_RSSI=5000'     ; Display RSSI floor ( Average of 5000 samples )
+;  '-DSIGNAL_RSSI=true'             ; Display during signal receive
+; *** RF Module Options ***
+  '-DRF_SX1278="SX1278"'   ; Heltec ESP 32 Module
+  '-DRF_MODULE_DIO0=26'    ; SX1276 pin DIO0
+  '-DRF_MODULE_DIO1=35'    ; SX1276 pin DIO1
+  '-DRF_MODULE_DIO2=34'    ; SX1276 pin DIO2
+  '-DRF_MODULE_RST=14'     ; pin to be used as hardware reset
+  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
+  '-DONBOARD_LED=25'          ; Onboard LED is GPIO 25 on the Heltec Board
+; *** Heltec module requires non-standard SPI Config ***
+  '-DRF_MODULE_CS=18'      ; pin to be used as chip select
+  '-DRF_MODULE_MOSI=27'
+  '-DRF_MODULE_MISO=19'
+  '-DRF_MODULE_SCK=5'
+; *** RadioLib Options ***
+;  '-DRADIOLIB_DEBUG=true'
+;  '-DRADIOLIB_VERBOSE=true'
 
 [env:esp32dev-multi_receiver]
 platform = ${com.esp32_platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,7 +73,6 @@ extra_configs =
 ;default_envs = nodemcuv2-weatherstation
 ;default_envs = nodemcuv2-ir
 ;default_envs = avatto-bakeey-ir
-;default_envs = nodemcuv2-ble
 ;default_envs = nodemcuv2-2g
 ;default_envs = nodemcuv2-all-test
 ;default_envs = nodemcuv2-fastled-test
@@ -109,7 +108,7 @@ rfWeatherStation = WeatherStationDataRx@0.3.1
 rfm69 = https://github.com/LowPowerLab/RFM69.git#2e915ea
 rfm69spi = https://github.com/lowpowerlab/spiflash.git#9c0c2b9
 rfm69_low-power = Low-Power@1.6
-dht = DHT sensor library@1.4.2
+dht = DHT sensor library@1.3.2
 unifiedsensor = Adafruit Unified Sensor@1.1.4
 tsl2561 = Adafruit TSL2561@1.0.3
 bme280 = SparkFun BME280@2.0.4
@@ -134,10 +133,11 @@ smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.7
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
 shtc3 = https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library
 somfy_remote=Somfy_Remote_Lib@0.3.0
-rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.1.2
+rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.1.3
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.8.0
+decoder = https://github.com/theengs/decoder.git#v0.9.0
+ssd1306 = thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.3.0
 
 [env]
 framework = arduino
@@ -764,36 +764,50 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
 ; *** OpenMQTTGateway Modules ***
   '-DZgatewayRTL_433="rtl_433"'
-  '-DZradioSX127x="SX127x"'
-  '-DLED_ERROR=25'
+  '-DZradioCC1101="CC1101"'
 ; *** rtl_433_ESP Options ***
 ;  '-DRTL_DEBUG=4'           ; rtl_433 verbose mode
 ;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
 ;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
 ;  '-DMEMORY_DEBUG=true'   ; display memory usage information
-;  '-DDEMOD_DEBUG=true'  ; display signal debug info
-;  '-DMY_DEVICES=true'		; subset of devices
-;  '-DPUBLISH_UNPARSED=true'   ; publish unparsed signal details
-;  '-DRSSI_THRESHOLD=12'         ; Apply a delta of 12
-  '-DOOK_FIXED_THRESHOLD=0x50'  ; Inital OOK Threhold - Only for SX127X
+  '-DDEMOD_DEBUG=true'  ; display signal debug info
+;  '-DMY_DEVICES=true'             ; subset of devices
+  '-DPUBLISH_UNPARSED=true'   ; publish unparsed signal details
+;  '-DRSSI_THRESHOLD=12'         ; Apply a delta of 12 to average RSSI level
 ;  '-DAVERAGE_RSSI=5000'     ; Display RSSI floor ( Average of 5000 samples )
-;  '-DSIGNAL_RSSI=true'             ; Display during signal receive
+  '-DSIGNAL_RSSI=true'             ; Display during signal receive
+  '-DNO_DEAF_WORKAROUND=true'
 ; *** RF Module Options ***
-  '-DRF_SX1278="SX1278"'   ; Heltec ESP 32 Module
-  '-DRF_MODULE_DIO0=26'    ; SX1276 pin DIO0
-  '-DRF_MODULE_DIO1=35'    ; SX1276 pin DIO1
-  '-DRF_MODULE_DIO2=34'    ; SX1276 pin DIO2
-  '-DRF_MODULE_RST=14'     ; pin to be used as hardware reset
-  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
-  '-DONBOARD_LED=25'          ; Onboard LED is GPIO 25 on the Heltec Board
-; *** Heltec module requires non-standard SPI Config ***
-  '-DRF_MODULE_CS=18'      ; pin to be used as chip select
-  '-DRF_MODULE_MOSI=27'
-  '-DRF_MODULE_MISO=19'
-  '-DRF_MODULE_SCK=5'
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+;  '-DRF_MODULE_CS=5'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
 ; *** RadioLib Options ***
 ;  '-DRADIOLIB_DEBUG=true'
 ;  '-DRADIOLIB_VERBOSE=true'
+
+[env:heltec-rtl_433]
+platform = ${com.esp32_platform}
+board = heltec_wifi_lora_32_V2
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ssd1306}
+  ${libraries.rtl_433_ESP}
+build_flags =
+  ${com-esp.build_flags}
+; *** OpenMQTTGateway Config ***
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
+  '-DvalueAsATopic=true'    ; MQTT topic includes model and device
+  '-DGateway_Name="OpenMQTTGateway_heltec_rtl_433_ESP"'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DZboardHELTEC="HELTEC"'
+  '-DZradioSX127x="SX127x"'
+; *** ssd1306 Module Options ***
+  ; '-DLOG_TO_LCD=true'         ; Enable log to LCD
+  ; '-DLOG_LEVEL_LCD=LOG_LEVEL_TRACE'    // default is notice log level
 
 [env:esp32dev-multi_receiver]
 platform = ${com.esp32_platform}
@@ -817,6 +831,12 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_multi_receiver"'
   '-DvalueAsATopic=true'  ; MQTT topic includes model and device (rtl_433) or protocol and id (RF and PiLight)
 ;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+  '-DRF_MODULE_CS=5'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
+;  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
 
 [env:tinypico-ble]
 platform = ${com.esp32_platform}
@@ -891,15 +911,20 @@ build_flags =
   # Reading battery level every minutes should be more than enought
   '-DTimeBetweenReadingADC=60000'
 
-[env:heltec-wifi-lora-32-868]
+[env:heltec-wifi-lora-32-868]  ; Heltec ESP32 Board with SSD1306 display
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.lora}
+  ${libraries.ssd1306} 
 build_flags =
   ${com-esp.build_flags}
+    ; *** OpenMQTTGateway Modules ***
+  '-DZboardHELTEC="HELTEC"'
+  '-DLOG_TO_LCD=true'         ; Enable log to LCD
+  ;  '-DLOG_LEVEL_LCD=LOG_LEVEL_TRACE'    // default is notice log level
   '-DZgatewayLORA="LORA"'
   '-DLORA_BAND=868E6'
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
@@ -907,15 +932,20 @@ build_flags =
   '-DTimeLedON=0.1'
   '-DLED_SEND_RECEIVE_ON=1'
 
-[env:heltec-wifi-lora-32-915]
+[env:heltec-wifi-lora-32-915]   ; Heltec ESP32 Board with SSD1306 display
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.lora}
+  ${libraries.ssd1306} 
 build_flags =
   ${com-esp.build_flags}
+  ; *** OpenMQTTGateway Modules ***
+  '-DZboardHELTEC="HELTEC"'
+  '-DLOG_TO_LCD=true'         ; Enable log to LCD
+  ;  '-DLOG_LEVEL_LCD=LOG_LEVEL_TRACE'    // default is notice log level
   '-DZgatewayLORA="LORA"'
   '-DLORA_BAND=915E6'
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
@@ -1015,21 +1045,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgateway2G="2G"'
   '-DGateway_Name="OpenMQTTGateway_ESP8266_2G"'
-board_build.flash_mode = dout
-
-[env:nodemcuv2-ble]
-platform = ${com.esp8266_platform}
-board = nodemcuv2
-lib_deps =
-  ${com-esp.lib_deps}
-  ${libraries.wifimanager8266}
-  ${libraries.wire}
-  ${libraries.esp8266_mdns}
-  ${libraries.decoder}
-build_flags =
-  ${com-esp.build_flags}
-  '-DZgatewayBT="BT"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_BLE"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-ir]
@@ -1304,14 +1319,12 @@ lib_deps =
   ${libraries.dallastemperature}
   ${libraries.rfWeatherStation}
   ${libraries.stl}
-  ${libraries.decoder}
 build_flags =
   ${com-arduino.build_flags}
   '-DZgatewayRF="RF"'
   '-DZgatewayRF="RF315"'
   '-DZgatewayRF2="RF2"'
   '-DZgatewayIR="IR"'
-  '-DZgatewayBT="BT"'
   '-DZactuatorONOFF="ONOFF"'
   '-DZactuatorFASTLED="FASTLED"'
   '-DZactuatorPWM="PWM"'

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,7 +73,6 @@ extra_configs =
 ;default_envs = nodemcuv2-weatherstation
 ;default_envs = nodemcuv2-ir
 ;default_envs = avatto-bakeey-ir
-;default_envs = nodemcuv2-ble
 ;default_envs = nodemcuv2-2g
 ;default_envs = nodemcuv2-all-test
 ;default_envs = nodemcuv2-fastled-test
@@ -109,7 +108,7 @@ rfWeatherStation = WeatherStationDataRx@0.3.1
 rfm69 = https://github.com/LowPowerLab/RFM69.git#2e915ea
 rfm69spi = https://github.com/lowpowerlab/spiflash.git#9c0c2b9
 rfm69_low-power = Low-Power@1.6
-dht = DHT sensor library@1.4.2
+dht = DHT sensor library@1.3.2
 unifiedsensor = Adafruit Unified Sensor@1.1.4
 tsl2561 = Adafruit TSL2561@1.0.3
 bme280 = SparkFun BME280@2.0.4
@@ -134,10 +133,11 @@ smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.7
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
 shtc3 = https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library
 somfy_remote=Somfy_Remote_Lib@0.3.0
-rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.0.4
+rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.1.3
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.8.0
+decoder = https://github.com/theengs/decoder.git#v0.9.0
+ssd1306 = thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.3.0
 
 [env]
 framework = arduino
@@ -757,12 +757,57 @@ lib_deps =
   ${libraries.rtl_433_ESP}
 build_flags =
   ${com-esp.build_flags}
-  '-DZradioCC1101="CC1101"'
-  '-DZgatewayRTL_433="rtl_433"'
-  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
+; *** OpenMQTTGateway Config ***
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
   '-DvalueAsATopic=true'    ; MQTT topic includes model and device
-;  '-DPUBLISH_UNPARSED=true'  ; Publish details of undecoded signals
-;  '-DRTL_DEBUG=4'            ; enable rtl_433 verbose device decode
+  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
+  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DZradioCC1101="CC1101"'
+; *** rtl_433_ESP Options ***
+;  '-DRTL_DEBUG=4'           ; rtl_433 verbose mode
+;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
+;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
+;  '-DMEMORY_DEBUG=true'   ; display memory usage information
+  '-DDEMOD_DEBUG=true'  ; display signal debug info
+;  '-DMY_DEVICES=true'             ; subset of devices
+  '-DPUBLISH_UNPARSED=true'   ; publish unparsed signal details
+;  '-DRSSI_THRESHOLD=12'         ; Apply a delta of 12 to average RSSI level
+;  '-DAVERAGE_RSSI=5000'     ; Display RSSI floor ( Average of 5000 samples )
+  '-DSIGNAL_RSSI=true'             ; Display during signal receive
+  '-DNO_DEAF_WORKAROUND=true'
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+;  '-DRF_MODULE_CS=5'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
+; *** RadioLib Options ***
+;  '-DRADIOLIB_DEBUG=true'
+;  '-DRADIOLIB_VERBOSE=true'
+
+[env:heltec-rtl_433]
+platform = ${com.esp32_platform}
+board = heltec_wifi_lora_32_V2
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ssd1306}
+  ${libraries.rtl_433_ESP}
+build_flags =
+  ${com-esp.build_flags}
+; *** OpenMQTTGateway Config ***
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
+  '-DvalueAsATopic=true'    ; MQTT topic includes model and device
+  '-DGateway_Name="OpenMQTTGateway_heltec_rtl_433_ESP"'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DZboardHELTEC="HELTEC"'
+  '-DZradioSX127x="SX127x"'
+; *** ssd1306 Module Options ***
+  ; '-DLOG_TO_LCD=true'         ; Enable log to LCD
+  ; '-DLOG_LEVEL_LCD=LOG_LEVEL_TRACE'    // default is notice log level
 
 [env:esp32dev-multi_receiver]
 platform = ${com.esp32_platform}
@@ -786,6 +831,12 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_multi_receiver"'
   '-DvalueAsATopic=true'  ; MQTT topic includes model and device (rtl_433) or protocol and id (RF and PiLight)
 ;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+  '-DRF_MODULE_CS=5'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
+;  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
 
 [env:tinypico-ble]
 platform = ${com.esp32_platform}
@@ -860,15 +911,20 @@ build_flags =
   # Reading battery level every minutes should be more than enought
   '-DTimeBetweenReadingADC=60000'
 
-[env:heltec-wifi-lora-32-868]
+[env:heltec-wifi-lora-32-868]  ; Heltec ESP32 Board with SSD1306 display
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.lora}
+  ${libraries.ssd1306} 
 build_flags =
   ${com-esp.build_flags}
+    ; *** OpenMQTTGateway Modules ***
+  '-DZboardHELTEC="HELTEC"'
+  '-DLOG_TO_LCD=true'         ; Enable log to LCD
+  ;  '-DLOG_LEVEL_LCD=LOG_LEVEL_TRACE'    // default is notice log level
   '-DZgatewayLORA="LORA"'
   '-DLORA_BAND=868E6'
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
@@ -876,15 +932,20 @@ build_flags =
   '-DTimeLedON=0.1'
   '-DLED_SEND_RECEIVE_ON=1'
 
-[env:heltec-wifi-lora-32-915]
+[env:heltec-wifi-lora-32-915]   ; Heltec ESP32 Board with SSD1306 display
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.lora}
+  ${libraries.ssd1306} 
 build_flags =
   ${com-esp.build_flags}
+  ; *** OpenMQTTGateway Modules ***
+  '-DZboardHELTEC="HELTEC"'
+  '-DLOG_TO_LCD=true'         ; Enable log to LCD
+  ;  '-DLOG_LEVEL_LCD=LOG_LEVEL_TRACE'    // default is notice log level
   '-DZgatewayLORA="LORA"'
   '-DLORA_BAND=915E6'
   '-DGateway_Name="OpenMQTTGateway_ESP32_LORA"'
@@ -984,21 +1045,6 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgateway2G="2G"'
   '-DGateway_Name="OpenMQTTGateway_ESP8266_2G"'
-board_build.flash_mode = dout
-
-[env:nodemcuv2-ble]
-platform = ${com.esp8266_platform}
-board = nodemcuv2
-lib_deps =
-  ${com-esp.lib_deps}
-  ${libraries.wifimanager8266}
-  ${libraries.wire}
-  ${libraries.esp8266_mdns}
-  ${libraries.decoder}
-build_flags =
-  ${com-esp.build_flags}
-  '-DZgatewayBT="BT"'
-  '-DGateway_Name="OpenMQTTGateway_ESP8266_BLE"'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-ir]
@@ -1273,14 +1319,12 @@ lib_deps =
   ${libraries.dallastemperature}
   ${libraries.rfWeatherStation}
   ${libraries.stl}
-  ${libraries.decoder}
 build_flags =
   ${com-arduino.build_flags}
   '-DZgatewayRF="RF"'
   '-DZgatewayRF="RF315"'
   '-DZgatewayRF2="RF2"'
   '-DZgatewayIR="IR"'
-  '-DZgatewayBT="BT"'
   '-DZactuatorONOFF="ONOFF"'
   '-DZactuatorFASTLED="FASTLED"'
   '-DZactuatorPWM="PWM"'


### PR DESCRIPTION
## Description:

The main features of the upgrade to 0.1.3 of rtl_433_ESP are

1 - Change Transceiver Library to [RadioLib](https://github.com/jgromes/RadioLib)

2 - Add support for SX127X transceiver module ( I used the 433 Mhz version of this [Heltec module](https://heltec.org/project/wifi-lora-32/) for development ).

3 - Added automatic calibration of the RSSI Signal detection Threshold

4 - Removed dependency on loop for start and end of signal detection, and moved to a ESP32 Task

5 - Moved received signal decoding to a ESP32 Task

6 - Identified Blueline PowerCost Monitor decoder as source of significant memory overhead and disabled.

7 - Multi Receiver support has been validated with RF, RF2 and PiLight

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
