### PR TITLE
Bump decoder to v0.9.0

### DIFF
--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -35,6 +35,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | GOVEE|H5072|temperature/humidity/battery|
 | GOVEE|H5102|temperature/humidity/battery|
 | HONEYWELL|JQJCY01YM|formaldehyde/temperature/humidity/battery|
+| Hydractiva Digital | Amphiro/Oras|sessions/time/litres/temperature/energy|
 | iBeacon|protocol|uuid/mfid/major/minor/txpower @ 1 m/voltage|
 | INKBIRD (1)|IBS-TH1|temperature/humidity/battery|
 | INKBIRD (1)|IBS-TH2/P01B|temperature/battery|
@@ -42,6 +43,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | INKBIRD (1)|IBT-4XS|temperature1/temperature2/temperature3/temperature4|
 | INKBIRD (1)|IBT-6XS|temperature1/temperature2/temperature3/temperature4/temperature5/temperature6|
 | iNode|Energy Meter (1)|Current average and aggregate kW(h)/m³/battery|
+| Oria/Brifit/SigmaWit/SensorPro|TH Sensor|temperature/humidity/battery|
 | Mokosmart (1)|M1|x_axis/y_axis/z_axis/battery|
 | Mokosmart (1)|H4|temperature/humidity/voltage|
 | Qingping|CGDK2|temperature/humidity|
@@ -60,6 +62,8 @@ Added to that it retrieves the measures from the devices below. By default the d
 | Switchbot|Meter (Plus)|temperature/humidity/battery|
 | Thermobeacon|WS02|temperature/humidity/voltage/timestamp/maximum temperature/maximum temperature timestamp/minimum temperature/minimum temperature timestamp|
 | Thermobeacon|WS08|temperature/humidity/voltage/timestamp/maximum temperature/maximum temperature timestamp/minimum temperature/minimum temperature timestamp|
+| ThermoPro|TP357|temperature/humidity|
+| ThermoPro|TP358|temperature/humidity|
 | TPMS|TPMS|temperature/pressure/battery/alarm/count|
 | Vegtrug||temperature/moisture/luminance/fertility|
 | XIAOMI Mi Flora|HHCCJCY01HHCC|temperature/moisture/luminance/fertility/battery(1)(c)|

--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -44,16 +44,16 @@ Added to that it retrieves the measures from the devices below. By default the d
 | INKBIRD (1)|IBT-6XS|temperature1/temperature2/temperature3/temperature4/temperature5/temperature6|
 | iNode|Energy Meter (1)|Current average and aggregate kW(h)/m³/battery|
 | Oria/Brifit/SigmaWit/SensorPro|TH Sensor|temperature/humidity/battery|
-| Mokosmart (1)|M1|x_axis/y_axis/z_axis/battery|
+| Mokosmart (1)|M1|acceleration x/y/z-axis/battery|
 | Mokosmart (1)|H4|temperature/humidity/voltage|
 | Qingping|CGDK2|temperature/humidity|
 | Qingping|CGH1|open|
-| Qingping|CGPR1|presence/luminance|
+| Qingping|CGPR1|presence/luminance/battery|
 | Qingping|CGDN1|temperature/humidity/PM2.5/PM10/carbon dioxide|
-| RDL52832||mfid/uuid/minor/major/txpower @ 1 m/temperature/humidity/acceleration|
+| RDL52832||mfid/uuid/minor/major/txpower @ 1 m/temperature/humidity/acceleration x/y/z-axis|
 | RBaron|b-parasite|moisture/temperature/humidity/luminance (v1.1.0+)/voltage|
-| RuuviTag Raw V1|RuuviTag|temperature/humidity/pressure/acceleration/voltage|
-| RuuviTag Raw V2|RuuviTag|temperature/humidity/pressure/acceleration/voltage/TX power/movement/counter/sequence number|
+| RuuviTag Raw V1|RuuviTag|temperature/humidity/pressure/acceleration x/y/z-axis/voltage|
+| RuuviTag Raw V2|RuuviTag|temperature/humidity/pressure/acceleration x/y/z-axis/voltage/TX power/movement/counter/sequence number|
 | SmartDry|Laundry Sensor|temperature/humidity/shake/voltage/wake|
 | Switchbot|Bot (c)|mode/state/battery|
 | Switchbot|Motion Sensor|movement/light level/sensing distance/led/scope tested/battery|

--- a/platformio.ini
+++ b/platformio.ini
@@ -137,7 +137,7 @@ somfy_remote=Somfy_Remote_Lib@0.3.0
 rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.0.4
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.8.0
+decoder = https://github.com/theengs/decoder.git#v0.9.0
 
 [env]
 framework = arduino


### PR DESCRIPTION
## Description:

- Amphiro/Oras Digital Shower Head by @DigiH in https://github.com/theengs/decoder/pull/195
- ThermoPro TP357 & TP358 by @DigiH in https://github.com/theengs/decoder/pull/198
- Oria T301 by @DigiH in https://github.com/theengs/decoder/pull/199
- CGPR1 enhancements by @DigiH in https://github.com/theengs/decoder/pull/200
- Unit adjustments CGP1W & TPMS by @DigiH in https://github.com/theengs/decoder/pull/201
- Ohm to Ω by @DigiH in https://github.com/theengs/decoder/pull/202
- string_from_hex_data clarification by @DigiH in https://github.com/theengs/decoder/pull/203
- Acceleration adjustments by @DigiH in https://github.com/theengs/decoder/pull/204
- SmartDry shake changes by @DigiH in https://github.com/theengs/decoder/pull/206

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
