### PR TITLE
Re-publish BTtoMQTT Theengs discovery topics on MQTT re-connect

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -77,7 +77,6 @@ vector<BLEAction> BLEactions;
 
 vector<BLEdevice*> devices;
 int newDevices = 0;
-
 static BLEdevice NO_DEVICE_FOUND = {{0},
                                     0,
                                     false,
@@ -853,9 +852,11 @@ boolean valid_service_data(const char* data, int size) {
 
 #  ifdef ZmqttDiscovery
 // This function always should be called from the main core as it generates direct mqtt messages
-void launchBTDiscovery() {
-  if (newDevices == 0)
+// When overrideDiscovery=true, we publish discovery messages of known devices (even if no new)
+void launchBTDiscovery(bool overrideDiscovery) {
+  if (!overrideDiscovery && newDevices == 0)
     return;
+#    ifdef ESP32
   if (xSemaphoreTake(semaphoreCreateOrUpdateDevice, pdMS_TO_TICKS(1000)) == pdFALSE) {
     Log.error(F("Semaphore NOT taken" CR));
     return;
@@ -866,8 +867,8 @@ void launchBTDiscovery() {
   for (vector<BLEdevice*>::iterator it = localDevices.begin(); it != localDevices.end(); ++it) {
     BLEdevice* p = *it;
     Log.trace(F("Device mac %s" CR), p->macAdr);
-    // Do not launch discovery for the devices already discovered or that are not unique by their MAC Address (Ibeacon, GAEN and Microsoft Cdp)
-    if (!isDiscovered(p) &&
+    // Do not launch discovery for the devices already discovered (unless we have overrideDiscovery) or that are not unique by their MAC Address (Ibeacon, GAEN and Microsoft Cdp)
+    if ((overrideDiscovery || !isDiscovered(p)) &&
         p->sensorModel_id != TheengsDecoder::BLE_ID_NUM::IBEACON &&
         p->sensorModel_id != TheengsDecoder::BLE_ID_NUM::MS_CDP &&
         p->sensorModel_id != TheengsDecoder::BLE_ID_NUM::GAEN) {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -77,6 +77,7 @@ vector<BLEAction> BLEactions;
 
 vector<BLEdevice*> devices;
 int newDevices = 0;
+
 static BLEdevice NO_DEVICE_FOUND = {{0},
                                     0,
                                     false,

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -857,7 +857,6 @@ boolean valid_service_data(const char* data, int size) {
 void launchBTDiscovery(bool overrideDiscovery) {
   if (!overrideDiscovery && newDevices == 0)
     return;
-#    ifdef ESP32
   if (xSemaphoreTake(semaphoreCreateOrUpdateDevice, pdMS_TO_TICKS(1000)) == pdFALSE) {
     Log.error(F("Semaphore NOT taken" CR));
     return;

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -30,7 +30,7 @@ extern void setupBT();
 extern bool BTtoMQTT();
 extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
 extern void emptyBTQueue();
-extern void launchBTDiscovery();
+extern void launchBTDiscovery(bool overrideDiscovery);
 
 #ifdef ESP32
 extern int btQueueBlocked;

--- a/main/main.ino
+++ b/main/main.ino
@@ -1385,7 +1385,7 @@ void loop() {
       // or, when we have just re-connected (only when discovery_republish_on_reconnect is enabled)
       bool publishDiscovery = disc && (!connectedOnce || (discovery_republish_on_reconnect && justReconnected));
       if (publishDiscovery) {
-          pubMqttDiscovery();
+        pubMqttDiscovery();
       }
 #endif
       connectedOnce = true;


### PR DESCRIPTION
- Improved version of #1274, this should re-publish more according to my local tests, meeting my original intent with https://github.com/1technophile/OpenMQTTGateway/issues/1273
- Handle return value of (MQTT) client.loop() to detect connection loss faster
- remove accidentally committed main.ino.cpp in previous PR, similar to #1289

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
