### PR TITLE
HA auto discovery - Add numbers for interval and scans netween connects

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -277,6 +277,8 @@ void createDiscovery(const char* sensor_type,
   if (payload_on[0]) {
     if (strcmp(sensor_type, "button") == 0) {
       sensor["pl_prs"] = payload_on; // payload_press for a button press
+    } else if (strcmp(sensor_type, "number") == 0) {
+      sensor["cmd_tpl"] = payload_on; // payload_on for a switch
     } else {
       sensor["pl_on"] = payload_on; // payload_on for a switch
     }
@@ -924,21 +926,21 @@ void pubMqttDiscovery() {
 #  endif
 
 #  ifdef ZgatewayBT
-  createDiscovery("sensor", //set Type
+  createDiscovery("number", //set Type
                   subjectSYStoMQTT, "BT: Interval between scans", (char*)getUniqueId("interval", "").c_str(), //set state_topic,name,uniqueId
-                  "", "", "{{ value_json.interval }}", //set availability_topic,device_class,value_template,
-                  "", "", "ms", //set,payload_on,payload_off,unit_of_meas,
+                  "", "", "{{ value_json.interval/1000 }}", //set availability_topic,device_class,value_template,
+                  "{\"interval\":{{value*1000}}}", "", "s", //set,payload_on,payload_off,unit_of_meas,
                   0, //set  off_delay
-                  "", "", true, "", //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
+                  "", "", true, subjectMQTTtoBTset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
                   "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain,
                   stateClassNone //State Class
   );
-  createDiscovery("sensor", //set Type
+  createDiscovery("number", //set Type
                   subjectSYStoMQTT, "BT: Connnect every X scan(s)", (char*)getUniqueId("scanbcnct", "").c_str(), //set state_topic,name,uniqueId
                   "", "", "{{ value_json.scanbcnct }}", //set availability_topic,device_class,value_template,
-                  "", "", "", //set,payload_on,payload_off,unit_of_meas,
-                  0, //set  off_delay
-                  "", "", true, "", //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
+                  "{\"scanbcnct\":{{value}}}", "", "", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set off_delay
+                  "", "", true, subjectMQTTtoBTset, //set,payload_avalaible,payload_not avalaible,is a gateway entity, command topic
                   "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain
                   stateClassNone //State Class
   );


### PR DESCRIPTION
## Description:
To be able to set those values directly through the HA interface
![image](https://user-images.githubusercontent.com/12672732/207154145-d41f0828-cf09-46d3-8500-a1b006599263.png)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
