### PR TITLE
Removed forced 5.3.0 platform for Lolin C3 boards

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -1573,8 +1573,8 @@ custom_hardware = AirM2M ESP32C3-CORE
 
 ; Wemos Lolin C3 mini v2.1.0
 [env:lolin_c3_mini]
-;platform = ${com.esp32_platform} ; standard is @5.2.0, causes `assert rwble.c 261` error
-platform = espressif32@5.3.0  ; override to @5.3.0. Includes a fixed for the `assert rwble.c 261` error
+platform = ${com.esp32_platform} ; standard is now @6.1.x, should not have `assert rwble.c 261` error anymore
+;platform = espressif32@5.3.0  ; override to @5.3.0. Includes a fixed for the `assert rwble.c 261` error
 board = lolin_c3_mini
 board_build.partitions = min_spiffs.csv
 monitor_speed = 115200


### PR DESCRIPTION
## Description:
Forcing platform vesion @5.3.0 was a stopgap since the reference at the time was 5.2.0, which had issues. (the infamous `assert rwble.c 261` error)
Now it makes sense (IMHO of course) to go back to the default platform since those issues have been fixed and  [it should also be more stable](https://github.com/1technophile/OpenMQTTGateway/pull/1547#issuecomment-1481439786)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
