### PR TITLE
[CI] Remove unnecessary macro

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
           - "ttgo-t-beam"
           - "heltec-wifi-lora-32-868"
           - "heltec-wifi-lora-32-915"
-          - "esp32dev-mqtt-fw-test"
           - "nodemcuv2-all-test"
           - "nodemcuv2-fastled-test"
           - "nodemcuv2-2g"

--- a/platformio.ini
+++ b/platformio.ini
@@ -992,19 +992,6 @@ build_flags =
   '-DTimeLedON=0.1'
   '-DLED_SEND_RECEIVE_ON=1'
 
-[env:esp32dev-mqtt-fw-test]
-platform = ${com.esp32_platform}
-board = esp32dev
-lib_deps =
-  ${com-esp.lib_deps}
-  ${libraries.wifimanager32}
-build_flags =
-  ${com-esp.build_flags}
-  '-DMQTT_HTTPS_FW_UPDATE'
-  '-DMQTT_SECURE_SELF_SIGNED'
-  '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
-board_build.flash_mode = dout
-
 [env:nodemcuv2-all-test]
 platform = ${com.esp8266_platform}
 board = nodemcuv2
@@ -1216,7 +1203,7 @@ lib_deps =
   ${libraries.wifimanager8266}
 build_flags =
   ${com-esp.build_flags}
-  '-DMQTT_HTTPS_FW_UPDATE'
+  '-DMQTT_SECURE_SELF_SIGNED'
   '-DGateway_Name="OpenMQTTGateway_TEST_MQTT_FW"'
 board_build.flash_mode = dout
 


### PR DESCRIPTION
## Description:
This macro is not necessary to add per environment as it is present into com-esp as a global macro for all ESP, also modifying nodemcuv2-mqtt-fw-test env to test self signed only. Removing `env:esp32dev-mqtt-fw-test` as self signed cert are already tested into `env:esp32dev-ble-aws`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
