### PR TITLE
Wifi Manager AP name and password extracted from MAC

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -50,7 +50,7 @@
  */
 /*-------------DEFINE GATEWAY NAME BELOW IT CAN ALSO BE DEFINED IN platformio.ini----------------*/
 
-// Uncomment to use the MAC address in the format of 112233445566 as the gateway name
+// Uncomment to use the MAC address first 4 digits in the format of 5566 as the gateway name
 // Any definition of Gateway_Name will be ignored. The Gateway_Short_name _ MAC will be used as the access point name.
 //#define USE_MAC_AS_GATEWAY_NAME
 #ifndef Gateway_Name
@@ -114,11 +114,9 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #  endif
 #endif
 
-#define WM_PWD_FROM_MAC false // enable to set the password from the 8 first digit of the ESP mac address for enhanced security, enabling this option requires to have access to the MAC address, either through a sticker or with serial monitoring
-#if !WM_PWD_FROM_MAC
-#  ifndef WifiManager_password
-#    define WifiManager_password "your_password" //this is going to be the WPA2-PSK password for the initial setup access point
-#  endif
+//#define WM_PWD_FROM_MAC true // enable to set the password from the 8 first digit of the ESP mac address for enhanced security, enabling this option requires to have access to the MAC address, either through a sticker or with serial monitoring
+#ifndef WifiManager_password
+#  define WifiManager_password "your_password" //this is going to be the WPA2-PSK password for the initial setup access point
 #endif
 #ifndef WifiManager_ssid
 #  define WifiManager_ssid Gateway_Name //this is the network name of the initial setup access point

--- a/platformio.ini
+++ b/platformio.ini
@@ -292,7 +292,7 @@ build_flags =
   '-DZgatewayWeatherStation="WeatherStation"'
   '-DsimplePublishing=true'
   '-DWM_PWD_FROM_MAC=true'
-  '-DGateway_Name="OpenMQTTGateway_ESP32_ALL"'
+  '-DUSE_MAC_AS_GATEWAY_NAME=true'
 
 [env:esp32dev-rf]
 platform = ${com.esp32_platform}


### PR DESCRIPTION
## Description:
Set the AP name with the short name plus the 4 first digits of the ESP mac
to don't disclose the password used for WM.
Also change the wm password from MAc to be the last 8 digits, as these will change more than the first 8 ones. Also make consistent the ifndef qnd the parsing between WM_PWD_FROM_MAC and USE_MAC_AS_GATEWAY_NAME

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
