### PR TITLE
Support LM75 temperature sensor

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -315,6 +315,7 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 //#define ZsensorTSL2561 "TSL2561"  //ESP8266, Arduino, ESP32
 //#define ZsensorBME280  "BME280"   //ESP8266, Arduino, ESP32
 //#define ZsensorHTU21   "HTU21"    //ESP8266, Arduino, ESP32
+//#define ZsensorLM75   "LM75"    //ESP8266, Arduino, ESP32
 //#define ZsensorDHT     "DHT"      //ESP8266, Arduino, ESP32,  Sonoff RF Bridge
 //#define ZsensorDS1820  "DS1820"   //ESP8266, Arduino, ESP32
 //#define ZsensorGPIOKeyCode "GPIOKeyCode" //ESP8266, Arduino, ESP32

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -554,6 +554,21 @@ void pubMqttDiscovery() {
   }
 #  endif
 
+#  ifdef ZsensorLM75
+  Log.trace(F("LM75Discovery" CR));
+  char* LM75sensor[8] = {"sensor", "temp", "htu", "temperature", jsonTempc, "", "", "°C"};
+  //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
+
+  createDiscovery(LM75sensor[0],
+                  LM75TOPIC, LM75sensor[1], (char*)getUniqueId(LM75sensor[1], LM75sensor[2]).c_str(),
+                  will_Topic, LM75sensor[3], LM75sensor[4],
+                  LM75sensor[5], LM75sensor[6], LM75sensor[7],
+                  0, "", "", true, "",
+                  "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain
+                  stateClassNone //State Class
+  );
+#  endif
+
 #  ifdef ZsensorAHTx0
 #    define AHTparametersCount 2
   Log.trace(F("AHTx0Discovery" CR));

--- a/main/ZsensorLM75.ino
+++ b/main/ZsensorLM75.ino
@@ -76,7 +76,7 @@ void MeasureTemp() {
     }
 
     // Check if reads failed and exit early (to try again).
-    if (isnan(lm75TempC) ) {
+    if (isnan(lm75TempC)) {
       Log.error(F("Failed to read from sensor HLM75!" CR));
     } else {
       Log.notice(F("Creating LM75 buffer" CR));

--- a/main/ZsensorLM75.ino
+++ b/main/ZsensorLM75.ino
@@ -56,6 +56,8 @@ void setupZsensorLM75() {
 
 #  if defined(ESP32)
   Wire.begin(I2C_SDA, I2C_SCL);
+#  elif defined(ESP8266)
+  Wire.begin();
 #  endif
 }
 

--- a/main/ZsensorLM75.ino
+++ b/main/ZsensorLM75.ino
@@ -1,0 +1,97 @@
+/*
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
+   Send and receiving command by MQTT
+
+   This is a Temperature Addon:
+   - Measures Temperature
+   - Generates Values for: Temperature in degrees C and F
+   - Required Hardware Module: LM75 or NCT75
+   - Required Library: jeremycole/I2C Temperature Sensors derived from the LM75
+
+   Connection Schemata:
+   --------------------
+
+   LM75 ------> Arduino Uno ----------> ESP8266
+   ==============================================
+   Vcc ---------> 5V -------------------> Vu (5V)
+   GND ---------> GND ------------------> GND
+   SCL ---------> Pin A5 ---------------> D1
+   SDA ---------> Pin A4 ---------------> D2
+
+    This file is part of OpenMQTTGateway.
+
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "User_config.h"
+
+#ifdef ZsensorLM75
+#  include <stdint.h>
+
+#  include "Temperature_LM75_Derived.h"
+#  include "Wire.h" // Library for communication with I2C / TWI devices
+#  include "config_LM75.h"
+
+//Time used to wait for an interval before resending measured values
+unsigned long timelm75 = 0;
+
+//Global sensor object
+Generic_LM75 lm75Sensor;
+
+void setupZsensorLM75() {
+  delay(10); // Gives the Sensor enough time to turn on
+  Log.notice(F("LM75 Initialized - begin()" CR));
+
+#  if defined(ESP32)
+  Wire.begin(I2C_SDA, I2C_SCL);
+#  endif
+}
+
+void MeasureTemp() {
+  if (millis() > (timelm75 + TimeBetweenReadinglm75)) {
+    Log.trace(F("Read LM75 Sensor" CR));
+
+    timelm75 = millis();
+    static float persisted_lm75_tempc;
+
+    float lm75TempC = lm75Sensor.readTemperatureC();
+
+    if (lm75TempC >= 998) {
+      Log.error(F("Failed to read from sensor LM75!" CR));
+      return;
+    }
+
+    // Check if reads failed and exit early (to try again).
+    if (isnan(lm75TempC) ) {
+      Log.error(F("Failed to read from sensor HLM75!" CR));
+    } else {
+      Log.notice(F("Creating LM75 buffer" CR));
+      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
+      JsonObject LM75data = jsonBuffer.to<JsonObject>();
+      // Generate Temperature in degrees C
+      if (lm75TempC != persisted_lm75_tempc || lm75_always) {
+        float lm75TempF = (lm75TempC * 1.8) + 32;
+        LM75data["tempc"] = (float)lm75TempC;
+        LM75data["tempf"] = (float)lm75TempF;
+        pub(LM75TOPIC, LM75data);
+      } else {
+        Log.notice(F("Same Temp. Don't send it" CR));
+      }
+    }
+    persisted_lm75_tempc = lm75TempC;
+  }
+}
+
+#endif

--- a/main/config_LM75.h
+++ b/main/config_LM75.h
@@ -1,0 +1,58 @@
+/*
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation
+
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
+   Send and receiving command by MQTT
+
+   This is a Temperature Addon:
+   - Measures Temperature
+   - Generates Values for: Temperature in degrees C and F
+   - Required Hardware Module: LM75 or NCT75
+   - Required Library: jeremycole/I2C Temperature Sensors derived from the LM75
+
+   Connection Schemata:
+   --------------------
+
+   LM75 ------> Arduino Uno ----------> ESP8266
+   ==============================================
+   Vcc ---------> 5V -------------------> Vu (5V)
+   GND ---------> GND ------------------> GND
+   SCL ---------> Pin A5 ---------------> D1
+   SDA ---------> Pin A4 ---------------> D2
+
+    This file is part of OpenMQTTGateway.
+
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef config_LM75_h
+#define config_LM75_h
+
+extern void setupLM75();
+extern void LM75toMQTT();
+
+#define lm75_always            true // if false when the current value of the parameter is the same as previous one don't send it by MQTT
+#define TimeBetweenReadinglm75 30000
+
+/*----------------------------USER PARAMETERS-----------------------------*/
+/*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
+#define LM75TOPIC "/TEMPtoMQTT/lm75"
+
+#if defined(ESP32)
+#  if !defined(I2C_SDA) || !defined(I2C_SCL)
+#    define I2C_SDA 16
+#    define I2C_SCL 0
+#  endif
+#endif
+
+#endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -114,6 +114,9 @@ struct GfSun2000Data {};
 #ifdef ZsensorHTU21
 #  include "config_HTU21.h"
 #endif
+#ifdef ZsensorLM75
+#  include "config_LM75.h"
+#endif
 #ifdef ZsensorAHTx0
 #  include "config_AHTx0.h"
 #endif
@@ -719,6 +722,10 @@ void setup() {
 #ifdef ZsensorHTU21
   setupZsensorHTU21();
   modules.add(ZsensorHTU21);
+#endif
+#ifdef ZsensorLM75
+  setupZsensorLM75();
+  modules.add(ZsensorLM75);
 #endif
 #ifdef ZsensorAHTx0
   setupZsensorAHTx0();
@@ -1428,6 +1435,9 @@ void loop() {
 #endif
 #ifdef ZsensorHTU21
       MeasureTempHum(); //Addon to measure Temperature, Humidity, of a HTU21 sensor
+#endif
+#ifdef ZsensorLM75
+      MeasureTemp(); //Addon to measure Temperature of an LM75 sensor
 #endif
 #ifdef ZsensorAHTx0
       MeasureAHTTempHum(); //Addon to measure Temperature, Humidity, of an 'AHTx0' sensor

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,6 +140,7 @@ emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
 decoder = https://github.com/theengs/decoder.git#v0.9.5
 ssd1306 = thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.3.0
+lm75 = jeremycole/I2C Temperature Sensors derived from the LM75@^1.0.3
 
 [env]
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -254,6 +254,7 @@ lib_deps =
   ${libraries.bme280}
   ${libraries.bmp180}
   ${libraries.htu21}
+  ${libraries.lm75}
   ${libraries.ahtx0}
   ${libraries.unifiedsensor}
   ${libraries.dht}
@@ -1015,6 +1016,7 @@ lib_deps =
   ${libraries.bme280}
   ${libraries.bmp180}
   ;${libraries.htu21}
+  ${libraries.lm75}
   ${libraries.ahtx0}
   ${libraries.unifiedsensor}
   ${libraries.dht}


### PR DESCRIPTION
## Description:

Adds support for LM75 compatible sensors.  Mostly copy+paste from the existing HTU21 sensor. I have tested this with a ESP8266 and NCT75 temperature sensor and it publishes sensible temperature values.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
