### PR TITLE
[RTL_433 Discovery] Add Govee water sensor Status entity

### DIFF
--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -161,7 +161,7 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
                             (char*)idWoKey.c_str(), "", pdevice->modelName, (char*)idWoKey.c_str(), false, // device name, device manufacturer, device model, device ID, retain
                             stateClassTotalIncreasing //State Class
             );
-          } else if (strcmp(parameters[i][0], "event") == 0 && strcmp(pdevice->modelName, "Govee-Water") == 0) {
+          } else if (strcmp(parameters[i][0], "event") == 0 && strcmp(pdevice->modelName, "Govee-Water") == 0) { //the entity will detect Water Leak Event and go back to Off state after 60seconds
             createDiscovery("binary_sensor", //set Type
                             (char*)topic.c_str(), parameters[i][1], pdevice->uniqueId, //set state_topic,name,uniqueId
                             "", parameters[i][3], (char*)value_template.c_str(), //set availability_topic,device_class,value_template,

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -161,6 +161,16 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
                             (char*)idWoKey.c_str(), "", pdevice->modelName, (char*)idWoKey.c_str(), false, // device name, device manufacturer, device model, device ID, retain
                             stateClassTotalIncreasing //State Class
             );
+          } else if (strcmp(parameters[i][0], "event") == 0 && strcmp(pdevice->modelName, "Govee-Water") == 0) {
+            createDiscovery("binary_sensor", //set Type
+                            (char*)topic.c_str(), parameters[i][1], pdevice->uniqueId, //set state_topic,name,uniqueId
+                            "", parameters[i][3], (char*)value_template.c_str(), //set availability_topic,device_class,value_template,
+                            "Water Leak", "", parameters[i][2], //set,payload_on,payload_off,unit_of_meas,
+                            60, //set  off_delay
+                            "", "", false, "", //set,payload_available,payload_not available   ,is a gateway entity, command topic
+                            (char*)idWoKey.c_str(), "Govee", pdevice->modelName, (char*)idWoKey.c_str(), false, // device name, device manufacturer, device model, device ID, retain
+                            stateClassMeasurement //State Class
+            );
           } else {
             createDiscovery("sensor", //set Type
                             (char*)topic.c_str(), parameters[i][1], pdevice->uniqueId, //set state_topic,name,uniqueId

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -82,7 +82,7 @@ struct RTL_433device {
 
 extern std::vector<RTL_433device*> RTL_433devices;
 
-const char parameters[39][4][24] = {
+const char parameters[40][4][24] = {
     // RTL_433 key, name, unit, device_class
     {"temperature_C", "temperature", "°C", "temperature"},
     {"temperature_1_C", "temperature", "°C", "temperature"},
@@ -122,7 +122,9 @@ const char parameters[39][4][24] = {
     {"tamper", "tamper", "", ""},
     {"alarm", "alarm", "", ""},
     {"motion", "motion", "", "motion"},
-    {"strike_count", "strike count", "", ""}}; // from rtl_433_mqtt_hass.py
+    {"strike_count", "strike count", "", ""},// from rtl_433_mqtt_hass.py
+    {"event", "Status", "", "moisture"}
+    }; 
 #  endif
 #endif
 /*-------------------RF topics & parameters----------------------*/

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -122,9 +122,8 @@ const char parameters[40][4][24] = {
     {"tamper", "tamper", "", ""},
     {"alarm", "alarm", "", ""},
     {"motion", "motion", "", "motion"},
-    {"strike_count", "strike count", "", ""},// from rtl_433_mqtt_hass.py
-    {"event", "Status", "", "moisture"}
-    }; 
+    {"strike_count", "strike count", "", ""}, // from rtl_433_mqtt_hass.py
+    {"event", "Status", "", "moisture"}};
 #  endif
 #endif
 /*-------------------RF topics & parameters----------------------*/


### PR DESCRIPTION
## Description:
Add Govee water status sensor auto discovery as a binary_sensor, the entity will detect Water Leak Event and go back to Off state after 60seconds

![image](https://user-images.githubusercontent.com/12672732/222769050-95d58a2f-7651-401b-9568-b34b5570db19.png)

![image](https://user-images.githubusercontent.com/12672732/222768638-24ccc73e-72b3-4896-857b-3b862c969606.png)


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
