### PR TITLE
Initial Support for display of BT Messages on ssd1306 display

### DIFF
--- a/docs/use/boards.md
+++ b/docs/use/boards.md
@@ -124,3 +124,21 @@ The mqtt command to change the units is:
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306 -m '{"display-metric":false}'`
 
 Please note that it may take several seconds/display updates for the units to change.  This is due to the queueing of messages for display.
+
+### Flip Display 180 degrees
+
+This allows you to rotate the display 180 degrees.  Can be set at compile time or during use, defaults to true.
+
+The compiler directive is `-DDISPLAY_FLIP=false`
+
+The mqtt command to change display orientation is:
+
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306 -m '{"display-flip":false}'`
+
+Please note that it may take several seconds/display updates for the display to change.  This is due to the queueing of messages for display.
+
+### Display OpenMQTTGateway Logo when Idle
+
+When this option is enabled the OLED display will show the OpenMQTTGateway Logo when it is idle.  Defaults to false
+
+The compiler directive is `-DDISPLAY_IDLE_LOGO=true`

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -235,6 +235,9 @@ void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
       topic = BTConfig.extDecoderTopic; // If external decoder, use this topic to send data
     topic = subjectBTtoMQTT + String("/") + topic;
     pub((char*)topic.c_str(), data);
+    if (data.containsKey("model") || data.containsKey("distance")) { // Only display sensor data
+      pubOled((char*)topic.c_str(), data);
+    }
   }
   if (haPresenceEnabled && data.containsKey("distance")) {
     if (data.containsKey("servicedatauuid"))

--- a/main/config_SSD1306.h
+++ b/main/config_SSD1306.h
@@ -59,11 +59,15 @@
 #endif
 
 #ifndef DISPLAY_IDLE_LOGO
-#  define DISPLAY_IDLE_LOGO true // Display the OMG logo when idle
+#  define DISPLAY_IDLE_LOGO false // Display the OMG logo when idle
 #endif
 
 #ifndef DISPLAY_METRIC
 #  define DISPLAY_METRIC true // Units used for display of sensor data
+#endif
+
+#ifndef DISPLAY_FLIP
+#  define DISPLAY_FLIP true // Flip display orientation
 #endif
 
 /*------------------- DEFAULT DISPLAY GEOMETRY ----------------------*/

--- a/platformio.ini
+++ b/platformio.ini
@@ -431,6 +431,7 @@ lib_deps =
   ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
+  ${libraries.ssd1306}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'

--- a/platformio.ini
+++ b/platformio.ini
@@ -422,6 +422,28 @@ build_flags =
   '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 
+[env:esp32dev-ble-heltec]
+platform = ${com.esp32_platform}
+board = heltec_wifi_lora_32_V2  ; or ttgo-lora32-v21  for the LilyGO Board
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ble}
+  ${libraries.decoder}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayBT="BT"'
+  '-DPublishOnlySensors=true'
+  '-DLED_SEND_RECEIVE=LED_BUILTIN'
+ ; '-DLED_SEND_RECEIVE_ON=0'
+  '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_Heltec"'
+; *** ssd1306 Display Options ***
+  ;'-DLOG_TO_LCD=false'         ; Enable log to LCD
+  ;'-DLOG_LEVEL_LCD=LOG_LEVEL_NOTICE'
+  ;'-DDISPLAY_FLIP=false'
+  ;'-DDISPLAY_IDLE_LOGO=false'
+
 [env:esp32dev-ble-openhab]
 platform = ${com.esp32_platform}
 board = esp32dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -440,6 +440,7 @@ build_flags =
  ; '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_Heltec"'
 ; *** ssd1306 Display Options ***
+  '-DZdisplaySSD1306="HELTEC_OLED"'
   ;'-DLOG_TO_LCD=false'         ; Enable log to LCD
   ;'-DLOG_LEVEL_LCD=LOG_LEVEL_NOTICE'
   ;'-DDISPLAY_FLIP=false'


### PR DESCRIPTION
## Description:

@DigiH This is my first take on enabling the ssd1306 display for Bluetooth sensors.  And it currently only really support my think bird.

Can you take at the mapping section for BT messages, and let me know.  If you have some sample messages for devices or other suggestions, much appreciated.

I added an additional board definition which should enable the display on a Heltec board - esp32dev-ble-heltec

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
