### PR TITLE
[MQTT] Optional message retain flag

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -359,6 +359,9 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #ifndef will_Retain
 #  define will_Retain true
 #endif
+#ifndef sensor_Retain
+#  define sensor_Retain false
+#endif
 #ifndef will_Message
 #  define will_Message "offline"
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -462,7 +462,7 @@ void pub_custom_topic(const char* topic, JsonObject& data, boolean retain) {
  * @param payload  the payload
  */
 void pubMQTT(const char* topic, const char* payload) {
-  pubMQTT(topic, payload, false);
+  pubMQTT(topic, payload, sensor_Retain);
 }
 
 /**


### PR DESCRIPTION
## Description:
Add optional retain flag to sensor messages.
The default behaviour (ie: **not** retaining messages) is preserved as default

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
