### PR TITLE
[BT] Copy advertised device to avoid concurrent data access.

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -563,8 +563,10 @@ static int taskCore = 0;
 
 class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
   void onResult(BLEAdvertisedDevice* advertisedDevice) {
-    if (xQueueSend(BLEQueue, &advertisedDevice, 0) != pdTRUE) {
+    BLEAdvertisedDevice* ad = new BLEAdvertisedDevice(*advertisedDevice);
+    if (xQueueSend(BLEQueue, &ad, 0) != pdTRUE) {
       Log.error(F("BLEQueue full" CR));
+      delete (ad);
     }
   }
 };
@@ -597,6 +599,7 @@ void procBLETask(void* pvParameters) {
 
       if (BTConfig.filterConnectable && device->connect) {
         Log.notice(F("Filtered connectable device" CR));
+        delete (advertisedDevice);
         continue;
       }
 
@@ -636,6 +639,7 @@ void procBLETask(void* pvParameters) {
         Log.trace(F("Filtered MAC device" CR));
       }
     }
+    delete (advertisedDevice);
   }
 }
 


### PR DESCRIPTION
## Description:
This change fixes the following error :
```
Backtrace: 0x400e534c:0x3ffe26e0 0x400e5555:0x3ffe2700 0x400e12b3:0x3ffe2720 0x40090dee:0x3ffe27f0
  #0  0x400e534c:0x3ffe26e0 in NimBLEAdvertisedDevice::findAdvField(unsigned char, unsigned char, unsigned int*) at .pio/libdeps/esp32dev-ble/NimBLE-Arduino/src/NimBLEAdvertisedDevice.cpp:464
```
## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
