### PR TITLE
[BT Discovery] Improve BM2 discovery

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -466,7 +466,7 @@ void BM2Discovery(const char* mac, const char* sensorModel_id) {
 #    define BM2parametersCount 2
   Log.trace(F("BM2Discovery" CR));
   const char* BM2sensor[BM2parametersCount][9] = {
-      {"sensor", "volt", mac, "voltage", jsonVolt, "", "", "V", stateClassMeasurement},
+      {"sensor", "volt", mac, "voltage", jsonVoltBM2, "", "", "V", stateClassMeasurement}, // We use a json definition that retrieve only data from the BM2 decoder, as this sensor also advertize volt as an iBeacon
       {"sensor", "batt", mac, "battery", jsonBatt, "", "", "%", stateClassMeasurement}
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
@@ -1033,7 +1033,7 @@ void process_bledata(JsonObject& BLEdata) {
       model_id != TheengsDecoder::BLE_ID_NUM::MS_CDP &&
       model_id != TheengsDecoder::BLE_ID_NUM::GAEN) { // Broadcaster devices
     Log.trace(F("Decoder found device: %s" CR), BLEdata["model_id"].as<const char*>());
-    if (model_id == TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC) {
+    if (model_id == TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC || model_id == TheengsDecoder::BLE_ID_NUM::BM2) {
       createOrUpdateDevice(mac, device_flags_connect, model_id, mac_type); // Device that broadcast and can be connected
     } else {
       createOrUpdateDevice(mac, device_flags_init, model_id, mac_type);

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -167,6 +167,7 @@ void announceDeviceTrigger(bool use_gateway_info,
 #  define jsonCount    "{{ value_json.count }}"
 #  define jsonAlarm    "{{ value_json.alarm }}"
 #  define jsonInuse    "{{ value_json.power | float > 0 }}"
+#  define jsonVoltBM2  "{{% if  value_json.model_id == \"BM2\" -%} {{value_json.volt}} {%- endif %}}"
 #else // Home assistant autodiscovery value key definition
 #  define jsonBatt     "{{ value_json.batt | is_defined }}"
 #  define jsonLux      "{{ value_json.lux | is_defined }}"
@@ -203,6 +204,7 @@ void announceDeviceTrigger(bool use_gateway_info,
 #  define jsonCount    "{{ value_json.count | is_defined }}"
 #  define jsonAlarm    "{{ value_json.alarm | is_defined }}"
 #  define jsonInuse    "{{ value_json.power | is_defined | float > 0 }}"
+#  define jsonVoltBM2  "{{% if  value_json.model_id == \"BM2\" and value_json.volt is defined -%} {{value_json.volt}} {%- endif %}}"
 #endif
 
 #define stateClassNone            ""


### PR DESCRIPTION
## Description:
To filter advertisements coming from iBeacon packets containing `volt`, indeed the voltage is not properly advertised through the iBeacon packet and renders a wrong voltage

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
