### PR TITLE
[SSD1306] displaymetric - hyphen removal for discovery compatibility

### DIFF
--- a/docs/use/displays.md
+++ b/docs/use/displays.md
@@ -5,7 +5,7 @@ Several options are available for the display of information on the SSD1306 disp
 
 The current SSD1306 display states are being published to the `SSD1306toMQTT` topic, e.g.
 
-`{"onstate":true,"brightness":50,"display-metric":true,"display-flip":true,"idlelogo":true,"log-oled":false,"json-oled":true}`
+`{"onstate":true,"brightness":50,"displaymetric":true,"display-flip":true,"idlelogo":true,"log-oled":false,"json-oled":true}`
 
 ### Display ON/OFF
 To turn the SSD1306 display on or off.
@@ -38,7 +38,7 @@ This can be set with the compiler directive `-DDISPLAY_METRIC=false`.
 
 or with the runtime command
 
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m {"display-metric":false}`
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m {"displaymetric":false}`
 
 ### Rotating the display by 180 degrees
 

--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -166,9 +166,9 @@ void MQTTtoSSD1306(char* topicOri, JsonObject& SSD1306data) { // json object dec
       Log.notice(F("Set json-oled: %T" CR), jsonDisplay);
       success = true;
     }
-    if (SSD1306data.containsKey("display-metric")) {
-      displayMetric = SSD1306data["display-metric"].as<bool>();
-      Log.notice(F("Set display-metric: %T" CR), displayMetric);
+    if (SSD1306data.containsKey("displaymetric")) {
+      displayMetric = SSD1306data["displaymetric"].as<bool>();
+      Log.notice(F("Set displaymetric: %T" CR), displayMetric);
       success = true;
     }
     if (SSD1306data.containsKey("idlelogo")) {
@@ -233,7 +233,7 @@ bool SSD1306Config_save() {
   jo["brightness"] = displayBrightness;
   jo["log-oled"] = logToOLEDDisplay;
   jo["json-oled"] = jsonDisplay;
-  jo["display-metric"] = displayMetric;
+  jo["displaymetric"] = displayMetric;
   jo["idlelogo"] = idlelogo;
   jo["display-flip"] = displayFlip;
   // Save config into NVS (non-volatile storage)
@@ -275,7 +275,7 @@ bool SSD1306Config_load() {
     displayBrightness = jo["brightness"].as<int>();
     logToOLEDDisplay = jo["log-oled"].as<bool>();
     jsonDisplay = jo["json-oled"].as<bool>();
-    displayMetric = jo["display-metric"].as<bool>();
+    displayMetric = jo["displaymetric"].as<bool>();
     idlelogo = jo["idlelogo"].as<bool>();
     displayFlip = jo["display-flip"].as<bool>();
     return true;
@@ -1023,7 +1023,7 @@ void stateSSD1306Display() {
   JsonObject DISPLAYdata = jsonBuffer.to<JsonObject>();
   DISPLAYdata["onstate"] = (bool)displayState;
   DISPLAYdata["brightness"] = (int)displayBrightness;
-  DISPLAYdata["display-metric"] = (bool)displayMetric;
+  DISPLAYdata["displaymetric"] = (bool)displayMetric;
   DISPLAYdata["display-flip"] = (bool)displayFlip;
   DISPLAYdata["idlelogo"] = (bool)idlelogo;
   DISPLAYdata["log-oled"] = (bool)logToOLEDDisplay;


### PR DESCRIPTION
display-metric; removed hyphen to displaymetric, for discovery compatibility.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
