### PR TITLE
BT Active Scan Interval

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -146,6 +146,18 @@ With Home Assistant, this command is directly available through MQTT auto discov
 
 If false, the gateway will only do a passive scanning (not request for sensor broadcasts), some sensors may not advertize their data with passive scanning.
 
+## Setting the time between active scanning
+
+If you have passive scanning activated, but also have some devices which require active scanning, this defines the time interval between two intermittent active scans.
+
+If you want to change the time between active scans you can change it by MQTT. For setting the active scan interval time to every 5 minutes:
+
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"intervalacts":300000}'`
+
+::: tip
+Setting `{"intervalacts":0}` deactivates intermittent active scanning to only have consistent passive scanning if `'{"activescan":false}'`.
+:::
+
 ## Setting if the gateway connects to BLE devices eligibles on ESP32
 
 If you want to change this characteristic:

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -66,7 +66,7 @@ extern int btQueueLengthCount;
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -100 will not be reported
 
 #ifndef Scan_duration
-#  define Scan_duration 10000 //define the time for a scan); in milliseconds
+#  define Scan_duration 10000 //define the time for a scan; in milliseconds
 #endif
 #ifndef BLEScanInterval
 #  define BLEScanInterval 52 // How often the scan occurs / switches channels; in milliseconds,
@@ -77,6 +77,9 @@ extern int btQueueLengthCount;
 #ifndef ActiveBLEScan
 #  define ActiveBLEScan true // Set active scanning, this will get more data from the advertiser.
 #endif
+#ifndef TimeBtwActive
+#  define TimeBtwActive 55555 //define default time between two BLE active scans when general passive scanning is selected; in milliseconds
+#endif
 #ifndef TimeBtwConnect
 #  define TimeBtwConnect 3600000 //define default time between BLE connection attempt (not used for immediate actions); in milliseconds
 #endif
@@ -85,7 +88,7 @@ extern int btQueueLengthCount;
 #  define BLEScanDuplicateCacheSize 200
 #endif
 #ifndef TimeBtwRead
-#  define TimeBtwRead 55555 //define default time between 2 scans); in milliseconds
+#  define TimeBtwRead 55555 //define default time between 2 scans; in milliseconds
 #endif
 
 #ifndef PublishOnlySensors
@@ -131,6 +134,7 @@ unsigned long scanCount = 0;
 struct BTConfig_s {
   bool bleConnect; // Attempt a BLE connection to sensors with ESP32
   bool activeScan;
+  unsigned long intervalActiveScan; // Time between 2 active scans when generally passive scanning
   unsigned long BLEinterval; // Time between 2 scans
   unsigned long intervalConnect; // Time between 2 connects
   bool pubOnlySensors; // Publish only the identified sensors (like temperature sensors)


### PR DESCRIPTION
Introduces and **TimeBtwActive/intervalacts** to allow for intermittent BT active scanning when `"activescan":false`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
