### PR TITLE
[ONOFF] Add overcurrent protection

### DIFF
--- a/main/ZsensorRN8209.ino
+++ b/main/ZsensorRN8209.ino
@@ -35,6 +35,23 @@ extern "C" bool init_8209c_interface();
 
 StaticJsonDocument<JSON_MSG_BUFFER> doc;
 
+// GetCurrent function for critical operation like overcurrent protection
+float getRN8209current() {
+  uint8_t ret = rn8209c_read_emu_status();
+  if (ret) {
+    int32_t current;
+    uint32_t temp_current = 0;
+    rn8209c_read_current(phase_A, &temp_current);
+    if (ret == 1) {
+      current = temp_current;
+    } else {
+      current = (int32_t)temp_current * (-1);
+    }
+    return current / 10000.0;
+  }
+  return 0;
+}
+
 void rn8209_loop(void* mode) {
   if (!ProcessLock) {
     uint32_t voltage;
@@ -78,6 +95,7 @@ void setupRN8209() {
   set_user_param(cal);
   init_8209c_interface();
   xTaskCreate(rn8209_loop, "rn8209_loop", RN8209_TASK_STACK_SIZE, NULL, RN8209_TASK_PRIO, NULL);
+  Log.trace(F("ZsensorRN8209 setup done " CR));
 }
 
 #endif // ZsensorRN8209

--- a/main/config_ONOFF.h
+++ b/main/config_ONOFF.h
@@ -47,10 +47,17 @@ extern void MQTTtoONOFF(char* topicOri, JsonObject& RFdata);
 //#  define ACTUATOR_BUTTON_TRIGGER_LEVEL LOW // 0 or 1, set to the level which to detect a button press to change the actuator state.
 #endif
 #ifndef MAX_TEMP_ACTUATOR
-//#  define MAX_TEMP_ACTUATOR         70 // Temperature that will trigger the relay to go OFF
+//#  define MAX_TEMP_ACTUATOR         70.0 // Temperature that will trigger the relay to go OFF
 #endif
+#ifndef MAX_CURRENT_ACTUATOR
+//#  define MAX_CURRENT_ACTUATOR         15.0 // Current that will trigger the relay to go OFF
+#endif
+
 #ifndef TimeBetweenReadingIntTemp
 #  define TimeBetweenReadingIntTemp 5000 // Time interval between internal temp measurement to switch off the relay if MAX_TEMP_ACTUATOR is reached
+#endif
+#ifndef TimeBetweenReadingCurrent
+#  define TimeBetweenReadingCurrent 1000 // Time interval between internal temp measurement to switch off the relay if MAX_TEMP_ACTUATOR is reached
 #endif
 /*-------------------PIN DEFINITIONS----------------------*/
 // default pin, if not set into the MQTT json

--- a/main/main.ino
+++ b/main/main.ino
@@ -692,6 +692,19 @@ void setup() {
   Log.notice(F("OpenMQTTGateway Version: " OMG_VERSION CR));
 #  endif
 
+/*
+ The 2 modules below are not connection dependent so start them before the connectivity functions
+ Note that the ONOFF module need to start after the RN8209 so that the overCurrent task is launched after the setup of the sensor
+*/
+#  ifdef ZsensorRN8209
+  setupRN8209();
+  modules.add(ZsensorRN8209);
+#  endif
+#  ifdef ZactuatorONOFF
+  setupONOFF();
+  modules.add(ZactuatorONOFF);
+#  endif
+
   String s = WiFi.macAddress();
 #  ifdef USE_MAC_AS_GATEWAY_NAME
   sprintf(gateway_name, "%.2s%.2s%.2s%.2s%.2s%.2s",
@@ -757,10 +770,6 @@ void setup() {
 
   delay(1500);
 
-#ifdef ZactuatorONOFF
-  setupONOFF();
-  modules.add(ZactuatorONOFF);
-#endif
 #ifdef ZsensorBME280
   setupZsensorBME280();
   modules.add(ZsensorBME280);
@@ -897,10 +906,6 @@ void setup() {
 #    undef ACTIVE_RECEIVER
 #  endif
 #  define ACTIVE_RECEIVER ACTIVE_RTL
-#endif
-#ifdef ZsensorRN8209
-  setupRN8209();
-  modules.add(ZsensorRN8209);
 #endif
 #if defined(ZgatewayRTL_433) || defined(ZgatewayRF) || defined(ZgatewayPilight) || defined(ZgatewayRF2)
 #  ifdef DEFAULT_RECEIVER // Allow defining of default receiver as a compiler directive
@@ -1586,9 +1591,6 @@ void loop() {
 #endif
 #ifdef ZactuatorFASTLED
       FASTLEDLoop();
-#endif
-#ifdef ZactuatorONOFF
-      OverHeatingRelayOFF();
 #endif
 #ifdef ZactuatorPWM
       PWMLoop();


### PR DESCRIPTION
## Description:
Add a function that switches OFF the actuator if the current measured is more than MAX_CURRENT_ACTUATOR
and uses RTOS task for the overLimitTemp function

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
