### PR TITLE
Spi connectivity check for c1101

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -111,6 +111,12 @@ void setupRF() {
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
   Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
 #  ifdef ZradioCC1101 //receiving with CC1101
+  if (ELECHOUSE_cc1101.getCC1101()) {
+    Log.notice("C1101 spi Connection OK");
+  } else {
+    Log.error("C1101 spi Connection Error");
+  }
+
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz);
 #  endif


### PR DESCRIPTION
## Description:

I had messed up the wiring from the c1101 to my esp. This will do a basic connectivity check from the esp to the c1101 and print out a warning/success message. 