### PR TITLE
Enable to configure the OTA password from the Wifi Manager portal

### DIFF
--- a/docs/upload/portal.md
+++ b/docs/upload/portal.md
@@ -21,6 +21,7 @@ From your smartphone search for your OpenMQTTGateway wifi network and connect to
 * Set your MQTT Server password (facultative)
 * Set your MQTT base topic if you need to change it (you must keep the / at the end)
 * Set your gateway name if you need to change it
+* Set your Over The Air password, this password is used for local and remote OTA
 
 * Click on save
 


### PR DESCRIPTION
## Description:
To enable the user to change the default one when setting up the gateway

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
