### PR TITLE
fix rf gateway f strings

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -112,9 +112,9 @@ void setupRF() {
   Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
 #  ifdef ZradioCC1101 //receiving with CC1101
   if (ELECHOUSE_cc1101.getCC1101()) {
-    Log.notice("C1101 spi Connection OK");
+    Log.notice(F("C1101 spi Connection OK" CR));
   } else {
-    Log.error("C1101 spi Connection Error");
+    Log.error(F("C1101 spi Connection Error" CR));
   }
 
   ELECHOUSE_cc1101.Init();


### PR DESCRIPTION
Signed-off-by: Christian Krämer <christian.kraemer@tngtech.com>

## Description:
* Fixes the f string as mentioned [here](https://github.com/1technophile/OpenMQTTGateway/pull/1287#issuecomment-1302044269) 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
