### PR TITLE
Add dynamic active scan setting

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -136,6 +136,18 @@ With Home Assistant, this command is directly available through MQTT auto discov
 
 The gateway will publish only the detected sensors like Mi Flora, Mi jia, LYWSD03MMC... and not the other BLE devices. This is usefull if you don't use the gateway for presence detection but only to retrieve sensors data.
 
+## Setting if the gateway use active or passive scanning
+
+If you want to change this characteristic (default:true):
+
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"activescan":false}'`
+
+::: tip
+With Home Assistant, this command is directly available through MQTT auto discovery as a switch into the HASS OpenMQTTGateway device entities list.
+:::
+
+If false, the gateway will only do a passive scanning (not request for sensor broadcasts), some sensors may not advertize their data with passive scanning.
+
 ## Setting if the gateway connects to BLE devices eligibles on ESP32
 
 If you want to change this characteristic:

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -89,6 +89,7 @@ static bool oneWhite = false;
 void BTConfig_init() {
   BTConfig.bleConnect = AttemptBLEConnect;
   BTConfig.BLEinterval = TimeBtwRead;
+  BTConfig.activeScan = ActiveBLEScan;
   BTConfig.BLEscanBeforeConnect = ScanBeforeConnect;
   BTConfig.pubOnlySensors = PublishOnlySensors;
   BTConfig.presenceEnable = HassPresence;
@@ -127,6 +128,8 @@ void BTConfig_fromJson(JsonObject& BTdata, bool startup = false) {
   // Scan interval set
   if (BTdata.containsKey("interval") && BTdata["interval"] != 0)
     BTConfig_update(BTdata, "interval", BTConfig.BLEinterval);
+  // Define if the scan is active or passive
+  BTConfig_update(BTdata, "activescan", BTConfig.activeScan);
   // Number of scan before a connect set
   BTConfig_update(BTdata, "scanbcnct", BTConfig.BLEscanBeforeConnect);
   // publish all BLE devices discovered or  only the identified sensors (like temperature sensors)
@@ -164,6 +167,7 @@ void BTConfig_fromJson(JsonObject& BTdata, bool startup = false) {
   JsonObject jo = jsonBuffer.to<JsonObject>();
   jo["bleconnect"] = BTConfig.bleConnect;
   jo["interval"] = BTConfig.BLEinterval;
+  jo["activescan"] = BTConfig.activeScan;
   jo["scanbcnct"] = BTConfig.BLEscanBeforeConnect;
   jo["onlysensors"] = BTConfig.pubOnlySensors;
   jo["hasspresence"] = BTConfig.presenceEnable;
@@ -611,7 +615,7 @@ void BLEscan() {
   BLEScan* pBLEScan = BLEDevice::getScan();
   MyAdvertisedDeviceCallbacks myCallbacks;
   pBLEScan->setAdvertisedDeviceCallbacks(&myCallbacks);
-  pBLEScan->setActiveScan(ActiveBLEScan);
+  pBLEScan->setActiveScan(BTConfig.activeScan);
   pBLEScan->setInterval(BLEScanInterval);
   pBLEScan->setWindow(BLEScanWindow);
   BLEScanResults foundDevices = pBLEScan->start(Scan_duration / 1000, false);
@@ -789,6 +793,7 @@ void setupBT() {
   Log.notice(F("BLE scans interval: %d" CR), BTConfig.BLEinterval);
   Log.notice(F("BLE scans number before connect: %d" CR), BTConfig.BLEscanBeforeConnect);
   Log.notice(F("Publishing only BLE sensors: %T" CR), BTConfig.pubOnlySensors);
+  Log.notice(F("Active BLE scan: %T" CR), BTConfig.activeScan);
   Log.notice(F("minrssi: %d" CR), -abs(BTConfig.minRssi));
   Log.notice(F("Low Power Mode: %d" CR), lowpowermode);
 

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -963,6 +963,15 @@ void pubMqttDiscovery() {
                   stateClassNone //State Class
   );
   createDiscovery("switch", //set Type
+                  "", "BT: Active scan", (char*)getUniqueId("active_scan", "").c_str(), //set state_topic,name,uniqueId
+                  "", "", "", //set availability_topic,device_class,value_template,
+                  "{\"activescan\":true}", "{\"activescan\":false}", "", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoBTset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
+                  "", "", "", "", true, // device name, device manufacturer, device model, device MAC, retain
+                  stateClassNone //State Class
+  );
+  createDiscovery("switch", //set Type
                   "", "BT: Publish HASS presence", (char*)getUniqueId("hasspresence", "").c_str(), //set state_topic,name,uniqueId
                   "", "", "", //set availability_topic,device_class,value_template,
                   "{\"hasspresence\":true}", "{\"hasspresence\":false}", "", //set,payload_on,payload_off,unit_of_meas,

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -146,6 +146,7 @@ unsigned long scanCount = 0;
 /*----------------CONFIGURABLE PARAMETERS-----------------*/
 struct BTConfig_s {
   bool bleConnect; // Attempt a BLE connection to sensors with ESP32
+  bool activeScan;
   unsigned int BLEinterval; // Time between 2 scans
   unsigned int BLEscanBeforeConnect; // Number of BLE scans between connection cycles
   bool pubOnlySensors; // Publish only the identified sensors (like temperature sensors)


### PR DESCRIPTION
## Description:
This commit add the capability to set passive scanning during runtime, versus build time before, so as to improve energy consumption of sensors when they don't require active scanning

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
