### PR TITLE
[HA Discovery] Add a check on device id before concatenating it to the device name

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -332,7 +332,7 @@ void createDiscovery(const char* sensor_type,
     identifiers.add(String(getMacAddress()));
   } else {
     //The Connections
-    if (device_id[0] != 0) {
+    if (device_id[0]) {
       JsonArray connections = device.createNestedArray("connections");
       JsonArray connection_mac = connections.createNestedArray();
       connection_mac.add("mac");
@@ -352,7 +352,7 @@ void createDiscovery(const char* sensor_type,
 
     // generate unique device name by adding the second half of the device_id only if device_name and device_id are different
     if (device_name[0]) {
-      if (strcmp(device_id, device_name) != 0) {
+      if (strcmp(device_id, device_name) != 0 && device_id[0]) {
         device["name"] = device_name + String("-") + String(device_id + 6);
       } else {
         device["name"] = device_name;


### PR DESCRIPTION
## Description:
Reinforce checks on device id building, so as to avoid concatenating an unknown array

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
