### PR TITLE
Enable connection with encryption without certificate validation

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -196,6 +196,10 @@ const char* certificate PROGMEM = R"EOF("
 #    define MQTT_SECURE_DEFAULT false
 #  endif
 
+#  ifndef MQTT_CERT_VALIDATE_DEFAULT
+#    define MQTT_CERT_VALIDATE_DEFAULT false
+#  endif
+
 #  ifndef AWS_IOT
 #    define AWS_IOT false
 #  endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -213,6 +213,7 @@ static unsigned long last_ota_activity_millis = 0;
 #  define isDiscovered(device)  device->isDisc
 
 static bool mqtt_secure = MQTT_SECURE_DEFAULT;
+static bool mqtt_cert_validate = MQTT_CERT_VALIDATE_DEFAULT;
 static uint8_t mqtt_ss_index = MQTT_SECURE_SELF_SIGNED_INDEX_DEFAULT;
 static String mqtt_cert = "";
 static String ota_server_cert = "";
@@ -729,7 +730,12 @@ void setup() {
 #if defined(ESP8266) || defined(ESP32)
   if (mqtt_secure) {
     eClient = new WiFiClientSecure;
-    setupTLS(MQTT_SECURE_SELF_SIGNED, mqtt_ss_index);
+    if (mqtt_cert_validate) {
+      setupTLS(MQTT_SECURE_SELF_SIGNED, mqtt_ss_index);
+    } else {
+      WiFiClientSecure* sClient = (WiFiClientSecure*)eClient;
+      sClient->setInsecure();
+    }
   } else {
     eClient = new WiFiClient;
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -473,6 +473,7 @@ build_flags =
   '-DLED_SEND_RECEIVE_ON=0'
   '-DMQTT_SECURE_DEFAULT=true'
   '-DMQTT_SECURE_SELF_SIGNED'
+  '-DMQTT_CERT_VALIDATE_DEFAULT=true'
   '-DMQTT_SERVER="xxxxxxxxxxxxx-ats.iot.eu-west-2.amazonaws.com"'
   '-DMQTT_PORT="8883"'
   '-DMQTT_USER=""'


### PR DESCRIPTION
## Description:
This parameter enables to connect to an MQTT broker without validating the certificate chain of trust, it stills uses encryption for the communication but will be vulnerable to a MITM attack.
This is done to enable connection to MQTT brokers that doesn't have trusted certificates and/or to avoid managing certificate on the gateway side.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
