### PR TITLE
Fix for #1458: crash on sending LoRa data

### DIFF
--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -73,6 +73,10 @@ Try and determine device given the JSON type
 uint8_t _determineDevice(JsonObject& LORAdata) {
   const char* protocol_name = LORAdata["type"];
 
+  // No type provided
+  if (!protocol_name)
+    return UNKNOWN_DEVICE;
+
   if (strcmp(protocol_name, "WiPhone") == 0)
     return WIPHONE;
 
@@ -240,7 +244,7 @@ void MQTTtoLORA(char* topicOri, JsonObject& LORAdata) { // json object decoding
         // We have hex data: create convert to binary
         byte raw[strlen(hex) / 2];
         _hexToRaw(hex, raw, sizeof(raw));
-        LoRa.print((char*)raw);
+        LoRa.write((uint8_t*)raw, sizeof(raw));
       } else {
         // ascii payload
         LoRa.print(message);


### PR DESCRIPTION
## Description:
This PR fixes the crash introduced in #1458 (I'm so sorry I introduced this).

Upon writing documentation for the new features, I discovered the device will crash when sending `message` or `hex` data.
It now verifies the presence of the `type` field, and also makes sure the correct size is used when sending in hex.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
