### PR TITLE
Allow for both BT and RTL_433 Gateways at the same time.

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -70,7 +70,7 @@ vector<BLEAction> BLEactions;
 vector<BLEdevice*> devices;
 int newDevices = 0;
 
-static BLEdevice NO_DEVICE_FOUND = {{0},
+static BLEdevice NO_BT_DEVICE_FOUND = {{0},
                                     0,
                                     false,
                                     false,
@@ -361,7 +361,7 @@ BLEdevice* getDeviceByMac(const char* mac) {
       return *it;
     }
   }
-  return &NO_DEVICE_FOUND;
+  return &NO_BT_DEVICE_FOUND;
 }
 
 bool updateWorB(JsonObject& BTdata, bool isWhite) {
@@ -388,7 +388,7 @@ void createOrUpdateDevice(const char* mac, uint8_t flags, int model, int mac_typ
   }
 
   BLEdevice* device = getDeviceByMac(mac);
-  if (device == &NO_DEVICE_FOUND) {
+  if (device == &NO_BT_DEVICE_FOUND) {
     Log.trace(F("add %s" CR), mac);
     //new device
     device = new BLEdevice();

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -71,12 +71,12 @@ vector<BLEdevice*> devices;
 int newDevices = 0;
 
 static BLEdevice NO_BT_DEVICE_FOUND = {{0},
-                                    0,
-                                    false,
-                                    false,
-                                    false,
-                                    false,
-                                    TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL};
+                                       0,
+                                       false,
+                                       false,
+                                       false,
+                                       false,
+                                       TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL};
 static bool oneWhite = false;
 
 void BTConfig_init() {

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -47,7 +47,7 @@ SemaphoreHandle_t semaphorecreateOrUpdateDeviceRTL_433;
 std::vector<RTL_433device*> RTL_433devices;
 int newRTL_433Devices = 0;
 
-static RTL_433device NO_DEVICE_FOUND = {{0},
+static RTL_433device NO_RTL_433_DEVICE_FOUND = {{0},
                                         0,
                                         false};
 
@@ -60,7 +60,7 @@ RTL_433device* getDeviceById(const char* id) {
       return *it;
     }
   }
-  return &NO_DEVICE_FOUND;
+  return &NO_RTL_433_DEVICE_FOUND;
 }
 
 void dumpRTL_433Devices() {
@@ -79,7 +79,7 @@ void createOrUpdateDeviceRTL_433(const char* id, const char* model, uint8_t flag
   }
 
   RTL_433device* device = getDeviceById(id);
-  if (device == &NO_DEVICE_FOUND) {
+  if (device == &NO_RTL_433_DEVICE_FOUND) {
     Log.trace(F("add %s" CR), id);
     //new device
     device = new RTL_433device();

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -48,8 +48,8 @@ std::vector<RTL_433device*> RTL_433devices;
 int newRTL_433Devices = 0;
 
 static RTL_433device NO_RTL_433_DEVICE_FOUND = {{0},
-                                        0,
-                                        false};
+                                                0,
+                                                false};
 
 RTL_433device* getDeviceById(const char* id); // Declared here to avoid pre-compilation issue (misplaced auto declaration by pio)
 RTL_433device* getDeviceById(const char* id) {


### PR DESCRIPTION
## Description:
See https://github.com/1technophile/OpenMQTTGateway/issues/1490

Rename two static variables so they don't conflict when enabling both BT and RTL_433 gateways.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
