### PR TITLE
Update of rtl_433_ESP to version 0.1.3 - Support for SX127X transceiv…

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -478,7 +478,7 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #  define STRTO_UL_ULL       strtoul
 #endif
 
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
 // variable to avoid duplicates
 #  ifndef time_avoid_duplicate
 #    define time_avoid_duplicate 3000 // if you want to avoid duplicate MQTT message received set this to > 0, the value is the time in milliseconds during which we don't publish duplicates

--- a/main/ZboardHeltec.ino
+++ b/main/ZboardHeltec.ino
@@ -1,19 +1,19 @@
-/*  
-  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+/*
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation
 
-   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
    Send and receiving command by MQTT
- 
+
     HELTEC ESP32 LORA - SSD1306 / Onboard 0.96-inch 128*64 dot matrix OLED display
-  
+
     Copyright: (c)Florian ROBERT
-    
+
     Contributors:
     - 1technophile
     - NorthernMan54
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -187,7 +187,10 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       int msgLength = rf.stringToPulseTrain(raw, codes, MAXPULSESTREAMLENGTH);
       if (msgLength > 0) {
 #  ifdef ZradioCC1101
-        ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
+        disableActiveReceiver();
+        ELECHOUSE_cc1101.Init();
+        pinMode(RF_EMITTER_GPIO, OUTPUT);
+        ELECHOUSE_cc1101.SetTx(receiveMhz); // set Transmit on
         rf.disableReceiver();
 #  endif
         rf.sendPulseTrain(codes, msgLength, repeats);
@@ -215,7 +218,10 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
     if (message && protocol) {
       Log.trace(F("MQTTtoPilight msg & protocol ok" CR));
 #  ifdef ZradioCC1101
-      ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
+      disableActiveReceiver();
+      ELECHOUSE_cc1101.Init();
+      pinMode(RF_EMITTER_GPIO, OUTPUT);
+      ELECHOUSE_cc1101.SetTx(receiveMhz); // set Transmit on
       rf.disableReceiver();
 #  endif
       int msgLength = rf.send(protocol, message);
@@ -287,6 +293,7 @@ extern void enablePilightReceive() {
 #  endif
 
 #  ifdef ZradioCC1101
+  ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
   rf.setCallback(pilightCallback);

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -176,6 +176,7 @@ void RFtoMQTT() {
 #  if simpleReceiving
 void MQTTtoRF(char* topicOri, char* datacallback) {
 #    ifdef ZradioCC1101 // set Receive off and Transmitt on
+  disableActiveReceiver();
   ELECHOUSE_cc1101.SetTx(receiveMhz);
 #    endif
   mySwitch.disableReceive();
@@ -251,6 +252,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
 #    ifdef ZradioCC1101 // set Receive off and Transmitt on
       float trMhz = RFdata["mhz"] | CC1101_FREQUENCY;
       if (validFrequency((int)trMhz)) {
+        disableActiveReceiver();
         ELECHOUSE_cc1101.SetTx(trMhz);
         Log.notice(F("Transmit mhz: %F" CR), trMhz);
       }
@@ -321,6 +323,7 @@ void enableRFReceive() {
 #  endif
 
 #  ifdef ZradioCC1101 // set Receive on and Transmitt off
+  ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz);
 #  endif
   mySwitch.disableTransmit();

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -152,6 +152,9 @@ void rf2Callback(unsigned int period, unsigned long address, unsigned long group
 void MQTTtoRF2(char* topicOri, char* datacallback) {
 #    ifdef ZradioCC1101
   NewRemoteReceiver::disable();
+  disableActiveReceiver();
+  ELECHOUSE_cc1101.Init();
+  pinMode(RF_EMITTER_GPIO, OUTPUT);
   ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
 #    endif
 
@@ -268,6 +271,9 @@ void MQTTtoRF2(char* topicOri, JsonObject& RF2data) { // json object decoding
     if (boolSWITCHTYPE != 99) {
 #    ifdef ZradioCC1101
       NewRemoteReceiver::disable();
+      disableActiveReceiver();
+      ELECHOUSE_cc1101.Init();
+      pinMode(RF_EMITTER_GPIO, OUTPUT);
       ELECHOUSE_cc1101.SetTx(CC1101_FREQUENCY); // set Transmit on
 #    endif
       Log.trace(F("MQTTtoRF2 switch type ok" CR));
@@ -356,10 +362,11 @@ void enableRF2Receive() {
   disableRFReceive();
 #  endif
 
-  NewRemoteReceiver::init(RF_RECEIVER_GPIO, 2, rf2Callback);
 #  ifdef ZradioCC1101
+  ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
+  NewRemoteReceiver::init(RF_RECEIVER_GPIO, 2, rf2Callback);
 }
 
 #endif

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -28,17 +28,12 @@
 */
 #include "User_config.h"
 #ifdef ZgatewayRTL_433
-#  ifndef ZradioCC1101
-#    error "CC1101 is the only supported receiver module for RTL_433 and needs to be enabled."
-#  endif
 
 #  include <rtl_433_ESP.h>
 
 char messageBuffer[JSON_MSG_BUFFER];
 
-rtl_433_ESP rtl_433(-1); // use -1 to disable transmitter
-
-#  include <ELECHOUSE_CC1101_SRC_DRV.h>
+rtl_433_ESP rtl_433(-1);
 
 void rtl_433_Callback(char* message) {
   DynamicJsonDocument jsonBuffer2(JSON_MSG_BUFFER);
@@ -49,6 +44,7 @@ void rtl_433_Callback(char* message) {
     return;
   }
 
+  unsigned long MQTTvalue = (int)RFrtl_433_ESPdata["id"] + round(RFrtl_433_ESPdata["temperature_C"]);
   String topic = String(subjectRTL_433toMQTT);
 #  if valueAsATopic
   String model = RFrtl_433_ESPdata["model"];
@@ -61,14 +57,16 @@ void rtl_433_Callback(char* message) {
   }
 #  endif
 
-  pub((char*)topic.c_str(), RFrtl_433_ESPdata);
+  if (!isAduplicateSignal(MQTTvalue)) {
+    pub((char*)topic.c_str(), RFrtl_433_ESPdata);
+    storeSignalValue(MQTTvalue);
+  }
 #  ifdef MEMORY_DEBUG
   Log.trace(F("Post rtl_433_Callback: %d" CR), ESP.getFreeHeap());
 #  endif
 }
 
 void setupRTL_433() {
-  rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
   rtl_433.setCallback(rtl_433_Callback, messageBuffer, JSON_MSG_BUFFER);
   Log.trace(F("ZgatewayRTL_433 command topic: %s%s%s" CR), mqtt_topic, gateway_name, subjectMQTTtoRTL_433);
   Log.notice(F("ZgatewayRTL_433 setup done " CR));
@@ -93,16 +91,24 @@ extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
       success = true;
     }
     if (RTLdata.containsKey("rssi")) {
-      int minimumRssi = RTLdata["rssi"] | 0;
-      Log.notice(F("RTL_433 minimum RSSI: %d" CR), minimumRssi);
-      rtl_433.setMinimumRSSI(minimumRssi);
+      int rssiThreshold = RTLdata["rssi"] | 0;
+      Log.notice(F("RTL_433 RSSI Threshold Delta: %d " CR), rssiThreshold);
+      rtl_433.setRSSIThreshold(rssiThreshold);
       success = true;
     }
+#  if defined(RF_SX1276) || defined(RF_SX1278)
+    if (RTLdata.containsKey("ookThreshold")) {
+      int newOokThreshold = RTLdata["ookThreshold"] | 0;
+      Log.notice(F("RTL_433 ookThreshold %d" CR), newOokThreshold);
+      rtl_433.setOOKThreshold(newOokThreshold);
+      success = true;
+    }
+#  endif
     if (RTLdata.containsKey("debug")) {
       int debug = RTLdata["debug"] | -1;
       Log.notice(F("RTL_433 set debug: %d" CR), debug);
-      rtl_433.setDebug(debug);
-      rtl_433.initReceiver(RF_RECEIVER_GPIO, receiveMhz);
+      // rtl_433.setDebug(debug);
+      rtl_433.initReceiver(RF_MODULE_RECEIVER_GPIO, receiveMhz);
       success = true;
     }
     if (RTLdata.containsKey("status")) {
@@ -131,9 +137,9 @@ extern void enableRTLreceive() {
 #  ifdef ZgatewayPilight
   disablePilightReceive();
 #  endif
-  ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
-  rtl_433.enableReceiver(RF_RECEIVER_GPIO);
-  pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
+
+  rtl_433.initReceiver(RF_MODULE_RECEIVER_GPIO, receiveMhz);
+  rtl_433.enableReceiver(RF_MODULE_RECEIVER_GPIO);
 }
 
 extern void disableRTLreceive() {
@@ -142,8 +148,12 @@ extern void disableRTLreceive() {
   rtl_433.disableReceiver();
 }
 
-extern int getRTLMinimumRSSI() {
-  return rtl_433.minimumRssi;
+extern int getRTLrssiThreshold() {
+  return rtl_433.rssiThreshold;
+}
+
+extern int getRTLAverageRSSI() {
+  return rtl_433.averageRssi;
 }
 
 extern int getRTLCurrentRSSI() {
@@ -153,5 +163,11 @@ extern int getRTLCurrentRSSI() {
 extern int getRTLMessageCount() {
   return rtl_433.messageCount;
 }
+
+#  if defined(RF_SX1276) || defined(RF_SX1278)
+extern int getOOKThresh() {
+  return rtl_433.OokFixedThreshold;
+}
+#  endif
 
 #endif

--- a/main/config_HELTEC.h
+++ b/main/config_HELTEC.h
@@ -1,19 +1,19 @@
 /*  
-  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation
 
-   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
    Send and receiving command by MQTT
- 
+
     HELTEC ESP32 LORA - SSD1306 / Onboard 0.96-inch 128*64 dot matrix OLED display
-  
+
     Copyright: (c)Florian ROBERT
-    
+
     Contributors:
     - 1technophile
     - NorthernMan54
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -63,13 +63,9 @@ extern void setupRTL_433();
 extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata);
 extern void enableRTLreceive();
 extern void disableRTLreceive();
-extern int getRTLMinimumRSSI();
+extern int getRTLrssiThreshold();
 extern int getRTLCurrentRSSI();
 extern int getRTLMessageCount();
-/**
- * minimumRssi minimum RSSI value to enable receiver
- */
-int minimumRssi = 0;
 #endif
 /*-------------------RF topics & parameters----------------------*/
 //433Mhz MQTT Subjects and keys
@@ -118,7 +114,7 @@ int minimumRssi = 0;
 #  define CC1101_FREQUENCY 433.92
 #endif
 // Allow ZGatewayRF Module to change receive frequency of CC1101 Transceiver module
-#ifdef ZradioCC1101
+#if defined(ZradioCC1101) || defined(ZradioSX127x)
 float receiveMhz = CC1101_FREQUENCY;
 #endif
 
@@ -164,7 +160,7 @@ int activeReceiver = 0;
 #  define ACTIVE_RTL      3
 #  define ACTIVE_RF2      4
 
-#  ifdef ZradioCC1101
+#  if defined(ZradioCC1101) || defined(ZradioSX127x)
 bool validFrequency(float mhz) {
   //  CC1101 valid frequencies 300-348 MHZ, 387-464MHZ and 779-928MHZ.
   if (mhz >= 300 && mhz <= 348)
@@ -265,6 +261,37 @@ void enableActiveReceiver(bool isBoot) {
   }
   currentReceiver = activeReceiver;
 }
+
+void disableActiveReceiver() {
+  Log.trace(F("disableActiveReceiver: %d" CR), activeReceiver);
+  switch (activeReceiver) {
+#  ifdef ZgatewayPilight
+    case ACTIVE_PILIGHT:
+      disablePilightReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRF
+    case ACTIVE_RF:
+      disableRFReceive();
+      break;
+#  endif
+#  ifdef ZgatewayRTL_433
+    case ACTIVE_RTL:
+      disableRTLreceive();
+      break;
+#  endif
+#  ifdef ZgatewayRF2
+    case ACTIVE_RF2:
+      disableRF2Receive();
+      break;
+#  endif
+#  ifndef ARDUINO_AVR_UNO // Space issues with the UNO
+    default:
+      Log.error(F("ERROR: unsupported receiver %d" CR), activeReceiver);
+#  endif
+  }
+}
+
 #endif
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -133,7 +133,7 @@ smartrc-cc1101-driver-lib = SmartRC-CC1101-Driver-Lib@2.5.7
 stl = https://github.com/mike-matera/ArduinoSTL.git#7411816
 shtc3 = https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library
 somfy_remote=Somfy_Remote_Lib@0.3.0
-rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.0.4
+rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.1.3
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
 decoder = https://github.com/theengs/decoder.git#v0.9.0
@@ -757,12 +757,57 @@ lib_deps =
   ${libraries.rtl_433_ESP}
 build_flags =
   ${com-esp.build_flags}
-  '-DZradioCC1101="CC1101"'
-  '-DZgatewayRTL_433="rtl_433"'
-  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
+; *** OpenMQTTGateway Config ***
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
   '-DvalueAsATopic=true'    ; MQTT topic includes model and device
-;  '-DPUBLISH_UNPARSED=true'  ; Publish details of undecoded signals
-;  '-DRTL_DEBUG=4'            ; enable rtl_433 verbose device decode
+  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
+  '-DGateway_Name="OpenMQTTGateway_rtl_433_ESP"'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DZradioCC1101="CC1101"'
+; *** rtl_433_ESP Options ***
+;  '-DRTL_DEBUG=4'           ; rtl_433 verbose mode
+;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
+;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
+;  '-DMEMORY_DEBUG=true'   ; display memory usage information
+  '-DDEMOD_DEBUG=true'  ; display signal debug info
+;  '-DMY_DEVICES=true'             ; subset of devices
+  '-DPUBLISH_UNPARSED=true'   ; publish unparsed signal details
+;  '-DRSSI_THRESHOLD=12'         ; Apply a delta of 12 to average RSSI level
+;  '-DAVERAGE_RSSI=5000'     ; Display RSSI floor ( Average of 5000 samples )
+  '-DSIGNAL_RSSI=true'             ; Display during signal receive
+  '-DNO_DEAF_WORKAROUND=true'
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+;  '-DRF_MODULE_CS=5'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
+; *** RadioLib Options ***
+;  '-DRADIOLIB_DEBUG=true'
+;  '-DRADIOLIB_VERBOSE=true'
+
+[env:heltec-rtl_433]
+platform = ${com.esp32_platform}
+board = heltec_wifi_lora_32_V2
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ssd1306}
+  ${libraries.rtl_433_ESP}
+build_flags =
+  ${com-esp.build_flags}
+; *** OpenMQTTGateway Config ***
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
+  '-DvalueAsATopic=true'    ; MQTT topic includes model and device
+  '-DGateway_Name="OpenMQTTGateway_heltec_rtl_433_ESP"'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DZboardHELTEC="HELTEC"'
+  '-DZradioSX127x="SX127x"'
+; *** ssd1306 Module Options ***
+  ; '-DLOG_TO_LCD=true'         ; Enable log to LCD
+  ; '-DLOG_LEVEL_LCD=LOG_LEVEL_TRACE'    // default is notice log level
 
 [env:esp32dev-multi_receiver]
 platform = ${com.esp32_platform}
@@ -786,6 +831,12 @@ build_flags =
   '-DGateway_Name="OpenMQTTGateway_multi_receiver"'
   '-DvalueAsATopic=true'  ; MQTT topic includes model and device (rtl_433) or protocol and id (RF and PiLight)
 ;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+  '-DRF_MODULE_CS=5'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
+;  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
 
 [env:tinypico-ble]
 platform = ${com.esp32_platform}


### PR DESCRIPTION
## Description:

The main features of the upgrade to 0.1.3 of rtl_433_ESP are

1 - Change Transceiver Library to RadioLib

2 - Add support for SX127X transceiver module ( I used the 433 Mhz version of this Heltec module for development ).

3 - Added automatic calibration of the RSSI Signal detection Threshold

4 - Removed dependency on loop for start and end of signal detection, and moved to a ESP32 Task

5 - Moved received signal decoding to a ESP32 Task

6 - Identified Blueline PowerCost Monitor decoder as source of significant memory overhead and disabled.

7 - Multi Receiver support has been validated with RF, RF2 and PiLight

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
