### PR TITLE
[RN8209] Fix in use binary_sensor template

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -897,7 +897,7 @@ void pubMqttDiscovery() {
       {"sensor", "volt", "RN8209", "voltage", jsonVolt, "", "", "V"},
       {"sensor", "current", "RN8209", "current", jsonCurrent, "", "", "A"},
       {"sensor", "power", "RN8209", "power", jsonPower, "", "", "W"},
-      {"binary_sensor", "inUse", "RN8209", "power", jsonInuseRN8209, "", "", ""}
+      {"binary_sensor", "inUse", "RN8209", "power", jsonInuseRN8209, "on", "off", ""}
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -171,7 +171,7 @@ void announceDeviceTrigger(bool use_gateway_info,
 #  define jsonCount       "{{ value_json.count }}"
 #  define jsonAlarm       "{{ value_json.alarm }}"
 #  define jsonInuse       "{{ value_json.power | float > 0 }}"
-#  define jsonInuseRN8209 "{{ value_json.power | float > 0.02 }}"
+#  define jsonInuseRN8209 "{% if value_json.power > 0.02 -%} on {% else %} off {%- endif %}"
 #  define jsonVoltBM2     "{% if value_json.uuid is not defined -%} {{value_json.volt}} {%- endif %}"
 #else // Home assistant autodiscovery value key definition
 #  define jsonBatt        "{{ value_json.batt | is_defined }}"
@@ -209,7 +209,7 @@ void announceDeviceTrigger(bool use_gateway_info,
 #  define jsonCount       "{{ value_json.count | is_defined }}"
 #  define jsonAlarm       "{{ value_json.alarm | is_defined }}"
 #  define jsonInuse       "{{ value_json.power | is_defined | float > 0 }}"
-#  define jsonInuseRN8209 "{{ value_json.power | is_defined | float > 0.02 }}"
+#  define jsonInuseRN8209 "{% if value_json.power > 0.02 -%} on {% else %} off {%- endif %}"
 #  define jsonVoltBM2     "{% if value_json.uuid is not defined and value_json.volt is defined -%} {{value_json.volt}} {%- endif %}"
 #endif
 


### PR DESCRIPTION
## Description:
State was previously unknown in HA, this change enable to value the binary_sensor to `on` or `off` depending on the power value

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
