### PR TITLE
[CI] Change environments ini name

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -318,7 +318,7 @@ build_flags =
   '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE_C"'
   '-DTimeBtwRead=0'
-  '-DScan_duration=1000'
+  '-DScan_duration=3000'
   '-DAttemptBLEConnect=false'
 custom_description = Regular BLE gateway with continuous scan and no BLE connection attempt per default
 
@@ -1382,9 +1382,10 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DLED_SEND_RECEIVE=2'
   '-DLED_SEND_RECEIVE_ON=0'
-  '-DpubBLEManufacturerData=true'
+  '-DTimeBtwRead=0'
+  '-DScan_duration=3000'
+  '-DAttemptBLEConnect=false'
   '-DpubBLEAdvData=true'
-  '-DpubBLEServiceUUID=true'
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
 custom_description = Default BLE gateway with additional servicedata, manufacturerdata and service uuid for analysing decoding issues
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ src_dir = main
 include_dir = main
 
 extra_configs =
-  boards.ini
+  environments.ini
   tests/*_env.ini
   *_env.ini
 

--- a/scripts/generate_board_docs.py
+++ b/scripts/generate_board_docs.py
@@ -11,7 +11,7 @@ table_init = pd.DataFrame(columns=['Environment', 'uC', 'Hardware', 'Description
 table = table_init
 
 # Parse platformio.ini to retrieve boards information
-conf.read('boards.ini')
+conf.read('environments.ini')
 for each_section in conf.sections():
     if ("env:" in each_section and "-test" not in each_section):
         env = each_section.replace("env:", "")


### PR DESCRIPTION
## Description:
Remove unnecessary macros,
modify `esp32dev-ble-datatest` environment to be continuous
change scan duration to 3s for continuous scan esp32 ble environments

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
