### PR TITLE
[TRIGGER] Enable reset at start when InputGPIO is used

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -579,7 +579,7 @@ CRGB leds2[FASTLED_IND_NUM_LEDS];
 #define InitialMQTTConnectionTimeout 10 // time estimated (s) before the board is connected to MQTT
 #define subjectSYStoMQTT             "/SYStoMQTT"
 #define subjectMQTTtoSYSset          "/commands/MQTTtoSYS/config"
-
+#define TimeToResetAtStart           5000 // Time we allow the user at start for the reset command by button press
 /*-------------------DEFINE LOG LEVEL----------------------*/
 #ifndef LOG_LEVEL
 #  define LOG_LEVEL LOG_LEVEL_NOTICE

--- a/main/main.ino
+++ b/main/main.ino
@@ -1113,13 +1113,11 @@ void saveConfigCallback() {
 }
 
 #  ifdef TRIGGER_GPIO
-void checkButton() { // Check if button is pressed so as to reset the credentials and parameters stored into the flash, code from tzapu/wifimanager examples
-#    if defined(INPUT_GPIO) && defined(ZsensorGPIOInput) && INPUT_GPIO == TRIGGER_GPIO
-  MeasureGPIOInput();
-#    else
-  // check for button press
+/**
+ * Identify a long button press to trigger a reset
+* */
+void blockingWaitForReset() {
   if (digitalRead(TRIGGER_GPIO) == LOW) {
-    // poor mans debounce/press-hold, code not ideal for production
     delay(50);
     if (digitalRead(TRIGGER_GPIO) == LOW) {
       Log.trace(F("Trigger button Pressed" CR));
@@ -1131,7 +1129,23 @@ void checkButton() { // Check if button is pressed so as to reset the credential
       }
     }
   }
+}
+
+/**
+ * Check if button is pressed so as to reset the credentials and parameters stored into the flash
+* */
+void checkButton() {
+  unsigned long timeFromStart = millis();
+  // Identify if the reset button is pushed at start
+  if (timeFromStart < TimeToResetAtStart) {
+    blockingWaitForReset();
+  } else { // When we are not at start we either check the button as a regular input (ZsensorGPIOInput used) or for a reset
+#    if defined(INPUT_GPIO) && defined(ZsensorGPIOInput) && INPUT_GPIO == TRIGGER_GPIO
+    MeasureGPIOInput();
+#    else
+    blockingWaitForReset();
 #    endif
+  }
 }
 #  else
 void checkButton() {}


### PR DESCRIPTION
## Description:
The start period  is defined by the macro `TimeToResetAtStart`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
