### PR TITLE
[SSD1306] prefs start-up optimisation

### DIFF
--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -238,8 +238,8 @@ void SSD1306Config_init() {
 bool SSD1306Config_load() {
   StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
   preferences.begin(Gateway_Short_Name, true);
-  String exists = preferences.getString("SSD1306Config", "{}");
-  if (exists != "{}") {
+  bool exists = preferences.isKey("SSD1306Config");
+  if (exists) {
     auto error = deserializeJson(jsonBuffer, preferences.getString("SSD1306Config", "{}"));
     preferences.end();
     if (error) {
@@ -258,6 +258,7 @@ bool SSD1306Config_load() {
     displayMetric = jo["displaymetric"].as<bool>();
     idlelogo = jo["idlelogo"].as<bool>();
     displayFlip = jo["display-flip"].as<bool>();
+    Log.notice(F("Saved SSD1306 config loaded" CR));
     return true;
   } else {
     preferences.end();


### PR DESCRIPTION
Avoid
`[ 137][E][Preferences.cpp:483] getString(): nvs_get_str len fail: SSD1306Config NOT_FOUND `
error during start-up when no save preferences have been found

[lilygo-rtl-433-ssd1306-error](https://community.openmqttgateway.com/t/lilygo-rtl-433-ssd1306-error/2359)

now correctly
```
************* WELCOME TO OpenMQTTGateway **************
N: SSD1306 config initialised
N: No SSD1306 config to load
N: Setup SSD1306 Display end
```

and additionally  
```
************* WELCOME TO OpenMQTTGateway **************
N: SSD1306 config initialised
N: Saved SSD1306 config loaded
N: Setup SSD1306 Display end
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
