### PR TITLE
[BT] Continuous active scanning when adaptive scanning is false

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -137,12 +137,14 @@ The gateway will publish only the detected sensors like Mi Flora, Mi jia, LYWSD0
 ## Setting if the gateway use adaptive scanning
 
 Adaptive scanning lets the gateway decide for you the best passive `interval` and active `intervalacts` scan interval, depending on the characteristics of your devices.
-The gateway retrieves your devices' information from [Theengs Decoder](https://decoder.theengs.io) and adapts its parameters accordingly.
+The gateway retrieves your devices' information from [Theengs Decoder](https://decoder.theengs.io) and adapts its parameters accordingly if a device that requires it is detected.
 For example a door or a PIR sensor will require continuous scanning, so if detected the gateway is going to reduce its time between scans to the minimum. Or your devices may also require active scanning to retrieve data, in this case the gateway will also trigger active scans at regular intervals.
 
 If you want to change this characteristic (default:true):
 
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"adaptivescan":false}'`
+
+Setting Adaptive scanning to `false` will automatically put the gateway to continuous active scanning.
 
 ::: tip
 With Home Assistant, this command is directly available through MQTT auto discovery as a switch into the HASS OpenMQTTGateway device entities list.

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -151,12 +151,17 @@ void stateBTMeasures(bool start) {
 void BTConfig_fromJson(JsonObject& BTdata, bool startup = false) {
   // Attempts to connect to eligible devices or not
   BTConfig_update(BTdata, "bleconnect", BTConfig.bleConnect);
+  // Identify AdaptiveScan deactivation to pass to continuous mode
+  if (BTdata.containsKey("adaptivescan") && BTdata["adaptivescan"] == false && BTConfig.adaptiveScan == true) {
+    BTdata["interval"] = MinTimeBtwScan;
+    BTdata["intervalacts"] = MinTimeBtwScan;
+  }
+  BTConfig_update(BTdata, "adaptivescan", BTConfig.adaptiveScan);
+  // Time before before active scan
   // Scan interval set
   if (BTdata.containsKey("interval") && BTdata["interval"] != 0)
     BTConfig_update(BTdata, "interval", BTConfig.BLEinterval);
-  // Define if the scan is active or passive
-  BTConfig_update(BTdata, "adaptivescan", BTConfig.adaptiveScan);
-  // Time before before active scan
+  // Define if the scan is adaptive or not
   BTConfig_update(BTdata, "intervalacts", BTConfig.intervalActiveScan);
   // Time before a connect set
   BTConfig_update(BTdata, "intervalcnct", BTConfig.intervalConnect);


### PR DESCRIPTION
## Description:
Set `interval` and `intervalacts` to the minimum when adaptive scanning is deactivated. When the user encounters a device not detected due to adaptive scanning, we set the gateway to continuous active scan to maximize the chance of detecting the device.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
