### PR TITLE
Enable to set the WM pwd from the Mac

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -114,8 +114,11 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #  endif
 #endif
 
-#ifndef WifiManager_password
-#  define WifiManager_password "your_password" //this is going to be the WPA2-PSK password for the initial setup access point
+#define WM_PWD_FROM_MAC false // enable to set the password from the 8 first digit of the ESP mac address for enhanced security, enabling this option requires to have access to the MAC address, either through a sticker or with serial monitoring
+#if !WM_PWD_FROM_MAC
+#  ifndef WifiManager_password
+#    define WifiManager_password "your_password" //this is going to be the WPA2-PSK password for the initial setup access point
+#  endif
 #endif
 #ifndef WifiManager_ssid
 #  define WifiManager_ssid Gateway_Name //this is the network name of the initial setup access point

--- a/main/main.ino
+++ b/main/main.ino
@@ -1226,9 +1226,18 @@ void setup_wifimanager(bool reset_settings) {
 
   if (!wifi_reconnect_bypass()) // if we didn't connect with saved credential we start Wifimanager web portal
   {
+    // Wifi Manager password
+    String wm_password;
+#  if WM_PWD_FROM_MAC // From ESP Mac Address
+    wm_password = WiFi.macAddress();
+    wm_password.replace(":", "");
+    wm_password.substring(0, 8);
+#  else
+    wm_password = WifiManager_password; // From macro definition
+#  endif
 #  ifdef ESP32
     if (lowpowermode < 2) {
-      displayPrint("Connect your phone to WIFI AP:", WifiManager_ssid, WifiManager_password);
+      displayPrint("Connect your phone to WIFI AP:", WifiManager_ssid, const_cast<char*>(wm_password.c_str()));
     } else { // in case of low power mode we put the ESP to sleep again if we didn't get connected (typical in case the wifi is down)
 #    ifdef ZgatewayBT
       lowPowerESP32();
@@ -1238,11 +1247,11 @@ void setup_wifimanager(bool reset_settings) {
 
     ErrorIndicatorON();
     InfoIndicatorON();
-    Log.notice(F("Connect your phone to WIFI AP: %s with PWD: %s" CR), WifiManager_ssid, WifiManager_password);
+    Log.notice(F("Connect your phone to WIFI AP: %s with PWD: %s" CR), WifiManager_ssid, wm_password.c_str());
     //fetches ssid and pass and tries to connect
     //if it does not connect it starts an access point with the specified name
     //and goes into a blocking loop awaiting configuration
-    if (!wifiManager.autoConnect(WifiManager_ssid, WifiManager_password)) {
+    if (!wifiManager.autoConnect(WifiManager_ssid, wm_password.c_str())) {
       Log.warning(F("failed to connect and hit timeout" CR));
       delay(3000);
       //reset and try again

--- a/platformio.ini
+++ b/platformio.ini
@@ -289,6 +289,7 @@ build_flags =
   '-DZsensorGPIOKeyCode="GPIOKeyCode"'
   '-DZgatewayWeatherStation="WeatherStation"'
   '-DsimplePublishing=true'
+  '-DWM_PWD_FROM_MAC=true'
   '-DGateway_Name="OpenMQTTGateway_ESP32_ALL"'
 
 [env:esp32dev-rf]


### PR DESCRIPTION
## Description:
So as to reinforce security for AP configuration access, enable to set the Wifi Manager Password from the 8 first digits of the ESP Mac address

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
