### PR TITLE
[BT] Regular BLE system parameter pub

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -1492,6 +1492,9 @@ void loop() {
       if (now > (timer_sys_measures + (TimeBetweenReadingSYS * 1000)) || !timer_sys_measures) {
         timer_sys_measures = millis();
         stateMeasures();
+#  ifdef ZgatewayBT
+        stateBTMeasures(false);
+#  endif
       }
 #endif
 #ifdef ZsensorBME280
@@ -1562,12 +1565,7 @@ void loop() {
       if (disc)
         launchBTDiscovery(publishDiscovery);
 #  endif
-#  ifndef ESP32
-      if (BTtoMQTT())
-        Log.trace(F("BTtoMQTT OK" CR));
-#  else
       emptyBTQueue();
-#  endif
 #endif
 #ifdef ZgatewaySRFB
       SRFBtoMQTT();
@@ -1705,10 +1703,6 @@ void stateMeasures() {
 #  ifdef ZgatewayBT
 #    ifdef ESP32
   SYSdata["lowpowermode"] = (int)lowpowermode;
-  SYSdata["btqblck"] = btQueueBlocked;
-  SYSdata["btqsum"] = btQueueLengthSum;
-  SYSdata["btqsnd"] = btQueueLengthCount;
-  SYSdata["btqavg"] = (btQueueLengthCount > 0 ? btQueueLengthSum / (float)btQueueLengthCount : 0);
 #    endif
   SYSdata["interval"] = BTConfig.BLEinterval;
   SYSdata["scanbcnct"] = BTConfig.BLEscanBeforeConnect;


### PR DESCRIPTION
## Description:
Publish BT config parameter at start so as to update the switch statuses in the controller Also publish regularly in case of controller restart Also move btqsum, btqsnd and btqavg to BTtoMQTT topic instead of SYStoMQTT as they are more relevant here

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
