### PR TITLE
[BT] Adaptive scan sequence change

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -152,9 +152,14 @@ void BTConfig_fromJson(JsonObject& BTdata, bool startup = false) {
   // Attempts to connect to eligible devices or not
   BTConfig_update(BTdata, "bleconnect", BTConfig.bleConnect);
   // Identify AdaptiveScan deactivation to pass to continuous mode
-  if (BTdata.containsKey("adaptivescan") && BTdata["adaptivescan"] == false && BTConfig.adaptiveScan == true && startup == false) {
-    BTdata["interval"] = MinTimeBtwScan;
-    BTdata["intervalacts"] = MinTimeBtwScan;
+  if (startup == false) {
+    if (BTdata.containsKey("adaptivescan") && BTdata["adaptivescan"] == false && BTConfig.adaptiveScan == true) {
+      BTdata["interval"] = MinTimeBtwScan;
+      BTdata["intervalacts"] = MinTimeBtwScan;
+    } else if (BTdata.containsKey("adaptivescan") && BTdata["adaptivescan"] == true && BTConfig.adaptiveScan == false) {
+      BTdata["interval"] = TimeBtwRead;
+      BTdata["intervalacts"] = TimeBtwActive;
+    }
   }
   BTConfig_update(BTdata, "adaptivescan", BTConfig.adaptiveScan);
   // Time before before active scan


### PR DESCRIPTION
## Description:
When reactivating adaptive scan, restore default
The goal is to restart the algorithm with the default value wich reduce traffic and devices power consumption.
It will detect alone if there is a need to reduce intervals

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
