### PR TITLE
Added WiPhone LoRa support

### DIFF
--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -56,32 +56,6 @@ enum LORA_ID_NUM {
 typedef enum LORA_ID_NUM LORA_ID_NUM;
 
 /*
-Taken from main/ZgatewaySRFB.ino
-From an hexa char array ("A220EE...") to a byte array (half the size)
- */
-bool _hexToRaw(const char* in, byte* out, int rawSize) {
-  if (strlen(in) != rawSize * 2)
-    return false;
-  char tmp[3] = {0};
-  for (unsigned char p = 0; p < rawSize; p++) {
-    memcpy(tmp, &in[p * 2], 2);
-    out[p] = strtol(tmp, NULL, 16);
-  }
-  return true;
-}
-
-/*
-Taken from main/ZgatewaySRFB.ino
-From a byte array to an hexa char array ("A220EE...", double the size)
- */
-bool _rawToHex(byte* in, char* out, int rawSize) {
-  for (unsigned char p = 0; p < rawSize; p++) {
-    sprintf_P(&out[p * 2], PSTR("%02X" CR), in[p]);
-  }
-  return true;
-}
-
-/*
 Try and determine device given the payload
  */
 uint8_t _determineDevice(byte* packet, int packetSize) {

--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -33,6 +33,124 @@
 #  include <SPI.h>
 #  include <Wire.h>
 
+#define WIPHONE_MESSAGE_MAGIC 0x6c6d
+#define WIPHONE_MESSAGE_MIN_LEN sizeof(wiphone_message) - WIPHONE_MAX_MESSAGE_LEN
+#define WIPHONE_MAX_MESSAGE_LEN 230
+
+typedef struct __attribute__((packed)) {
+  // WiPhone uses RadioHead library which has additional (unused) headers
+  uint8_t rh_to;
+  uint8_t rh_from;
+  uint8_t rh_id;
+  uint8_t rh_flags;
+  uint16_t magic;
+  uint32_t to;
+  uint32_t from;
+  char     message[WIPHONE_MAX_MESSAGE_LEN];
+}
+wiphone_message;
+
+enum LORA_ID_NUM
+{
+    UNKNOWN_DEVICE = -1,
+    WIPHONE,
+};
+typedef enum LORA_ID_NUM LORA_ID_NUM;
+
+/*
+Taken from main/ZgatewaySRFB.ino
+From an hexa char array ("A220EE...") to a byte array (half the size)
+ */
+bool _hexToRaw(const char* in, byte* out, int rawSize) {
+  if (strlen(in) != rawSize * 2)
+    return false;
+  char tmp[3] = {0};
+  for (unsigned char p = 0; p < rawSize; p++) {
+    memcpy(tmp, &in[p * 2], 2);
+    out[p] = strtol(tmp, NULL, 16);
+  }
+  return true;
+}
+
+/*
+Taken from main/ZgatewaySRFB.ino
+From a byte array to an hexa char array ("A220EE...", double the size)
+ */
+bool _rawToHex(byte* in, char* out, int rawSize) {
+  for (unsigned char p = 0; p < rawSize; p++) {
+    sprintf_P(&out[p * 2], PSTR("%02X" CR), in[p]);
+  }
+  return true;
+}
+
+/*
+Try and determine device given the payload
+ */
+uint8_t _determineDevice(byte* packet, int packetSize) {
+  // Check WiPhone header
+  if (packetSize >= WIPHONE_MESSAGE_MIN_LEN && ((wiphone_message*)packet)->magic == WIPHONE_MESSAGE_MAGIC)
+    return WIPHONE;
+
+  // No matches
+  return UNKNOWN_DEVICE;
+}
+
+/*
+Try and determine device given the JSON type
+ */
+uint8_t _determineDevice(JsonObject& LORAdata) {
+  const char* protocol_name = LORAdata["type"];
+
+  if (strcmp(protocol_name, "WiPhone") == 0)
+    return WIPHONE;
+
+  // No matches
+  return UNKNOWN_DEVICE;
+}
+
+/*
+Create JSON information from WiPhone packet
+ */
+boolean _WiPhoneToMQTT(byte* packet, JsonObject& LORAdata) {
+  // Decode the LoRa packet and send over MQTT
+  wiphone_message* msg = (wiphone_message*)packet;
+
+  // Set the header information
+  char from[9] = {0};
+  char to[9] = {0};
+  snprintf(from, 9, "%06X", msg->from);
+  snprintf(to, 9, "%06X", msg->to);
+
+  // From and To are the last 3 octets from the WiPhone's ESP32 chip ID
+  // Special case is 0x000000: "broadcast"
+  LORAdata["from"] = from;
+  LORAdata["to"] = to;
+
+  LORAdata["message"] = msg->message;
+  LORAdata["type"] = "WiPhone";
+  return true;
+}
+
+/*
+Create WiPhone packet from JSON
+ */
+boolean _MQTTtoWiPhone(JsonObject& LORAdata) {
+  // Prepare a LoRa packet to send to the WiPhone
+  wiphone_message wiphonemsg;
+  wiphonemsg.rh_to = 0xff;
+  wiphonemsg.rh_from = 0xff;
+  wiphonemsg.rh_id = 0x00;
+  wiphonemsg.rh_flags = 0x00;
+
+  wiphonemsg.magic = WIPHONE_MESSAGE_MAGIC;
+  wiphonemsg.from = strtol(LORAdata["from"], NULL, 16);
+  wiphonemsg.to = strtol(LORAdata["to"], NULL, 16);
+  const char* message = LORAdata["message"];
+  strlcpy(wiphonemsg.message, message, WIPHONE_MAX_MESSAGE_LEN);
+  LoRa.write((uint8_t*)&wiphonemsg, strlen(message)+WIPHONE_MESSAGE_MIN_LEN+1);
+  return true;
+}
+
 void setupLORA() {
   SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_SS);
   LoRa.setPins(LORA_SS, LORA_RST, LORA_DI0);
@@ -69,16 +187,38 @@ void LORAtoMQTT() {
     taskMessage = taskMessage + xPortGetCoreID();
     //trc(taskMessage);
 #  endif
-    String packet;
-    packet = "";
+    // Create packet and reserve null terminator space
+    byte packet[packetSize + 1];
+    boolean binary = false;
     for (int i = 0; i < packetSize; i++) {
-      packet += (char)LoRa.read();
+      packet[i] = (char)LoRa.read();
+
+      if ( packet[i] < 32 || packet[i] > 127 )
+        binary = true;
     }
+    // Terminate with a null character in case we have a string
+    packet[packetSize] = 0;
+
     LORAdata["rssi"] = (int)LoRa.packetRssi();
     LORAdata["snr"] = (float)LoRa.packetSnr();
     LORAdata["pferror"] = (float)LoRa.packetFrequencyError();
     LORAdata["packetSize"] = (int)packetSize;
-    LORAdata["message"] = (char*)packet.c_str();
+
+    uint8_t deviceId = _determineDevice( packet, packetSize );
+    if (deviceId == WIPHONE) {
+      _WiPhoneToMQTT(packet, LORAdata);
+    } else if (binary) {
+      // We have non-ascii data: create hex string of the data
+      char hex[packetSize * 2 + 1];
+      _rawToHex( packet, hex, packetSize );
+      // Terminate with a null character
+      hex[packetSize * 2] = 0;
+
+      LORAdata["hex"] = hex;
+    } else {
+      // ascii payload
+      LORAdata["message"] = packet;
+    }
     pub(subjectLORAtoMQTT, LORAdata);
     if (repeatLORAwMQTT) {
       Log.trace(F("Pub LORA for rpt" CR));
@@ -92,6 +232,7 @@ void MQTTtoLORA(char* topicOri, JsonObject& LORAdata) { // json object decoding
   if (cmpToMainTopic(topicOri, subjectMQTTtoLORA)) {
     Log.trace(F("MQTTtoLORA json" CR));
     const char* message = LORAdata["message"];
+    const char* hex = LORAdata["hex"];
     int txPower = LORAdata["txpower"] | LORA_TX_POWER;
     int spreadingFactor = LORAdata["spreadingfactor"] | LORA_SPREADING_FACTOR;
     long int frequency = LORAdata["frequency "] | LORA_BAND;
@@ -99,8 +240,9 @@ void MQTTtoLORA(char* topicOri, JsonObject& LORAdata) { // json object decoding
     int codingRateDenominator = LORAdata["codingrate"] | LORA_CODING_RATE;
     int preambleLength = LORAdata["preamblelength"] | LORA_PREAMBLE_LENGTH;
     byte syncWord = LORAdata["syncword"] | LORA_SYNC_WORD;
-    bool Crc = LORAdata["enablecrc"] | DEFAULT_CRC;
-    if (message) {
+    bool crc = LORAdata["enablecrc"] | DEFAULT_CRC;
+    bool invertIQ = LORAdata["invertiq"] | INVERT_IQ;
+    if (message || hex) {
       LoRa.setTxPower(txPower);
       LoRa.setFrequency(frequency);
       LoRa.setSpreadingFactor(spreadingFactor);
@@ -108,10 +250,30 @@ void MQTTtoLORA(char* topicOri, JsonObject& LORAdata) { // json object decoding
       LoRa.setCodingRate4(codingRateDenominator);
       LoRa.setPreambleLength(preambleLength);
       LoRa.setSyncWord(syncWord);
-      if (Crc)
+      if (crc)
         LoRa.enableCrc();
+      else
+        LoRa.disableCrc();
+
+      if ( invertIQ )
+        LoRa.enableInvertIQ();
+      else
+        LoRa.disableInvertIQ();
+
       LoRa.beginPacket();
-      LoRa.print(message);
+      uint8_t deviceId = _determineDevice( LORAdata );
+      if (deviceId == WIPHONE) {
+        _MQTTtoWiPhone(LORAdata);
+      } else if (hex) {
+        // We have hex data: create convert to binary
+        byte raw[ strlen(hex)/2];
+        _hexToRaw(hex, raw, sizeof(raw));
+        LoRa.print((char*)raw);
+      } else {
+        // ascii payload
+        LoRa.print(message);
+      }
+
       LoRa.endPacket();
       Log.trace(F("MQTTtoLORA OK" CR));
       pub(subjectGTWLORAtoMQTT, LORAdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also

--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -33,9 +33,9 @@
 #  include <SPI.h>
 #  include <Wire.h>
 
-#define WIPHONE_MESSAGE_MAGIC 0x6c6d
-#define WIPHONE_MESSAGE_MIN_LEN sizeof(wiphone_message) - WIPHONE_MAX_MESSAGE_LEN
-#define WIPHONE_MAX_MESSAGE_LEN 230
+#  define WIPHONE_MESSAGE_MAGIC   0x6c6d
+#  define WIPHONE_MESSAGE_MIN_LEN sizeof(wiphone_message) - WIPHONE_MAX_MESSAGE_LEN
+#  define WIPHONE_MAX_MESSAGE_LEN 230
 
 typedef struct __attribute__((packed)) {
   // WiPhone uses RadioHead library which has additional (unused) headers
@@ -46,14 +46,12 @@ typedef struct __attribute__((packed)) {
   uint16_t magic;
   uint32_t to;
   uint32_t from;
-  char     message[WIPHONE_MAX_MESSAGE_LEN];
-}
-wiphone_message;
+  char message[WIPHONE_MAX_MESSAGE_LEN];
+} wiphone_message;
 
-enum LORA_ID_NUM
-{
-    UNKNOWN_DEVICE = -1,
-    WIPHONE,
+enum LORA_ID_NUM {
+  UNKNOWN_DEVICE = -1,
+  WIPHONE,
 };
 typedef enum LORA_ID_NUM LORA_ID_NUM;
 
@@ -147,7 +145,7 @@ boolean _MQTTtoWiPhone(JsonObject& LORAdata) {
   wiphonemsg.to = strtol(LORAdata["to"], NULL, 16);
   const char* message = LORAdata["message"];
   strlcpy(wiphonemsg.message, message, WIPHONE_MAX_MESSAGE_LEN);
-  LoRa.write((uint8_t*)&wiphonemsg, strlen(message)+WIPHONE_MESSAGE_MIN_LEN+1);
+  LoRa.write((uint8_t*)&wiphonemsg, strlen(message) + WIPHONE_MESSAGE_MIN_LEN + 1);
   return true;
 }
 
@@ -193,7 +191,7 @@ void LORAtoMQTT() {
     for (int i = 0; i < packetSize; i++) {
       packet[i] = (char)LoRa.read();
 
-      if ( packet[i] < 32 || packet[i] > 127 )
+      if (packet[i] < 32 || packet[i] > 127)
         binary = true;
     }
     // Terminate with a null character in case we have a string
@@ -204,13 +202,13 @@ void LORAtoMQTT() {
     LORAdata["pferror"] = (float)LoRa.packetFrequencyError();
     LORAdata["packetSize"] = (int)packetSize;
 
-    uint8_t deviceId = _determineDevice( packet, packetSize );
+    uint8_t deviceId = _determineDevice(packet, packetSize);
     if (deviceId == WIPHONE) {
       _WiPhoneToMQTT(packet, LORAdata);
     } else if (binary) {
       // We have non-ascii data: create hex string of the data
       char hex[packetSize * 2 + 1];
-      _rawToHex( packet, hex, packetSize );
+      _rawToHex(packet, hex, packetSize);
       // Terminate with a null character
       hex[packetSize * 2] = 0;
 
@@ -255,18 +253,18 @@ void MQTTtoLORA(char* topicOri, JsonObject& LORAdata) { // json object decoding
       else
         LoRa.disableCrc();
 
-      if ( invertIQ )
+      if (invertIQ)
         LoRa.enableInvertIQ();
       else
         LoRa.disableInvertIQ();
 
       LoRa.beginPacket();
-      uint8_t deviceId = _determineDevice( LORAdata );
+      uint8_t deviceId = _determineDevice(LORAdata);
       if (deviceId == WIPHONE) {
         _MQTTtoWiPhone(LORAdata);
       } else if (hex) {
         // We have hex data: create convert to binary
-        byte raw[ strlen(hex)/2];
+        byte raw[strlen(hex) / 2];
         _hexToRaw(hex, raw, sizeof(raw));
         LoRa.print((char*)raw);
       } else {

--- a/main/config_LORA.h
+++ b/main/config_LORA.h
@@ -46,6 +46,7 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 #define LORA_PREAMBLE_LENGTH  8
 #define LORA_SYNC_WORD        0x12
 #define DEFAULT_CRC           true
+#define INVERT_IQ             false
 
 #define repeatLORAwMQTT false // do we repeat a received signal by using MQTT with LORA gateway
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -316,6 +316,30 @@ long value_from_hex_data(const char* service_data, int offset, int data_length, 
   return value;
 }
 
+/*
+From an hexa char array ("A220EE...") to a byte array (half the size)
+ */
+bool _hexToRaw(const char* in, byte* out, int rawSize) {
+  if (strlen(in) != rawSize * 2)
+    return false;
+  char tmp[3] = {0};
+  for (unsigned char p = 0; p < rawSize; p++) {
+    memcpy(tmp, &in[p * 2], 2);
+    out[p] = strtol(tmp, NULL, 16);
+  }
+  return true;
+}
+
+/*
+From a byte array to an hexa char array ("A220EE...", double the size)
+ */
+bool _rawToHex(byte* in, char* out, int rawSize) {
+  for (unsigned char p = 0; p < rawSize; p++) {
+    sprintf_P(&out[p * 2], PSTR("%02X" CR), in[p]);
+  }
+  return true;
+}
+
 char* ip2CharArray(IPAddress ip) { //from Nick Lee https://stackoverflow.com/questions/28119653/arduino-display-ethernet-localip
   static char a[16];
   sprintf(a, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);


### PR DESCRIPTION
## Description:
This PR enables decoding [WiPhone](https://www.wiphone.io/) LoRa packets.
WiPhone uses the RadioHead library which adds some extra bytes to the header, but is currently unused (as per default `0xFFFF0000`).

The format is as followed:
```
  uint8_t rh_to; // currently 0xff
  uint8_t rh_from; // currently 0xff
  uint8_t rh_id; // currently 0x00
  uint8_t rh_flags; // currently 0x00
  uint16_t magic; // always 0x6c6d
  uint32_t to; // ESP ChipID or 0x00000000 for "broadcast"
  uint32_t from; // ESP ChipID
  char message[230];
```
I modified the LoRa to support more devices in the future, but I would like to see a mechanism similar as used in the [rtl_433_ESP](https://github.com/NorthernMan54/rtl_433_ESP#v0.1.6) library;
Then again, this library does support the `sx127x` chipset (that also does LoRa) already, it only doesn't support the RFM9xW.

Sending a message would be as simple as:
`mosquitto_pub -h 127.0.0.1 -t "home/OpenMQTTGateway_ESP32_LORA/commands/MQTTtoLORA" -m '{"type":"WiPhone","from":"C0FFEE","to":"0","message":"Hello from OMG"}'`

Incoming messages will look like:
`home/OpenMQTTGateway_ESP32_LORA/LORAtoMQTT {"rssi":-113,"snr":5.5,"pferror":18748,"packetSize":34,"from":"123456","to":"000000","message":"hi from wiphone","type":"WiPhone"}`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).

## Notes:
To be honest, I'm not sure if people want to have the LoRa library extended to support decoding different payloads, but I thought it was the right thing to do (I came across this library which had all the fantastic features I needed, except LoRa payload decode support).

Also:
* When non-ascii data arrives, it converts to hex and will put the data in `LORAdata["hex"]` (and the other way around)
* I used the conversion methods from `Taken from main/ZgatewaySRFB.ino`, but it might be better to have a helper class that one could use to do these conversions.
* I also added invertIQ support for downstream/multiple gateway support

Let me know what you think.
Cheers.