### PR TITLE
[SYS] Bump ESP32 platform to v6.1.0 and ESP8266 to v4.1.0

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -1510,7 +1510,7 @@ build_flags =
 custom_description = Default BLE gateway with additional servicedata, manufacturerdata and service uuid for analysing decoding issues
 
 [env:esp32s3-dev-c1-ble]
-platform = ${com.esp32_c3_s3_platform}
+platform = ${com.esp32_platform}
 board = esp32-s3-devkitc-1
 lib_deps =
   ${com-esp.lib_deps}
@@ -1530,7 +1530,7 @@ build_flags =
 custom_description = BLE gateway on the S3
 
 [env:esp32c3-dev-m1-ble]
-platform = ${com.esp32_c3_s3_platform}
+platform = ${com.esp32_platform}
 board = esp32-c3-devkitm-1
 board_build.partitions = min_spiffs.csv
 lib_deps =
@@ -1551,7 +1551,7 @@ build_flags =
 custom_description = BLE gateway on the C3
 
 [env:airm2m_core_esp32c3]
-platform = ${com.esp32_c3_s3_platform}
+platform = ${com.esp32_platform}
 board = airm2m_core_esp32c3
 board_build.partitions = min_spiffs.csv
 lib_deps =
@@ -1571,7 +1571,7 @@ custom_hardware = AirM2M ESP32C3-CORE
 
 ; Wemos Lolin C3 mini v2.1.0
 [env:lolin_c3_mini]
-;platform = ${com.esp32_c3_s3_platform} ; standard is @5.2.0, causes `assert rwble.c 261` error
+;platform = ${com.esp32_platform} ; standard is @5.2.0, causes `assert rwble.c 261` error
 platform = espressif32@5.3.0  ; override to @5.3.0. Includes a fixed for the `assert rwble.c 261` error
 board = lolin_c3_mini
 board_build.partitions = min_spiffs.csv

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -416,9 +416,6 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #ifndef RGB_INDICATORS // Management of Errors, reception/emission and informations indicators with basic LED
 /*-------------DEFINE PINs FOR STATUS LEDs----------------*/
 #  ifndef LED_SEND_RECEIVE
-#    ifdef LED_BUILTIN
-#      define LED_SEND_RECEIVE LED_BUILTIN
-#    endif
 #    ifdef ESP8266
 //#      define LED_SEND_RECEIVE 40
 #    elif ESP32
@@ -433,9 +430,6 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #    define LED_SEND_RECEIVE_ON HIGH
 #  endif
 #  ifndef LED_ERROR
-#    ifdef LED_BUILTIN
-#      define LED_ERROR LED_BUILTIN
-#    endif
 #    ifdef ESP8266
 //#      define LED_ERROR 42
 #    elif ESP32
@@ -450,9 +444,6 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #    define LED_ERROR_ON HIGH
 #  endif
 #  ifndef LED_INFO
-#    ifdef LED_BUILTIN
-#      define LED_INFO LED_BUILTIN
-#    endif
 #    ifdef ESP8266
 //#      define LED_INFO 44
 #    elif ESP32

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -416,65 +416,95 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #ifndef RGB_INDICATORS // Management of Errors, reception/emission and informations indicators with basic LED
 /*-------------DEFINE PINs FOR STATUS LEDs----------------*/
 #  ifndef LED_SEND_RECEIVE
+#    ifdef LED_BUILTIN
+#      define LED_SEND_RECEIVE LED_BUILTIN
+#    endif
 #    ifdef ESP8266
-#      define LED_SEND_RECEIVE 40
+//#      define LED_SEND_RECEIVE 40
 #    elif ESP32
-#      define LED_SEND_RECEIVE 40
+//#      define LED_SEND_RECEIVE 40
 #    elif __AVR_ATmega2560__ //arduino mega
-#      define LED_SEND_RECEIVE 40
+//#      define LED_SEND_RECEIVE 40
 #    else //arduino uno/nano
-#      define LED_SEND_RECEIVE 40
+//#      define LED_SEND_RECEIVE 40
 #    endif
 #  endif
 #  ifndef LED_SEND_RECEIVE_ON
 #    define LED_SEND_RECEIVE_ON HIGH
 #  endif
 #  ifndef LED_ERROR
+#    ifdef LED_BUILTIN
+#      define LED_ERROR LED_BUILTIN
+#    endif
 #    ifdef ESP8266
-#      define LED_ERROR 42
+//#      define LED_ERROR 42
 #    elif ESP32
-#      define LED_ERROR 42
+//#      define LED_ERROR 42
 #    elif __AVR_ATmega2560__ //arduino mega
-#      define LED_ERROR 42
+//#      define LED_ERROR 42
 #    else //arduino uno/nano
-#      define LED_ERROR 42
+//#      define LED_ERROR 42
 #    endif
 #  endif
 #  ifndef LED_ERROR_ON
 #    define LED_ERROR_ON HIGH
 #  endif
 #  ifndef LED_INFO
+#    ifdef LED_BUILTIN
+#      define LED_INFO LED_BUILTIN
+#    endif
 #    ifdef ESP8266
-#      define LED_INFO 44
+//#      define LED_INFO 44
 #    elif ESP32
-#      define LED_INFO 44
+//#      define LED_INFO 44
 #    elif __AVR_ATmega2560__ //arduino mega
-#      define LED_INFO 44
+//#      define LED_INFO 44
 #    else //arduino uno/nano
-#      define LED_INFO 44
+//#      define LED_INFO 44
 #    endif
 #  endif
 #  ifndef LED_INFO_ON
 #    define LED_INFO_ON HIGH
 #  endif
-#  define SetupIndicators()            \
-    pinMode(LED_SEND_RECEIVE, OUTPUT); \
-    pinMode(LED_INFO, OUTPUT);         \
-    pinMode(LED_ERROR, OUTPUT);        \
-    SendReceiveIndicatorOFF();         \
-    InfoIndicatorOFF();                \
-    ErrorIndicatorOFF();
 
-#  define ErrorIndicatorON()        digitalWrite(LED_ERROR, LED_ERROR_ON)
-#  define ErrorIndicatorOFF()       digitalWrite(LED_ERROR, !LED_ERROR_ON)
-#  define SendReceiveIndicatorON()  digitalWrite(LED_SEND_RECEIVE, LED_SEND_RECEIVE_ON)
-#  define SendReceiveIndicatorOFF() digitalWrite(LED_SEND_RECEIVE, !LED_SEND_RECEIVE_ON)
-#  define InfoIndicatorON()         digitalWrite(LED_INFO, LED_INFO_ON)
-#  define InfoIndicatorOFF()        digitalWrite(LED_INFO, !LED_INFO_ON)
-#  define CriticalIndicatorON()     // Not used
-#  define CriticalIndicatorON()     // Not used
-#  define PowerIndicatorON()        // Not used
-#  define PowerIndicatorOFF()       // Not used
+#  ifdef LED_ERROR
+#    define SetupIndicatorError() \
+      pinMode(LED_ERROR, OUTPUT); \
+      ErrorIndicatorOFF();
+#    define ErrorIndicatorON()  digitalWrite(LED_ERROR, LED_ERROR_ON)
+#    define ErrorIndicatorOFF() digitalWrite(LED_ERROR, !LED_ERROR_ON)
+#  else
+#    define SetupIndicatorError()
+#    define ErrorIndicatorON()
+#    define ErrorIndicatorOFF()
+#  endif
+#  ifdef LED_SEND_RECEIVE
+#    define SetupIndicatorSendReceive()  \
+      pinMode(LED_SEND_RECEIVE, OUTPUT); \
+      SendReceiveIndicatorOFF();
+#    define SendReceiveIndicatorON()  digitalWrite(LED_SEND_RECEIVE, LED_SEND_RECEIVE_ON)
+#    define SendReceiveIndicatorOFF() digitalWrite(LED_SEND_RECEIVE, !LED_SEND_RECEIVE_ON)
+#  else
+#    define SetupIndicatorSendReceive()
+#    define SendReceiveIndicatorON()
+#    define SendReceiveIndicatorOFF()
+#  endif
+#  ifdef LED_INFO
+#    define SetupIndicatorInfo() \
+      pinMode(LED_INFO, OUTPUT); \
+      InfoIndicatorOFF();
+#    define InfoIndicatorON()  digitalWrite(LED_INFO, LED_INFO_ON)
+#    define InfoIndicatorOFF() digitalWrite(LED_INFO, !LED_INFO_ON)
+#  else
+#    define SetupIndicatorInfo()
+#    define InfoIndicatorON()
+#    define InfoIndicatorOFF()
+#  endif
+#  define CriticalIndicatorON() // Not used
+#  define CriticalIndicatorON() // Not used
+#  define PowerIndicatorON()    // Not used
+#  define PowerIndicatorOFF()   // Not used
+#  define SetupIndicators()     // Not used
 #else // Management of Errors, reception/emission and informations indicators with RGB LED
 #  if !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32C3) //I2S not available yet with Fastled on S3 and C3
 #    define FASTLED_ESP32_I2S // To avoid ESP32 instabilities https://github.com/FastLED/FastLED/issues/1438
@@ -549,6 +579,9 @@ CRGB leds2[FASTLED_IND_NUM_LEDS];
       leds2[FASTLED_INFO_LED] = CRGB::Black; \
       FastLED.show()
 #  endif
+#  define SetupIndicatorInfo()
+#  define SetupIndicatorSendReceive()
+#  define SetupIndicatorError()
 #endif
 
 #ifdef ESP8266

--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -174,10 +174,7 @@ void MQTTtoSSD1306(char* topicOri, JsonObject& SSD1306data) { // json object dec
     }
     // save, load, init, erase
     if (SSD1306data.containsKey("save") && SSD1306data["save"]) {
-      success = SSD1306Config_save();
-      if (success) {
-        Log.notice(F("SSD1306 config saved" CR));
-      }
+      SSD1306Config_save();
     } else if (SSD1306data.containsKey("load") && SSD1306data["load"]) {
       success = SSD1306Config_load();
       if (success) {
@@ -207,7 +204,7 @@ void MQTTtoSSD1306(char* topicOri, JsonObject& SSD1306data) { // json object dec
   }
 }
 
-bool SSD1306Config_save() {
+void SSD1306Config_save() {
   StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
   JsonObject jo = jsonBuffer.to<JsonObject>();
   jo["onstate"] = displayState;
@@ -223,6 +220,7 @@ bool SSD1306Config_save() {
   preferences.begin(Gateway_Short_Name, false);
   preferences.putString("SSD1306Config", conf);
   preferences.end();
+  Log.notice(F("SSD1306 config saved" CR));
 }
 
 void SSD1306Config_init() {

--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -827,10 +827,10 @@ OledSerial Oled(0); // Not sure about this, came from Hardwareserial
 OledSerial::OledSerial(int x) {
   displayQueue = xQueueCreate(5, sizeof(displayQueueMessage*));
 #  if defined(WIFI_Kit_32) || defined(WIFI_LoRa_32) || defined(WIFI_LoRa_32_V2)
-  // pinMode(RST_OLED, OUTPUT); // https://github.com/espressif/arduino-esp32/issues/4278
-  // digitalWrite(RST_OLED, LOW);
-  // delay(50);
-  // digitalWrite(RST_OLED, HIGH);
+  pinMode(RST_OLED, OUTPUT); // https://github.com/espressif/arduino-esp32/issues/4278
+  digitalWrite(RST_OLED, LOW);
+  delay(50);
+  digitalWrite(RST_OLED, HIGH);
   display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, GEOMETRY_128_64);
 #  elif defined(Wireless_Stick)
   // pinMode(RST_OLED, OUTPUT); // https://github.com/espressif/arduino-esp32/issues/4278

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -80,8 +80,6 @@ struct RTL_433device {
   bool isDisc;
 };
 
-extern std::vector<RTL_433device*> RTL_433devices;
-
 const char parameters[40][4][24] = {
     // RTL_433 key, name, unit, device_class
     {"temperature_C", "temperature", "°C", "temperature"},

--- a/main/main.ino
+++ b/main/main.ino
@@ -755,7 +755,10 @@ void setup() {
   checkButton();
 #endif
   //setup LED status
-  SetupIndicators();
+  SetupIndicatorError();
+  SetupIndicatorSendReceive();
+  SetupIndicatorInfo();
+  SetupIndicators(); // For RGB Leds
 
 #if defined(ESP8266) || defined(ESP32)
 #  ifdef ESP8266

--- a/main/main.ino
+++ b/main/main.ino
@@ -1492,24 +1492,24 @@ void setup_ethernet_esp32() {
 
 void WiFiEvent(WiFiEvent_t event) {
   switch (event) {
-    case SYSTEM_EVENT_ETH_START:
+    case ARDUINO_EVENT_ETH_START:
       Log.trace(F("Ethernet Started" CR));
       ETH.setHostname(gateway_name);
       break;
-    case SYSTEM_EVENT_ETH_CONNECTED:
+    case ARDUINO_EVENT_ETH_CONNECTED:
       Log.notice(F("Ethernet Connected" CR));
       break;
-    case SYSTEM_EVENT_ETH_GOT_IP:
+    case ARDUINO_EVENT_ETH_GOT_IP:
       Log.trace(F("OpenMQTTGateway MAC: %s" CR), ETH.macAddress().c_str());
       Log.trace(F("OpenMQTTGateway IP: %s" CR), ETH.localIP().toString().c_str());
       Log.trace(F("OpenMQTTGateway link speed: %d Mbps" CR), ETH.linkSpeed());
       esp32EthConnected = true;
       break;
-    case SYSTEM_EVENT_ETH_DISCONNECTED:
+    case ARDUINO_EVENT_ETH_DISCONNECTED:
       Log.error(F("Ethernet Disconnected" CR));
       esp32EthConnected = false;
       break;
-    case SYSTEM_EVENT_ETH_STOP:
+    case ARDUINO_EVENT_ETH_STOP:
       Log.error(F("Ethernet Stopped" CR));
       esp32EthConnected = false;
       break;
@@ -2178,8 +2178,6 @@ void MQTTHttpsFWUpdate(char* topicOri, JsonObject& HttpsFwUpdateData) {
 #    if defined(ZgatewayBT)
         stopProcessing();
 #    endif
-        if (!checkForUpdates())
-          return;
         systemUrl = RELEASE_LINK + latestVersion + "/" + ENV_NAME + "-firmware.bin";
         url = systemUrl.c_str();
         Log.notice(F("Using system OTA url with latest version %s" CR), url);

--- a/platformio.ini
+++ b/platformio.ini
@@ -169,9 +169,8 @@ build_flags =
 monitor_speed = 115200
 
 [com]
-esp8266_platform = espressif8266@3.2.0
-esp32_platform = espressif32@3.5.0
-esp32_c3_s3_platform = espressif32@5.2.0
+esp8266_platform = espressif8266@4.1.0
+esp32_platform = espressif32@6.1.0
 esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.5/platform-espressif32-v.2.0.5.zip
 atmelavr_platform = atmelavr@3.3.0
 


### PR DESCRIPTION
## Description:
Update ESP platforms


### Resolved Issues

* ZdisplaySSD1306 module when included causes a immediate reboot loop - #1551

### Open Issues

* Usage of GPIO pins greater than 39 causes excessive logging

```
[    41][E][esp32-hal-gpio.c:102] __pinMode(): Invalid pin selected
[    41][E][esp32-hal-gpio.c:102] __pinMode(): Invalid pin selected
E (40) gpio: gpio_set_level(226): GPIO output gpio_num error
E (45) gpio: gpio_set_level(226): GPIO output gpio_num error
E (51006) gpio: gpio_set_level(226): GPIO output gpio_num error
E (51012) gpio: gpio_set_level(226): GPIO output gpio_num error
E (51017) gpio: gpio_set_level(226): GPIO output gpio_num error
```
* Save configuration to flash triggers an exception/restart on a lily board

```
assert failed: heap_caps_free heap_caps.c:360 (heap != NULL && “free() target pointer is outside heap areas”)

Backtrace: 0x40083c69:0x3ffb2700 0x4008dcc1:0x3ffb2720 0x40093a45:0x3ffb2740 0x40084126:0x3ffb2870 0x40093a75:0x3ffb2890 0x40102e41:0x3ffb28b0 0x40102e51:0x3ffb28d0 0x400db272:0x3ffb28f0 0x400db3db:0x3ffb2c70 0x400db4f9:0x3ffb2cb0 0x400de686:0x3ffb2cd0 0x400dea63:0x3ffb3040 0x401a626d:0x3ffb30f0 0x400e641a:0x3ffb3110 0x400e64c1:0x3ffb3130 0x400e659e:0x3ffb3170 0x400e6751:0x3ffb31e0 0x400df386:0x3ffb3230 0x400df457:0x3ffb3250 0x401057e1:0x3ffb3290
  #0  0x40083c69:0x3ffb2700 in panic_abort at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/panic.c:408
  #1  0x4008dcc1:0x3ffb2720 in esp_system_abort at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/esp_system.c:137
  #2  0x40093a45:0x3ffb2740 in __assert_func at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/newlib/assert.c:85
  #3  0x40084126:0x3ffb2870 in heap_caps_free at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/heap/heap_caps.c:360
      (inlined by) heap_caps_free at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/heap/heap_caps.c:345
  #4  0x40093a75:0x3ffb2890 in free at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/newlib/heap.c:39
  #5  0x40102e41:0x3ffb28b0 in String::invalidate() at /Users/sgracey/.platformio/packages/framework-arduinoespressif32/cores/esp32/WString.cpp:163
  #6  0x40102e51:0x3ffb28d0 in String::~String() at /Users/sgracey/.platformio/packages/framework-arduinoespressif32/cores/esp32/WString.cpp:147
  #7  0x400db272:0x3ffb28f0 in SSD1306Config_save() at main/ZdisplaySSD1306.ino:224
```

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
