### PR TITLE
[RTL_433 Discovery] Do not store the devices in memory if discovery off

### DIFF
--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -214,8 +214,6 @@ void storeRTL_433Discovery(JsonObject& RFrtl_433_ESPdata, const char* model, con
     }
   }
 }
-#  else
-void storeRTL_433Discovery(JsonObject& RFrtl_433_ESPdata, const char* model, const char* uniqueid) {}
 #  endif
 
 void rtl_433_Callback(char* message) {
@@ -252,7 +250,10 @@ void rtl_433_Callback(char* message) {
 
   Log.notice(F("uniqueid: %s" CR), uniqueid.c_str());
   if (!isAduplicateSignal(MQTTvalue)) {
-    storeRTL_433Discovery(RFrtl_433_ESPdata, (char*)model.c_str(), (char*)uniqueid.c_str());
+#  ifdef ZmqttDiscovery
+    if (disc)
+      storeRTL_433Discovery(RFrtl_433_ESPdata, (char*)model.c_str(), (char*)uniqueid.c_str());
+#  endif
     pub((char*)topic.c_str(), RFrtl_433_ESPdata);
     storeSignalValue(MQTTvalue);
     pubOled((char*)topic.c_str(), RFrtl_433_ESPdata);


### PR DESCRIPTION
## Description:
Avoid storing devices in the vector if the discovery is off, the goal is to avoid a growing vector memory when the user stops the discovery

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
