### PR TITLE
[ONOFF] Set power indicator status at start

### DIFF
--- a/main/ZactuatorONOFF.ino
+++ b/main/ZactuatorONOFF.ino
@@ -38,6 +38,11 @@ void setupONOFF() {
   xTaskCreate(overLimitTemp, "overLimitTemp", 2500, NULL, 10, NULL);
 #  endif
   pinMode(ACTUATOR_ONOFF_GPIO, OUTPUT);
+  if (digitalRead(ACTUATOR_ONOFF_GPIO) == ACTUATOR_ON) {
+    PowerIndicatorON();
+  } else {
+    PowerIndicatorOFF();
+  }
 #  ifdef ACTUATOR_ONOFF_DEFAULT
   digitalWrite(ACTUATOR_ONOFF_GPIO, ACTUATOR_ONOFF_DEFAULT);
 #  endif


### PR DESCRIPTION
## Description:
So that it reflects the real state of the actuator even if a restart of the board was done

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
