### PR TITLE
[BT] Add BM2 voltage

### DIFF
--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -28,7 +28,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | BlueMaestro|TempoDisc 1 in 1|temperature/battery|
 | BlueMaestro|TempoDisc 3 in 1|temperature/humidity/dew point/battery|
 | BlueMaestro|TempoDisc 4 in 1|temperature/humidity/pressure/battery|
-| BM2 Battery Monitor|BM2|battery|
+| BM2 Battery Monitor|BM2|battery/volt(c)|
 | ClearGrass|CGG1|temperature/humidity/battery/voltage (depending on which CGG1 firmware is installed)|
 | ClearGrass alarm clock|CGD1|temperature/humidity/battery|
 | ClearGrass alarm clock|CGC1|temperature/humidity/battery|
@@ -84,7 +84,7 @@ Added to that it retrieves the measures from the devices below. By default the d
 | ThermoPro|TP393|temperature/humidity|
 | TPMS|TPMS|temperature/pressure/battery/alarm/count|
 | Vegtrug||temperature/moisture/luminance/fertility|
-| XIAOMI Mi Flora|HHCCJCY01HHCC|temperature/moisture/luminance/fertility/battery(1)(c)|
+| XIAOMI Mi Flora|HHCCJCY01HHCC|temperature/moisture/luminance/fertility/battery(c)|
 | XIAOMI Ropot|HHCCPOT002|temperature/moisture/fertility|
 | XIAOMI Mi Jia|LYWSDCGO|temperature/humidity/battery|
 | XIAOMI Mi Jia|LYWSD02|temperature/humidity/battery|

--- a/main/ZgatewayBLEConnect.h
+++ b/main/ZgatewayBLEConnect.h
@@ -41,6 +41,15 @@ public:
   void publishData() override;
 };
 
+class BM2_connect : public zBLEConnect {
+  //std::vector<uint8_t> m_data;
+  void notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, size_t length, bool isNotify);
+
+public:
+  BM2_connect(NimBLEAddress& addr) : zBLEConnect(addr) {}
+  void publishData() override;
+};
+
 class GENERIC_connect : public zBLEConnect {
   std::vector<uint8_t> m_data;
 

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -4,7 +4,6 @@
 #    include "ArduinoJson.h"
 #    include "ArduinoLog.h"
 #    include "ZgatewayBLEConnect.h"
-
 #    define convertTemp_CtoF(c) ((c * 1.8) + 32)
 
 extern bool ProcessLock;
@@ -243,6 +242,81 @@ void DT24_connect::publishData() {
   if (pChar && pChar->canNotify()) {
     Log.trace(F("Registering notification" CR));
     if (pChar->subscribe(true, std::bind(&DT24_connect::notifyCB, this,
+                                         std::placeholders::_1, std::placeholders::_2,
+                                         std::placeholders::_3, std::placeholders::_4))) {
+      m_taskHandle = xTaskGetCurrentTaskHandle();
+      if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(BLE_CNCT_TIMEOUT)) == pdFALSE) {
+        m_taskHandle = nullptr;
+      }
+    } else {
+      Log.notice(F("Failed registering notification" CR));
+    }
+  }
+}
+
+/*-----------------------BM2 HANDLING-----------------------*/
+void BM2_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, size_t length, bool isNotify) {
+  if (m_taskHandle == nullptr) {
+    return; // unexpected notification
+  }
+
+  if (!ProcessLock) {
+    Log.trace(F("Callback from %s characteristic" CR), pChar->getUUID().toString().c_str());
+    if (length == 16) {
+      Log.trace(F("Device identified creating BLE buffer" CR));
+      JsonObject& BLEdata = getBTJsonObject();
+      String mac_address = m_pClient->getPeerAddress().toString().c_str();
+      mac_address.toUpperCase();
+      BLEdata["model"] = "BM2 Battery Monitor";
+      BLEdata["id"] = (char*)mac_address.c_str();
+      mbedtls_aes_context aes;
+      mbedtls_aes_init(&aes);
+      unsigned char output[16];
+      unsigned char iv[16] = {};
+      unsigned char key[16] = {
+          108,
+          101,
+          97,
+          103,
+          101,
+          110,
+          100,
+          255,
+          254,
+          49,
+          56,
+          56,
+          50,
+          52,
+          54,
+          54,
+      };
+      mbedtls_aes_setkey_dec(&aes, key, 128);
+      mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_DECRYPT, 16, iv, (uint8_t*)&pData[0], output);
+      mbedtls_aes_free(&aes);
+      float volt = ((output[2] | (output[1] << 8)) >> 4) / 100.0f;
+      BLEdata["volt"] = volt;
+      Log.trace(F("volt: %F" CR), volt);
+      pubBT(BLEdata);
+    } else {
+      Log.notice(F("Invalid notification data" CR));
+      return;
+    }
+  } else {
+    Log.trace(F("Callback process canceled by processLock" CR));
+  }
+
+  xTaskNotifyGive(m_taskHandle);
+}
+
+void BM2_connect::publishData() {
+  NimBLEUUID serviceUUID("fff0");
+  NimBLEUUID charUUID("fff4");
+  NimBLERemoteCharacteristic* pChar = getCharacteristic(serviceUUID, charUUID);
+
+  if (pChar && pChar->canNotify()) {
+    Log.trace(F("Registering notification" CR));
+    if (pChar->subscribe(true, std::bind(&BM2_connect::notifyCB, this,
                                          std::placeholders::_1, std::placeholders::_2,
                                          std::placeholders::_3, std::placeholders::_4))) {
       m_taskHandle = xTaskGetCurrentTaskHandle();

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -209,6 +209,7 @@ public:
     LYWSD03MMC,
     MHO_C401,
     DT24_BLE,
+    BM2,
     XMWSDJ04MMC,
     MAX,
   };


### PR DESCRIPTION
## Description:
BM2 will be automatically detected and we will attempt a voltage retrieval through a BLE connection, frequency of the BLE connection is defined by `intervalcnct`

Credits to https://github.com/KrystianD/bm2-battery-monitor

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
