### PR TITLE
Fix for SSD1306 not working with latest ESP32 platform

### DIFF
--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -102,7 +102,10 @@ void loopSSD1306() {
       if (!Oled.displayPage(message)) {
         Log.warning(F("[ssd1306] displayPage failed: %s" CR), message->title);
       }
-      free(message);
+      if (currentOledMessage) {
+        free(currentOledMessage);
+      }
+      currentOledMessage = message;
       nextDisplayPage = uptime() + DISPLAY_PAGE_INTERVAL;
       logoDisplayed = false;
     }
@@ -824,22 +827,22 @@ OledSerial Oled(0); // Not sure about this, came from Hardwareserial
 OledSerial::OledSerial(int x) {
   displayQueue = xQueueCreate(5, sizeof(displayQueueMessage*));
 #  if defined(WIFI_Kit_32) || defined(WIFI_LoRa_32) || defined(WIFI_LoRa_32_V2)
-  pinMode(RST_OLED, OUTPUT);
-  digitalWrite(RST_OLED, LOW);
-  delay(50);
-  digitalWrite(RST_OLED, HIGH);
+  // pinMode(RST_OLED, OUTPUT); // https://github.com/espressif/arduino-esp32/issues/4278
+  // digitalWrite(RST_OLED, LOW);
+  // delay(50);
+  // digitalWrite(RST_OLED, HIGH);
   display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, GEOMETRY_128_64);
 #  elif defined(Wireless_Stick)
-  pinMode(RST_OLED, OUTPUT);
-  digitalWrite(RST_OLED, LOW);
-  delay(50);
-  digitalWrite(RST_OLED, HIGH);
+  // pinMode(RST_OLED, OUTPUT); // https://github.com/espressif/arduino-esp32/issues/4278
+  // digitalWrite(RST_OLED, LOW);
+  // delay(50);
+  // digitalWrite(RST_OLED, HIGH);
   display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, GEOMETRY_64_32);
 #  elif defined(ARDUINO_TTGO_LoRa32_v21new) // LILYGO® Disaster-Radio LoRa V2.1_1.6.1
-  pinMode(OLED_RST, OUTPUT);
-  digitalWrite(OLED_RST, LOW);
-  delay(50);
-  digitalWrite(OLED_RST, HIGH);
+  // pinMode(OLED_RST, OUTPUT);   // https://github.com/espressif/arduino-esp32/issues/4278
+  // digitalWrite(OLED_RST, LOW);
+  // delay(50);
+  // digitalWrite(OLED_RST, HIGH);
   display = new SSD1306Wire(0x3c, OLED_SDA, OLED_SCL, GEOMETRY_128_64);
 #  endif
 }
@@ -995,7 +998,7 @@ void OledSerial::drawLogo(int xshift, int yshift) {
   }
 }
 
-void stateSSD1306Display() {
+String stateSSD1306Display() {
   //Publish display state
   StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
   JsonObject DISPLAYdata = jsonBuffer.to<JsonObject>();
@@ -1021,6 +1024,9 @@ void stateSSD1306Display() {
   } else {
     Oled.display->resetOrientation();
   }
+  String output;
+  serializeJson(DISPLAYdata, output);
+  return output;
 }
 
 #endif

--- a/main/config_SSD1306.h
+++ b/main/config_SSD1306.h
@@ -107,6 +107,7 @@
 extern void setupSSD1306();
 extern void loopSSD1306();
 extern void MQTTtoSSD1306(char*, JsonObject&);
+extern String stateSSD1306Display();
 
 // Simple construct for displaying message in lcd and oled displays
 
@@ -139,6 +140,10 @@ struct displayQueueMessage {
   char line3[OLED_TEXT_WIDTH];
   char line4[OLED_TEXT_WIDTH];
 };
+
+displayQueueMessage* currentOledMessage;
+
+/*-------------------End of Global Variables----------------------*/
 
 // This pattern was borrowed from HardwareSerial and modified to support the ssd1306 display
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -152,7 +152,7 @@ rtl_433_ESP = https://github.com/NorthernMan54/rtl_433_ESP.git#v0.1.7
 emodbus =  miq19/eModbus@1.0.0
 gfSunInverter = https://github.com/BlackSmith/GFSunInverter.git#v1.0.1
 decoder = https://github.com/theengs/decoder.git#v1.3.0
-ssd1306 = thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.3.0
+ssd1306 = https://github.com/ThingPulse/esp8266-oled-ssd1306.git#f96fd6a
 lm75 = jeremycole/I2C Temperature Sensors derived from the LM75@^1.0.3
 rn8209 = https://github.com/theengs/RN8209C-SDK.git#arduino
 


### PR DESCRIPTION
## Description:

When testing the latest ESP32 platform, found that OMG got stuck in a reboot loop when SSD1306 was included in the build.

```
rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 188777542, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3fff0030,len:1184
load:0x40078000,len:13192
load:0x40080400,len:3028
entry 0x400805e4
ets Jun  8 2016 00:22:57
```

During troubleshooting found that just have having `pinMode(RST_OLED, OUTPUT)` present in the code, but not executed triggered the issue.  In our environment RST_OLED is GPIO16.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
