### PR TITLE
Add environment for board Wemos Lolin C3 mini

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
           - "esp32s3-dev-c1-ble"
           - "esp32c3-dev-m1-ble"
           - "airm2m_core_esp32c3"
+          - "lolin_c3_mini"
           - "thingpulse-espgateway"
           - "thingpulse-espgateway-ethernet"
     runs-on: ubuntu-latest

--- a/environments.ini
+++ b/environments.ini
@@ -1578,7 +1578,7 @@ extends = env:lolin_c3_mini
 build_flags =
   ${env:lolin_c3_mini.build_flags}
   '-DLOG_LEVEL=LOG_LEVEL_NOTICE' ;default
-  '-DWM_DEBUG_LEVEL=DEBUG_NOTIFY' ;default
+  '-DWM_DEBUG_LEVEL=1' ;DEBUG_NOTIFY=1, default value
 ; Serial output via USB
   '-DCONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=true'
   '-DCONFIG_ESP_CONSOLE_UART=ESP_CONSOLE_USB_SERIAL_JTAG'   

--- a/environments.ini
+++ b/environments.ini
@@ -1564,17 +1564,20 @@ build_flags =
   '-DTRIGGER_GPIO=9'
   '-DNO_INT_TEMP_READING=true' ; No internal temperature on ESP32 C3 or S3
   '-DGateway_Name="OpenMQTTGateway_ESP32C3_BLE"'
+; Serial output currently causes a delay on each message, if no serial listener is connected.
+; Therefore we disable serial output. Use the _with_serial environment if you
+; need serial output for debugging purposes.
+  '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; disable serial logging.
+  '-DWM_DEBUG_LEVEL=DEBUG_ERROR'  ; disable serial logging.
 custom_description = BLE gateway on ESP32C3
 custom_hardware = Wemos Lolin C3 mini v2.3.0
 
-; Serial output currently causes a delay on each message, if no serial listener is connected.
-; Use the _no_serial environment unless you are actively debugging.
-[env:lolin_c3_mini_no_serial]
+[env:lolin_c3_mini_with_serial]
 extends = env:lolin_c3_mini
 build_flags =
   ${env:lolin_c3_mini.build_flags}
-  '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; disable serial logging.
-  '-DWM_DEBUG_LEVEL=0'
+  '-DLOG_LEVEL=LOG_LEVEL_NOTICE' ;default
+  '-DWM_DEBUG_LEVEL=DEBUG_NOTIFY' ;default
 
 [env:thingpulse-espgateway]
 platform = ${com.esp32_platform}

--- a/environments.ini
+++ b/environments.ini
@@ -1539,6 +1539,43 @@ build_flags =
 custom_description = BLE gateway on the C3
 custom_hardware = AirM2M ESP32C3-CORE
 
+; Wemos Lolin C3 mini v2.3.0
+[env:lolin_c3_mini]
+;platform = ${com.esp32_c3_s3_platform} ; standard is @5.2.0, causes `assert rwble.c 261` error
+platform = espressif32@5.3.0  ; override to @5.3.0. Includes a fixed for the `assert rwble.c 261` error
+board = lolin_c3_mini
+board_build.partitions = min_spiffs.csv
+monitor_speed = 115200
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ble}
+  ${libraries.decoder}
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayBT="BT"'
+; FastLED must be disabled. FastLED is not compatible with this board at the current moment.
+; The LED pins must still be defined, to avoid an error loop on pin definitions.
+; Available GPIOs are 0 - 8, 10, 20, 21.
+; See https://community.openmqttgateway.com/t/watchdog-kills-omg-on-esp32-c3-within-seconds/2192/15
+  '-DLED_SEND_RECEIVE=10'
+  '-DLED_INFO=6'
+  '-DLED_ERROR=7'
+  '-DTRIGGER_GPIO=9'
+  '-DNO_INT_TEMP_READING=true' ; No internal temperature on ESP32 C3 or S3
+  '-DGateway_Name="OpenMQTTGateway_ESP32C3_BLE"'
+custom_description = BLE gateway on ESP32C3
+custom_hardware = Wemos Lolin C3 mini v2.3.0
+
+; Serial output currently causes a delay on each message, if no serial listener is connected.
+; Use the _no_serial environment unless you are actively debugging.
+[env:lolin_c3_mini_no_serial]
+extends = env:lolin_c3_mini
+build_flags =
+  ${env:lolin_c3_mini.build_flags}
+  '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; disable serial logging.
+  '-DWM_DEBUG_LEVEL=0'
+
 [env:thingpulse-espgateway]
 platform = ${com.esp32_platform}
 board = esp32dev

--- a/environments.ini
+++ b/environments.ini
@@ -1539,7 +1539,7 @@ build_flags =
 custom_description = BLE gateway on the C3
 custom_hardware = AirM2M ESP32C3-CORE
 
-; Wemos Lolin C3 mini v2.3.0
+; Wemos Lolin C3 mini v2.1.0
 [env:lolin_c3_mini]
 ;platform = ${com.esp32_c3_s3_platform} ; standard is @5.2.0, causes `assert rwble.c 261` error
 platform = espressif32@5.3.0  ; override to @5.3.0. Includes a fixed for the `assert rwble.c 261` error
@@ -1570,7 +1570,7 @@ build_flags =
   '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; disable serial logging.
   '-DWM_DEBUG_LEVEL=DEBUG_ERROR'  ; disable serial logging.
 custom_description = BLE gateway on ESP32C3
-custom_hardware = Wemos Lolin C3 mini v2.3.0
+custom_hardware = Wemos Lolin C3 mini v2.1.0
 
 [env:lolin_c3_mini_with_serial]
 extends = env:lolin_c3_mini

--- a/environments.ini
+++ b/environments.ini
@@ -1556,19 +1556,20 @@ build_flags =
   '-DZgatewayBT="BT"'
 ; FastLED must be disabled. FastLED is not compatible with this board at the current moment.
 ; The LED pins must still be defined, to avoid an error loop on pin definitions.
-; Available GPIOs are 0 - 8, 10, 20, 21.
+; These are dummy definitions and are not actually used. Any choice 2 - 10, 20, 21 should be fine.
 ; See https://community.openmqttgateway.com/t/watchdog-kills-omg-on-esp32-c3-within-seconds/2192/15
   '-DLED_SEND_RECEIVE=10'
   '-DLED_INFO=6'
   '-DLED_ERROR=7'
+; The momentary switch on the board is connected to GPIO9
   '-DTRIGGER_GPIO=9'
   '-DNO_INT_TEMP_READING=true' ; No internal temperature on ESP32 C3 or S3
   '-DGateway_Name="OpenMQTTGateway_ESP32C3_BLE"'
 ; Serial output currently causes a delay on each message, if no serial listener is connected.
-; Therefore we disable serial output. Use the _with_serial environment if you
+; As a default we disable serial output. Use the _with_serial environment if you
 ; need serial output for debugging purposes.
   '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; disable serial logging.
-  '-DWM_DEBUG_LEVEL=DEBUG_ERROR'  ; disable serial logging.
+  '-DWM_DEBUG_LEVEL=0'  ; disable serial logging.
 custom_description = BLE gateway on ESP32C3
 custom_hardware = Wemos Lolin C3 mini v2.1.0
 
@@ -1578,6 +1579,9 @@ build_flags =
   ${env:lolin_c3_mini.build_flags}
   '-DLOG_LEVEL=LOG_LEVEL_NOTICE' ;default
   '-DWM_DEBUG_LEVEL=DEBUG_NOTIFY' ;default
+; Serial output via USB
+  '-DCONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=true'
+  '-DCONFIG_ESP_CONSOLE_UART=ESP_CONSOLE_USB_SERIAL_JTAG'   
 
 [env:thingpulse-espgateway]
 platform = ${com.esp32_platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -98,6 +98,7 @@ extra_configs =
 ;default_envs = esp32s3-dev-c1-ble
 ;default_envs = esp32c3-dev-m1-ble
 ;default_envs = airm2m_core_esp32c3
+;default_envs = lolin_c3_mini
 ;default_envs = thingpulse-espgateway
 ;default_envs = thingpulse-espgateway-ethernet
 


### PR DESCRIPTION
## Description: New environment definition for board Wemos Lolin C3 mini v2.3.0

This is the result of a discussion about how to run OMG on this board. See https://community.openmqttgateway.com/t/watchdog-kills-omg-on-esp32-c3-within-seconds/2192/36


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
