### PR TITLE
Enable to keep actuator on off state in case of restart

### DIFF
--- a/main/ZactuatorONOFF.ino
+++ b/main/ZactuatorONOFF.ino
@@ -30,6 +30,13 @@
 
 #ifdef ZactuatorONOFF
 
+void setupONOFF() {
+  pinMode(ACTUATOR_ONOFF_GPIO, OUTPUT);
+#  ifdef ACTUATOR_ONOFF_DEFAULT
+  digitalWrite(ACTUATOR_ONOFF_GPIO, ACTUATOR_ONOFF_DEFAULT);
+#  endif
+}
+
 #  if jsonReceiving
 void MQTTtoONOFF(char* topicOri, JsonObject& ONOFFdata) {
   if (cmpToMainTopic(topicOri, subjectMQTTtoONOFF)) {
@@ -104,7 +111,11 @@ void ActuatorButtonTrigger() {
   }
   Log.trace(F("Actuator triggered %s by button" CR), level_string);
   digitalWrite(ACTUATOR_ONOFF_GPIO, level);
-  pub(subjectGTWONOFFtoMQTT, level_string);
+  // Send the state of the switch to the broker so as to update the status
+  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
+  JsonObject ONOFFdata = jsonBuffer.to<JsonObject>();
+  ONOFFdata["cmd"] = (int)level;
+  pub(subjectGTWONOFFtoMQTT, ONOFFdata);
 }
 
 #endif

--- a/main/config_ONOFF.h
+++ b/main/config_ONOFF.h
@@ -39,9 +39,7 @@ extern void MQTTtoONOFF(char* topicOri, JsonObject& RFdata);
 #ifndef ACTUATOR_ON
 #  define ACTUATOR_ON LOW // LOW or HIGH, set to the output level of the gpio pin to turn the actuator on.
 #endif
-#ifndef ACTUATOR_ONOFF_DEFAULT
-#  define ACTUATOR_ONOFF_DEFAULT !ACTUATOR_ON // ACTUATOR_ON or !ACTUATOR_ON, set to the state desired on reset.
-#endif
+//#  define ACTUATOR_ONOFF_DEFAULT !ACTUATOR_ON // ACTUATOR_ON or !ACTUATOR_ON, set to the state desired on reset.
 #ifndef ACTUATOR_BUTTON_TRIGGER_LEVEL
 #  define ACTUATOR_BUTTON_TRIGGER_LEVEL LOW // 0 or 1, set to the sensing level which to detect a button press to change the actuator state.
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -712,8 +712,8 @@ void setup() {
   delay(1500);
 
 #ifdef ZactuatorONOFF
-  pinMode(ACTUATOR_ONOFF_GPIO, OUTPUT);
-  digitalWrite(ACTUATOR_ONOFF_GPIO, ACTUATOR_ONOFF_DEFAULT);
+  setupONOFF();
+  modules.add(ZactuatorONOFF);
 #endif
 #ifdef ZsensorBME280
   setupZsensorBME280();


### PR DESCRIPTION
## Description:
and publish status as a json when triggering actuator on off through a button

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
