### PR TITLE
Fix internal temperature reading on ESP32

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -501,6 +501,7 @@ CRGB leds[FASTLED_IND_NUM_LEDS];
 //#  define TRIGGER_GPIO 14 // pin D5 as full reset button (long press >10s)
 #elif ESP32
 //#  define TRIGGER_GPIO 0 // boot button as full reset button (long press >10s)
+//#  define NO_INT_TEMP_READING true //Define if we don't want internal temperature reading for the ESP32
 #endif
 
 //      VCC   ------------D|-----------/\/\/\/\ -----------------  Arduino PIN

--- a/main/ZactuatorONOFF.ino
+++ b/main/ZactuatorONOFF.ino
@@ -107,7 +107,7 @@ void MQTTtoONOFF(char* topicOri, char* datacallback) {
 //Check regularly temperature of the ESP32 board and switch OFF the relay if temperature is more than MAX_TEMP_ACTUATOR
 #  ifdef MAX_TEMP_ACTUATOR
 void OverHeatingRelayOFF() {
-#    if defined(ESP32) && defined(SENS_SAR_MEAS_WAIT2_REG) // This macro is necessary to retrieve temperature and not present with S3 and C3 environment
+#    if defined(ESP32) && !defined(NO_INT_TEMP_READING)
   if (millis() > (timeinttemp + TimeBetweenReadingIntTemp)) {
     float internalTempc = intTemperatureRead();
     Log.trace(F("Internal temperature of the ESP32 %F" CR), internalTempc);

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -420,7 +420,7 @@ void pubMqttDiscovery() {
   );
 #    endif
 #  endif
-#  ifdef ESP32
+#  if defined(ESP32) && !defined(NO_INT_TEMP_READING)
   createDiscovery("sensor", //set Type
                   subjectSYStoMQTT, "SYS: Internal temperature", (char*)getUniqueId("tempc", "").c_str(), //set state_topic,name,uniqueId
                   "", "temperature", "{{ value_json.tempc }}", //set availability_topic,device_class,value_template,

--- a/main/main.ino
+++ b/main/main.ino
@@ -227,8 +227,7 @@ static String ota_server_cert = "";
 #  include <nvs_flash.h>
 
 bool ProcessLock = false; // Process lock when we want to use a critical function like OTA for example
-
-#  if defined(SENS_SAR_MEAS_WAIT2_REG)
+#  if !defined(NO_INT_TEMP_READING)
 // ESP32 internal temperature reading
 #    include <stdio.h>
 
@@ -1651,7 +1650,7 @@ unsigned long uptime() {
 /**
  * Calculate internal ESP32 temperature
  */
-#if defined(ESP32) && defined(SENS_SAR_MEAS_WAIT2_REG)
+#if defined(ESP32) && !defined(NO_INT_TEMP_READING)
 float intTemperatureRead() {
   SET_PERI_REG_BITS(SENS_SAR_MEAS_WAIT2_REG, SENS_FORCE_XPD_SAR, 3, SENS_FORCE_XPD_SAR_S);
   SET_PERI_REG_BITS(SENS_SAR_TSENS_CTRL_REG, SENS_TSENS_CLK_DIV, 10, SENS_TSENS_CLK_DIV_S);
@@ -1681,7 +1680,7 @@ void stateMeasures() {
   SYSdata["mqttport"] = mqtt_port;
   SYSdata["mqttsecure"] = mqtt_secure;
 #    ifdef ESP32
-#      ifdef SENS_SAR_MEAS_WAIT2_REG // This macro is necessary to retrieve temperature and not present with S3 and C3 environment
+#      ifndef NO_INT_TEMP_READING
   SYSdata["tempc"] = intTemperatureRead();
 #      endif
   SYSdata["freestack"] = uxTaskGetStackHighWaterMark(NULL);

--- a/platformio.ini
+++ b/platformio.ini
@@ -1512,6 +1512,7 @@ build_flags =
   '-DFASTLED_IND_TYPE=NEOPIXEL'
   '-DFASTLED_IND_NUM_LEDS=1'
   '-DRGB_INDICATORS=true'
+  '-DNO_INT_TEMP_READING=true' ; Internal temperature reading not building on ESP32 C3 or S3
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 
 [env:esp32c3-dev-m1-ble]
@@ -1531,6 +1532,7 @@ build_flags =
   '-DFASTLED_IND_TYPE=NEOPIXEL'
   '-DFASTLED_IND_NUM_LEDS=1'
   '-DRGB_INDICATORS=true'
+  '-DNO_INT_TEMP_READING=true' ; Internal temperature reading not building on ESP32 C3 or S3
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 
 [env:thingpulse-espgateway]


### PR DESCRIPTION
## Description:
The previous macro used SENS_SAR_MEAS_WAIT2_REG to identify if we have the reading capability was not working, so replacing it by a fresh one NO_INT_TEMP_READING, defined as a negation due to the fact that most of the ESP32 supports internal temperature reading.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
