### PR TITLE
[NTP] Only check NTP when user requires timestamp

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -1622,7 +1622,9 @@ void loop() {
         checkForUpdates();
 #  endif
 #  if defined(ESP8266) || defined(ESP32)
+#    if message_UTCtimestamp || message_unixtimestamp
         syncNTP();
+#    endif
 #  endif
         timer_sys_checks = millis();
       }


### PR DESCRIPTION
## Description:
The NTP syncing is not required at start when timestamp is not used

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
