### PR TITLE
Add rgb gpio powering pin

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -388,6 +388,7 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #  define ota_timeout_millis 30000
 #endif
 
+/*-------------ERRORS, INFOS, SEND RECEIVE Display through LED----------------*/
 #ifndef RGB_INDICATORS // Management of Errors, reception/emission and informations indicators with basic LED
 /*-------------DEFINE PINs FOR STATUS LEDs----------------*/
 #  ifndef LED_SEND_RECEIVE
@@ -456,7 +457,7 @@ CRGB leds[FASTLED_IND_NUM_LEDS];
     pinMode(RGB_LED_POWER, OUTPUT);                                                       \
     digitalWrite(RGB_LED_POWER, HIGH);                                                    \
     FastLED.addLeds<FASTLED_IND_TYPE, FASTLED_IND_DATA_GPIO>(leds, FASTLED_IND_NUM_LEDS); \
-    FastLED.setBrightness(20); /* Error, warning and infos display management*/
+    FastLED.setBrightness(20);
 #  define ErrorIndicatorON() \
     leds[0] = CRGB::Red;     \
     FastLED.show()

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -449,7 +449,12 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #else // Management of Errors, reception/emission and informations indicators with RGB LED
 #  include <FastLED.h>
 CRGB leds[FASTLED_IND_NUM_LEDS];
+#  ifndef RGB_LED_POWER
+#    define RGB_LED_POWER -1 // If the RGB Led is linked to GPIO pin for power define it here
+#  endif
 #  define SetupIndicators()                                                               \
+    pinMode(RGB_LED_POWER, OUTPUT);                                                       \
+    digitalWrite(RGB_LED_POWER, HIGH);                                                    \
     FastLED.addLeds<FASTLED_IND_TYPE, FASTLED_IND_DATA_GPIO>(leds, FASTLED_IND_NUM_LEDS); \
     FastLED.setBrightness(20); /* Error, warning and infos display management*/
 #  define ErrorIndicatorON() \


### PR DESCRIPTION
## Description:
When the RGB Led is powered by an uC pin, enable to power it up from the led setup

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
