### PR TITLE
Add BMP280 support, compiler directive support for oversampling

### DIFF
--- a/docs/prerequisites/board.md
+++ b/docs/prerequisites/board.md
@@ -3,7 +3,7 @@ OpenMQTTGateway is not closed to one board or type of board, by using the power 
 
 You can take a look to the [OpenMQTTGateway compatible website](https://compatible.openmqttgateway.com) to have a view of the [supported boards](https://compatible.openmqttgateway.com/index.php/boards/).
 
-Moreover the gateways capacities can be extended with sensors; DHT, HC SR501, ADC, I2C bus, INA226, TSL2561, BME280, HTU21D, AHTx0, DS1820
+Moreover the gateways capacities can be extended with sensors; DHT, HC SR501, ADC, I2C bus, INA226, TSL2561, BME280/BMP280, HTU21D, AHTx0, DS1820
 or actuators; LED, relays, PWM.
 
 ::: tip Running on a computer
@@ -56,7 +56,7 @@ HM10 is no longer supported by OpenMQTTGateway
 
 ![boards](../img/OpenMQTTGateway_boards.png)
 
-Arduino + ethernet shields enables faster responsiveness of the gateway and a reliable connection. 
+Arduino + ethernet shields enables faster responsiveness of the gateway and a reliable connection.
 
 The ESP platform is more flexible in term of installation (no need of an ethernet cable) but is less reliable in term of communication. Thanks to its higher memory and processing power it has more modules or possibilities compared to Arduino Uno & Mega.
 
@@ -64,6 +64,3 @@ Choosing your board depends heavily on the technologies you want to use with it.
 To have a good overview of the compatibilities per board you can refer to the compatible modules attributes of each [board](https://compatible.openmqttgateway.com/index.php/boards/).
 
 The choice between these boards will depend on your knowledge and your requirements in terms of reliability, situation, modules wanted and devices you already have.
-
-
-

--- a/docs/setitup/sensors.md
+++ b/docs/setitup/sensors.md
@@ -2,15 +2,16 @@
 ## Compatible sensors
 |Module|Purpose|Where to Buy|
 |-|-|-|
-|DHT11|Temperature and Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|DHT22|Temperature and Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|DHT11|Temperature, Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|DHT22|Temperature, Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
 |HCSR501|PIR|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
 |BH1750|Digital light|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|BME280|Temperature, Humidity and pressure|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|BME280|Temperature, Humidity, Pressure|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|BMP280|Temperature, Pressure|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
 |HTU21|Temperature, Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
 |GPIO Input|Inputs|-|
 |GPIO KeyCode|Keycode|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|INA226|Current and voltage|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|INA226|Current, Voltage|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
 |TSL2561|Luminosity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
 
 ## Pinout
@@ -21,8 +22,8 @@
 |Analog reading|A0|A0|A0|
 |BH1750 SDA|A4|D2|21|
 |BH1750 SCL|A5|D1|22|
-|BME280 SDA|A4|D2|21|
-|BME280 SCL|A5|D1|22|
+|BME280/BMP280 SDA|A4|D2|21|
+|BME280/BMP280 SCL|A5|D1|22|
 |HTU21 SDA|A4|D2|21|
 |HTU21 SCL|A5|D1|22|
 |INA226 SDA|A4|D2|21|

--- a/main/ZsensorBME280.ino
+++ b/main/ZsensorBME280.ino
@@ -1,29 +1,29 @@
-/*  
-  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation 
+/*
+  OpenMQTTGateway Addon  - ESP8266 or Arduino program for home automation
 
-   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker
    Send and receiving command by MQTT
- 
+
    This is the Climate Addon:
    - Measures Temperature, Humidity and Pressure
    - Generates Values for: Temperature in degrees C and F, Humidity in %, Pressure in Pa, Altitude in Meter and Feet
-   - Required Hardware Module: Bosch BME280
+   - Required Hardware Module: Bosch BME280/BMP280
    - Required Library: SparkFun BME280 Library v1.1.0 by Marshall Taylor
 
    Connection Schemata:
    --------------------
 
-   bme280 ------> Arduino Uno ----------> ESP8266
-   ==============================================
-   Vcc ---------> 5V -------------------> Vu (5V)
-   GND ---------> GND ------------------> GND
-   SCL ---------> Pin A5 ---------------> D1
-   SDA ---------> Pin A4 ---------------> D2
- 
+   BME280/BMP280 ------> Arduino Uno ----------> ESP8266
+   =====================================================
+   Vcc ----------------> 5V/3.3V     ----------> 5V/3.3V    (5V or 3.3V depends on the BME280/BMP280 board variant)
+   GND ----------------> GND         ----------> GND
+   SCL ----------------> Pin A5      ----------> D1
+   SDA ----------------> Pin A4      ----------> D2
+
     Copyright: (c) Hans-Juergen Dinges
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -58,7 +58,7 @@ void setupZsensorBME280() {
 
   mySensor.settings.commInterface = I2C_MODE;
   mySensor.settings.I2CAddress = BME280_i2c_addr;
-  Log.notice(F("Setup BME280 on adress: %X" CR), BME280_i2c_addr);
+  Log.notice(F("Setup BME280/BMP280 on address: %X" CR), BME280_i2c_addr);
   //***Operation settings*****************************//
 
   // runMode Setting - Values:
@@ -93,33 +93,35 @@ void setupZsensorBME280() {
   // ------------------------
   //  0, skipped
   //  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
-  mySensor.settings.tempOverSample = 1;
+  mySensor.settings.tempOverSample = BME280TemperatureOversample;
 
   // pressOverSample - Values:
   // -------------------------
   //  0, skipped
   //  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
-  mySensor.settings.pressOverSample = 1;
+  mySensor.settings.pressOverSample = BME280PressureOversample;
 
   // humidOverSample - Values:
   // -------------------------
   //  0, skipped
   //  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
-  mySensor.settings.humidOverSample = 1;
+  mySensor.settings.humidOverSample = BME280HumidityOversample;
 
-  // tempCorrection - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
+  // tempCorrection - Correction in celcius of temperature reported by BME280/BMP280 sensor. Both Celcius and Farenheit temperatures are adjusted.
   // -------------------------
   // Value is a float
   // ie Compiler Directive '-DBME280Correction=-3.4'
   mySensor.settings.tempCorrection = BME280Correction;
 
-  delay(10); // Gives the Sensor enough time to turn on (The BME280 requires 2ms to start up)
+  delay(10); // Gives the Sensor enough time to turn on (The BME280/BMP280 requires 2ms to start up)
 
   int ret = mySensor.begin();
   if (ret == 0x60) {
     Log.notice(F("Bosch BME280 successfully initialized: %X" CR), ret);
+  } else if (ret == 0x58) {
+    Log.notice(F("Bosch BMP280 successfully initialized: %X" CR), ret);
   } else {
-    Log.notice(F("Bosch BME280 failed: %X" CR), ret);
+    Log.notice(F("Bosch BME280/BMP280 failed: %X" CR), ret);
   }
 }
 
@@ -142,9 +144,9 @@ void MeasureTempHumAndPressure() {
 
     // Check if reads failed and exit early (to try again).
     if (isnan(BmeTempC) || isnan(BmeTempF) || isnan(BmeHum) || isnan(BmePa) || isnan(BmeAltiM) || isnan(BmeAltiFt)) {
-      Log.error(F("Failed to read from BME280!" CR));
+      Log.error(F("Failed to read from BME280/BMP280!" CR));
     } else {
-      Log.trace(F("Creating BME280 buffer" CR));
+      Log.trace(F("Creating BME280/BMP280 buffer" CR));
       StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
       JsonObject BME280data = jsonBuffer.to<JsonObject>();
       // Generate Temperature in degrees C

--- a/main/config_BME280.h
+++ b/main/config_BME280.h
@@ -1,15 +1,15 @@
-/*  
-  OpenMQTTGateway  - ESP8266 or Arduino program for home automation 
+/*
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation
 
-   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal  and a MQTT broker 
+   Act as a wifi or ethernet gateway between your 433mhz/infrared IR signal and a MQTT broker
    Send and receiving command by MQTT
- 
-   This files enables to set your parameter for the BME280 sensor
 
-    Copyright: (c) Hans-Juergen Dinges  
-    
+   This files enables you to set parameters for the BME280 or BMP280 sensors.
+
+    Copyright: (c) Hans-Juergen Dinges
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -26,13 +26,12 @@
    Connection Schemata:
    --------------------
 
-   BH1750 ------> Arduino Uno ----------> ESP8266
-   ==============================================
-   Vcc ---------> 5V -------------------> Vu (5V)
-   GND ---------> GND ------------------> GND
-   SCL ---------> Pin A5 ---------------> D1
-   SDA ---------> Pin A4 ---------------> D2
-   ADD ---------> N/C (Not Connected) --> N/C (Not Connected)
+   BME280/BMP280 ------> Arduino Uno ----------> ESP8266
+   =====================================================
+   Vcc ----------------> 5V/3.3V     ----------> 5V/3.3V    (5V or 3.3V depends on the BME280/BMP280 board variant)
+   GND ----------------> GND         ----------> GND
+   SCL ----------------> Pin A5      ----------> D1
+   SDA ----------------> Pin A4      ----------> D2
 
 */
 #ifndef config_BME280_h
@@ -62,15 +61,39 @@ int BME280_i2c_addr = 0x76; // Bosch BME280 I2C Address
 int BME280_PIN_SDA = SDA; // PIN SDA
 int BME280_PIN_SCL = SCL; // PIN SCL
 
-// Temperature correction for BME280 devices
+// Oversampling for BME280/BMP280 devices
+
+#ifndef BME280TemperatureOversample
+// BME280TemperatureOversample - Values:
+// ------------------------
+//  0, skipped
+//  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
+#  define BME280TemperatureOversample 1
+#endif
+
+#ifndef BME280PressureOversample
+// BME280PressureOversample - Values:
+// -------------------------
+//  0, skipped
+//  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
+#  define BME280PressureOversample 1
+#endif
+
+#ifndef BME280HumidityOversample
+// BME280HumidityOversample - Values:
+// -------------------------
+//  0, skipped
+//  1 through 5, oversampling *1, *2, *4, *8, *16 respectively
+#  define BME280HumidityOversample 1
+#endif
+
+// Temperature correction for BME280/BMP280 devices
 
 #ifndef BME280Correction
-
-// BME280Correction - Correction in celcius of temperature reported by bme280 sensor.  Both Celcius and Farenheit temperatures are adjusted.
+// BME280Correction - Correction in celcius of temperature reported by BME280/BMP280 sensor. Both Celcius and Farenheit temperatures are adjusted.
 // -------------------------
 // Value is a float
 // ie Compiler Directive '-DBME280Correction=-3.4'
-
 #  define BME280Correction 0
 #endif
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -1471,7 +1471,7 @@ void loop() {
       }
 #endif
 #ifdef ZsensorBME280
-      MeasureTempHumAndPressure(); //Addon to measure Temperature, Humidity, Pressure and Altitude with a Bosch BME280
+      MeasureTempHumAndPressure(); //Addon to measure Temperature, Humidity, Pressure and Altitude with a Bosch BME280/BMP280
 #endif
 #ifdef ZsensorHTU21
       MeasureTempHum(); //Addon to measure Temperature, Humidity, of a HTU21 sensor


### PR DESCRIPTION
## Description:
The BMP280 is a sister sensor to the BME280. Unlike the BME280, it doesn't measure humidity but is 33% more accurate than it for pressure. Technically, OMG already supports BMP280 with the same BME280 library ([added 2018](https://github.com/sparkfun/SparkFun_BME280_Arduino_Library/commit/6c239570ac816b5559c870fd68bbf5317fc2413a)) and it worked with OMG as it is, but this updates the documentation and comments and removes the error message when a BMP280 is recognized instead of a BME280.

I also add compiler directives for temperature/humidity/pressure oversampling settings for the BME280/BMP280. It's a minor change that mirrors the existing temperature correction, and the comments for it will mention the BMP280, so I included this in this PR too. Let me know if that's ok.

Some minor spelling and grammar fixes in the comments.

I don't know how to edit/suggest things to the Compatibility website, but we could add the [BMP-280 sensor I'm using](https://www.amazon.com/gp/product/B07VNDZ6N4/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1) to it.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
