### PR TITLE
[HA Discovery] Auto Off timer

### DIFF
--- a/docs/integrate/home_assistant.md
+++ b/docs/integrate/home_assistant.md
@@ -13,7 +13,7 @@ From Home Assistant site
 
 On OpenMQTTGateway the Home Assistant discovery is enabled by default on all binaries and platformio configurations except for UNO. With Arduino IDE please read the [advanced configuration section](../upload/advanced-configuration#auto-discovery) of the documentation. Here are a few tips for activating discovery on Home Assistant, but for detailed configuration please refer to the Home Assistant website. 
 
-Enable discovery on your MQTT integration in HASS.
+Enable discovery on your MQTT integration in HASS (activated per default).
 
 ![](../img/OpenMQTTGateway-Configuration-Home-Assistant-Discovery-Integration.png)
 
@@ -36,6 +36,9 @@ OMG will use the auto discovery functionality of home assistant to create gatewa
 ::: info
 The Bluetooth and the RTL_433 gateway will create automatically devices and entities, the RF gateway will create DeviceTrigger.
 The OpenMQTTGateway will also be available as a device to monitor its parameters and control it. The sensors (DHT for example) and actuators (relays) are attached to the gateway.
+
+30 minutes after its activation the auto discovery will be automaticaly deactivated, you can reactivate it from the gateway controls.
+Some devices may require a button push to trigger a message and generate the auto discovery.
 :::
 
 ## RTL_433 auto discovery specificity

--- a/docs/integrate/home_assistant.md
+++ b/docs/integrate/home_assistant.md
@@ -38,7 +38,7 @@ The Bluetooth and the RTL_433 gateway will create automatically devices and enti
 The OpenMQTTGateway will also be available as a device to monitor its parameters and control it. The sensors (DHT for example) and actuators (relays) are attached to the gateway.
 
 30 minutes after its activation the auto discovery will be automaticaly deactivated, you can reactivate it from the gateway controls.
-Some devices may require a button push to trigger a message and generate the auto discovery.
+Some devices may require a button push or motion/contact event to trigger a message and generate the auto discovery.
 :::
 
 ## RTL_433 auto discovery specificity

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -121,6 +121,10 @@ void announceDeviceTrigger(bool use_gateway_info,
 #  define discovery_republish_on_reconnect false
 #endif
 
+#ifndef DiscoveryAutoOffTimer
+#  define DiscoveryAutoOffTimer 1800000 // Timer (ms) that trigger auto discovery to off after activation, the goal is to avoid the discovery of entities that are not expected
+#endif
+
 #ifndef GATEWAY_MANUFACTURER
 #  define GATEWAY_MANUFACTURER "OMG_community"
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -200,6 +200,7 @@ int failure_number_ntwk = 0; // number of failure connecting to network
 int failure_number_mqtt = 0; // number of failure connecting to MQTT
 #ifdef ZmqttDiscovery
 bool disc = true; // Auto discovery with Home Assistant convention
+unsigned long lastDiscovery = 0; // Time of the last discovery to trigger automaticaly to off after DiscoveryAutoOffTimer
 #endif
 unsigned long timer_led_measures = 0;
 static void* eClient = nullptr;
@@ -1537,6 +1538,9 @@ void loop() {
       bool justReconnected = !connected;
 
 #ifdef ZmqttDiscovery
+      // Deactivate autodiscovery after DiscoveryAutoOffTimer
+      if (disc && (now > lastDiscovery + DiscoveryAutoOffTimer))
+        disc = false;
       // at first connection we publish the discovery payloads
       // or, when we have just re-connected (only when discovery_republish_on_reconnect is enabled)
       bool publishDiscovery = disc && (!connectedOnce || (discovery_republish_on_reconnect && justReconnected));
@@ -2355,6 +2359,8 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
 #ifdef ZmqttDiscovery
     if (SYSdata.containsKey("discovery")) {
       if (SYSdata["discovery"].is<bool>()) {
+        if (SYSdata["discovery"] == true && disc == false)
+          lastDiscovery = millis();
         disc = SYSdata["discovery"];
         stateMeasures();
         if (disc)


### PR DESCRIPTION
## Description:
Auto deactivate discovery after 30min from the last activation, goal is to avoid unwanted entities created

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
