### PR TITLE
Fix discovery duplicates for BT devices

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -943,8 +943,8 @@ void launchBTDiscovery(bool overrideDiscovery) {
         } else {
           Log.trace(F("Device UNKNOWN_MODEL %s" CR), p->macAdr);
         }
-        p->isDisc = true; // we don't need the semaphore and all the search magic via createOrUpdateDevice
       }
+      p->isDisc = true; // we don't need the semaphore and all the search magic via createOrUpdateDevice
     } else {
       Log.trace(F("Device already discovered or that doesn't require discovery %s" CR), p->macAdr);
     }


### PR DESCRIPTION
## Description:
Fix isdisc = true identification,

After[ this commit](https://github.com/1technophile/OpenMQTTGateway/commit/25b8123ff6471352951d3def22c815017f5f11e1) the discovery messages were published several times.
Recover the initial behavior so that the discovery messages are published only once per ESP32 cycle.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
