### PR TITLE
[BT] Scan_Duration as MQTT command

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -178,6 +178,12 @@ If you want to change the time between active scans you can change it by MQTT. F
 
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"intervalacts":300000}'`
 
+## Setting the duration of a scan
+
+If you want to change the default 10 sec duration of each scan cycle to 5 seconds
+
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"scanduration":5000}'`
+
 ## Setting if the gateway connects to BLE devices eligibles on ESP32
 
 If you want to change this characteristic:

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -66,7 +66,10 @@ extern int btQueueLengthCount;
 #define MinimumRSSI -100 //default minimum rssi value, all the devices below -100 will not be reported
 
 #ifndef Scan_duration
-#  define Scan_duration 10000 //define the time for a scan; in milliseconds
+#  define Scan_duration 10000 //define the duration for a scan; in milliseconds
+#endif
+#ifndef MinScanDuration
+#  define MinScanDuration 1000 //minimum duration for a scan; in milliseconds
 #endif
 #ifndef BLEScanInterval
 #  define BLEScanInterval 52 // How often the scan occurs / switches channels; in milliseconds,
@@ -144,6 +147,7 @@ struct BTConfig_s {
   unsigned long intervalActiveScan; // Time between 2 active scans when generally passive scanning
   unsigned long BLEinterval; // Time between 2 scans
   unsigned long intervalConnect; // Time between 2 connects
+  unsigned long scanDuration; // Duration for a scan; in milliseconds
   bool pubOnlySensors; // Publish only the identified sensors (like temperature sensors)
   bool pubRandomMACs; // Publish devices which randomly change their MAC address
   bool presenceEnable; // Publish into Home Assistant presence topic


### PR DESCRIPTION
Scan_Duration as runtime MQTT command 'scanduration'
Scan duration to new MinScanDuration 1 s with adaptive scanning enabled when **"acts" & "cont"** or **"cont" & type "CTMO"** devices are detected.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
