### PR TITLE
[LPM] - Fix reboot loop when low power is used

### DIFF
--- a/docs/use/boards.md
+++ b/docs/use/boards.md
@@ -24,6 +24,8 @@ OpenMQTTGateway support a low power mode for ESP32, this mode can be set by MQTT
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoBT/config" -m '{"lowpowermode":2}'`
 
+The interval between the ESP32 wake up is defined at build time by the macro `TimeBtwRead`, a change of the `interval` through MQTT will not impact the time between wake up.
+
 ::: tip
 When coming back from mode 2 to mode 0 you may publish the command with a retain flag so as to enable the gateway to retrieve it when reconnecting.
 A low power mode switch is automatically created by discovery with Home Assistant, you may experience a delay between the command and the state update due to the fact that the update is published every 2 minutes.

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -760,8 +760,8 @@ void coreTask(void* pvParameters) {
 }
 
 void lowPowerESP32() { // low power mode
-  Log.trace(F("Going to deep sleep for: %l s" CR), (BTConfig.BLEinterval / 1000));
-  deepSleep(BTConfig.BLEinterval * 1000);
+  Log.trace(F("Going to deep sleep for: %l s" CR), (TimeBtwRead / 1000));
+  deepSleep(TimeBtwRead * 1000);
 }
 
 void deepSleep(uint64_t time_in_us) {
@@ -771,7 +771,7 @@ void deepSleep(uint64_t time_in_us) {
 #  endif
 
   Log.trace(F("Deactivating ESP32 components" CR));
-  BLEDevice::deinit(true);
+  if (BLEDevice::getInitialized()) BLEDevice::deinit(true);
   esp_bt_mem_release(ESP_BT_MODE_BTDM);
   // Ignore the deprecated warning, this call is necessary here.
 #  pragma GCC diagnostic push


### PR DESCRIPTION
## Description:
Not deinitializing BLE at the start, if it has not been initialized. Setting the time between waking up from the macro rather than the config interval. This one does not have a value at the start.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
