### PR TITLE
[BT] Application level Watchdog Timer to avoid scan_evt timeout

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -101,6 +101,23 @@ void BTConfig_init() {
   BTConfig.presenceAwayTimer = PresenceAwayTimer;
 }
 
+// Watchdog, if there was no change of btQueueLengthSum for 5 minutes, restart ESP
+void btScanWDG() {
+  static unsigned long previousbtQueueLengthSum = 0;
+  static unsigned long lastBtMsgTime = 0;
+  unsigned long now = millis();
+  if (!ProcessLock &&
+      previousbtQueueLengthSum == btQueueLengthSum &&
+      btQueueLengthSum != 0 &&
+      (now - lastBtMsgTime > BTConfig.BLEinterval)) {
+    Log.error(F("BLE Scan watchdog triggered at : %ds" CR), lastBtMsgTime / 1000);
+    ESPRestart();
+  } else {
+    previousbtQueueLengthSum = btQueueLengthSum;
+    lastBtMsgTime = now;
+  }
+}
+
 unsigned long timeBetweenConnect = 0;
 unsigned long timeBetweenActive = 0;
 
@@ -707,7 +724,6 @@ void BLEscan() {
   while (uxQueueMessagesWaiting(BLEQueue)) {
     yield();
   }
-  disableCore0WDT();
   Log.notice(F("Scan begin" CR));
   BLEScan* pBLEScan = BLEDevice::getScan();
   MyAdvertisedDeviceCallbacks myCallbacks;
@@ -723,7 +739,6 @@ void BLEscan() {
   BLEScanResults foundDevices = pBLEScan->start(BTConfig.scanDuration / 1000, false);
   scanCount++;
   Log.notice(F("Found %d devices, scan number %d end" CR), foundDevices.getCount(), scanCount);
-  enableCore0WDT();
   Log.trace(F("Process BLE stack free: %u" CR), uxTaskGetStackHighWaterMark(xProcBLETaskHandle));
 }
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -1604,6 +1604,7 @@ void loop() {
         stateMeasures();
 #  ifdef ZgatewayBT
         stateBTMeasures(false);
+        btScanWDG();
 #  endif
 #  ifdef ZactuatorONOFF
         stateONOFFMeasures();


### PR DESCRIPTION
## Description:
Implement a BLE scan watchdog to bypass the problem related to the BLE scan hang `scan_evt timeout`
This is a bypass solution to https://github.com/espressif/arduino-esp32/issues/5860
The watchdog will restart the ESP if no new BLE messages has been added to the queue following:
* checked every 120s
* if we are after the last BLE message time + the BLE scan interval for passive
* if the process is not locked by an OTA update or other operation
We restart the ESP

We also remove the WDT0 enable and disable functions.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
