### PR TITLE
[DOCS] Move base outside of ThemeConfig

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,6 +3,7 @@ module.exports = {
       lineNumbers: true
     },
     title: 'OpenMQTTGateway version_tag',
+    base: '/',
     description: 'One gateway, many technologies: MQTT gateway for ESP8266, ESP32, Sonoff RF Bridge or Arduino with bidirectional 433mhz/315mhz/868mhz, Infrared communications, BLE, beacons detection, mi flora / mi jia / LYWSD02/ Mi Scale compatibility, SMS & LORA.',
     head: [
       ['link', { rel: "icon", type: "image/png", sizes: "32x32", href: "/favicon-32x32.png"}],
@@ -22,7 +23,6 @@ module.exports = {
       smoothScroll: true,
       repo: '1technophile/OpenMQTTGateway',
       docsDir: 'docs',
-      base: '/',
       docsBranch: 'development',
       lastUpdated: 'Last Updated',
       editLinks: true,


### PR DESCRIPTION
## Description:
The base subfolder was not located in the appropriate section of the `config.js`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
