### PR TITLE
[HA Discovery] Remove auto discovery switch

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -519,16 +519,6 @@ void pubMqttDiscovery() {
                   "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain
                   stateClassNone //State Class
   );
-  createDiscovery("switch", //set Type
-                  "", "SYS: Auto discovery", (char*)getUniqueId("discovery", "").c_str(), //set state_topic,name,uniqueId
-                  will_Topic, "", "", //set availability_topic,device_class,value_template,
-                  "{\"discovery\":true}", "{\"discovery\":false}", "", //set,payload_on,payload_off,unit_of_meas,
-                  0, //set  off_delay
-                  Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoSYSset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
-                  "", "", "", "", true, // device name, device manufacturer, device model, device MAC, retain,
-                  stateClassNone //State Class
-  );
-
 #  ifdef ZsensorBME280
 #    define BMEparametersCount 5
   Log.trace(F("bme280Discovery" CR));


### PR DESCRIPTION
## Description:
I don't think there is usage for such a switch into HA discoveryconvention, if you see it, auto discovery was already activated and all the entities created, so you will have to go to the mqtt client to remove the retained messages.
If you don't want auto discovery as an HA convention user you would have to go to the mqtt client to send the discovery message deactivation.
So either way as a HA user you have to go to a client.
And as people not wanting to use auto discovery with HA convention are the people that are not using HA convention, this switch as a little value.

Prereq #1364 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
