### PR TITLE
Bump Theengs Decoder to v095

### DIFF
--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -26,7 +26,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | BLE beacons keychains||rssi for presence detection|
 | BlueMaestro|TempoDisc|temperature/humidity/dew point/voltage|
 | BM2 Battery Monitor|BM2|battery|
-| ClearGrass|CGG1|temperature/humidity/battery|
+| ClearGrass|CGG1|temperature/humidity/battery/voltage (depending on which CGG1 firmware is installed)|
 | ClearGrass alarm clock|CGD1|temperature/humidity|
 | ClearGrass with atmospheric pressure|CGP1W|temperature/humidity/air pressure|
 | ClearGrass Clock|LYWSD02|temperature/humidity/battery|
@@ -40,12 +40,13 @@ Added to that it retrieves the measures from the devices below. By default the d
 | INKBIRD (1)|IBS-TH1|temperature/humidity/battery|
 | INKBIRD (1)|IBS-TH2/P01B|temperature/battery|
 | INKBIRD (1)|IBT-2X|temperature1/temperature2|
-| INKBIRD (1)|IBT-4XS|temperature1/temperature2/temperature3/temperature4|
+| INKBIRD|IBT-4X(S/C)|temperature1/temperature2/temperature3/temperature4|
 | INKBIRD (1)|IBT-6XS|temperature1/temperature2/temperature3/temperature4/temperature5/temperature6|
 | iNode|Energy Meter (1)|Current average and aggregate kW(h)/m³/battery|
 | Oria/Brifit/SigmaWit/SensorPro|TH Sensor|temperature/humidity/battery|
 | Mokosmart (1)|M1|acceleration x/y/z-axis/battery|
 | Mokosmart (1)|H4|temperature/humidity/voltage|
+| Otio/BeeWi|Door & Window Sensor|contact/battery|
 | Qingping|CGDK2|temperature/humidity|
 | Qingping|CGH1|open|
 | Qingping|CGPR1|presence/luminance/battery|
@@ -64,6 +65,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | Thermobeacon|WS08|temperature/humidity/voltage/timestamp/maximum temperature/maximum temperature timestamp/minimum temperature/minimum temperature timestamp|
 | ThermoPro|TP357|temperature/humidity|
 | ThermoPro|TP358|temperature/humidity|
+| ThermoPro|TP359|temperature/humidity|
 | TPMS|TPMS|temperature/pressure/battery/alarm/count|
 | Vegtrug||temperature/moisture/luminance/fertility|
 | XIAOMI Mi Flora|HHCCJCY01HHCC|temperature/moisture/luminance/fertility/battery(1)(c)|

--- a/platformio.ini
+++ b/platformio.ini
@@ -136,7 +136,7 @@ somfy_remote=Somfy_Remote_Lib@0.3.0
 rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.1.3
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
-decoder = https://github.com/theengs/decoder.git#v0.9.0
+decoder = https://github.com/theengs/decoder.git#v0.9.5
 ssd1306 = thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.3.0
 
 [env]


### PR DESCRIPTION
## Description:
* IBT-4XC inclusion by @DigiH in #208
* ThermoPro TP359 by @DigiH in #210
* IBS-TH1 external probe differentiation by @DigiH in #211 CGG1 firmware extension by @DigiH in #218
* Otio/BeeWi BSDOO by @DigiH in #214

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
