### PR TITLE
Add support for ESP8266 deep sleep and the sensor ds18b20 

### DIFF
--- a/docs/use/boards.md
+++ b/docs/use/boards.md
@@ -91,3 +91,20 @@ OpenMQTTGateway support a low power mode for ESP32, this mode can be set by MQTT
 
 The low power mode can be changed also with a push to button B when the board is processing (top button on M5stickC, M5stickC Plus and middle button of M5stack).
 If you are already in low power mode 1 or 2 with M5Stack you can wake up the board by pressing the red button.
+
+### Low power mode (deepSleep) for ESP8266 boards
+In certain use cases where power is severly limited you can use the ESP8266 deep sleep capability.
+
+* e.g. measuring a pool temperature every 5 minutes using an ESP8266 and DS18B20 probe where the ESP8266 is powered by very limited battery backed solar power.
+
+During deep sleep everything is off and (almost) all execution state is lost. 
+
+Consumption is about 20 µA.
+
+Use this when you want the device to sleep for minutes or hours.
+
+You only have to define the macro `ESP8266_DEEP_SLEEP_IN_US` with the number of microseconds.
+
+A hardware jumper is required connecting RST to a GPIO (not to CH_PD) defined by the macro `ESP8266_DEEP_SLEEP_WAKE_PIN` and defaulted to D0.
+
+And the sensor code must set variable `ready_to_sleep` to true after publishing the measurement to MQTT and the main loop will then enter deep sleep.

--- a/environments.ini
+++ b/environments.ini
@@ -1117,6 +1117,7 @@ build_flags =
   ;'-DZgatewayWeatherStation="WeatherStation"'
   '-DsimplePublishing=true'
   '-DGateway_Name="OpenMQTTGateway_ESP8266_ALL"'
+  '-DESP8266_DEEP_SLEEP_IN_US=120000000'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-fastled-test]

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -294,6 +294,16 @@ static_assert(MQTT_SECURE_SELF_SIGNED_INDEX_DEFAULT < (sizeof(certs_array) / siz
 #  endif
 #endif
 
+/**
+ * Deep-sleep for the ESP8266.
+ * Set the wake pin.
+ */
+#ifdef ESP8266_DEEP_SLEEP_IN_US
+#  ifndef ESP8266_DEEP_SLEEP_WAKE_PIN
+#    define ESP8266_DEEP_SLEEP_WAKE_PIN D0
+#  endif
+#endif
+
 /*------------------DEEP SLEEP parameters ------------------*/
 //DEFAULT_LOW_POWER_MODE -1 to normal mode, low power mode can't be used on this build
 //DEFAULT_LOW_POWER_MODE 0 to normal mode (no power consumption optimisations)

--- a/main/ZsensorDS1820.ino
+++ b/main/ZsensorDS1820.ino
@@ -162,6 +162,9 @@ void MeasureDS1820Temp() {
           Log.trace(F("DS1820: Temperature for device %s didn't change, don't publish it." CR), (char*)ds1820_addr[i].c_str());
         }
         persisted_temp[i] = current_temp[i];
+#  ifdef ESP8266_DEEP_SLEEP_IN_US
+        ready_to_sleep = true;
+#  endif
       }
     }
   }

--- a/main/config_DS1820.h
+++ b/main/config_DS1820.h
@@ -33,13 +33,17 @@ extern void pubOneWire_HADiscovery();
 
 /*----------------------------USER PARAMETERS-----------------------------*/
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
-#define OW_TOPIC            "/OneWiretoMQTT/ds1820"
-#define OW_MAX_SENSORS      8 // query max. sensors on 1-wire bus
-#define DS1820_ALWAYS       true // if false only published current temperature if has changed from previous reading
-#define DS1820_INTERVAL_SEC 60UL // time between DS1820 readings (seconds)
-#define DS1820_RESOLUTION   10 // conversion times: 9 bit (93.75 ms), 10 bit (187.5 ms), 11 bit (375 ms), 12 bit (750 ms)
-#define DS1820_DETAILS      true // publish extended info for each sensor (resolution, address, type)
-#define DS1820_CONV_TIME    2000UL // trigger conversion before requesting temperature readings (ms)
+#define OW_TOPIC       "/OneWiretoMQTT/ds1820"
+#define OW_MAX_SENSORS 8 // query max. sensors on 1-wire bus
+#define DS1820_ALWAYS  true // if false only published current temperature if has changed from previous reading
+#ifndef DS1820_INTERVAL_SEC
+#  define DS1820_INTERVAL_SEC 60UL // time between DS1820 readings (seconds)
+#endif
+#ifndef DS1820_RESOLUTION
+#  define DS1820_RESOLUTION 10 // conversion times: 9 bit (93.75 ms), 10 bit (187.5 ms), 11 bit (375 ms), 12 bit (750 ms)
+#endif
+#define DS1820_DETAILS   true // publish extended info for each sensor (resolution, address, type)
+#define DS1820_CONV_TIME 2000UL // trigger conversion before requesting temperature readings (ms)
 /*-------------------PIN DEFINITIONS----------------------*/
 
 #ifndef DS1820_OWBUS_GPIO

--- a/main/config_MQ2.h
+++ b/main/config_MQ2.h
@@ -55,7 +55,9 @@ extern void MQ2toMQTT();
 #  endif
 #endif
 
-#define TimeBetweenReadingmq2 10000
+#ifndef TimeBetweenReadingmq2
+#  define TimeBetweenReadingmq2 10000
+#endif
 /*----------------------------USER PARAMETERS-----------------------------*/
 /*-------------DEFINE YOUR MQTT PARAMETERS BELOW----------------*/
 #define subjectMQ2toMQTT "/GAStoMQTT/mq2"

--- a/main/main.ino
+++ b/main/main.ino
@@ -53,6 +53,14 @@ unsigned long timer_sys_checks = 0;
 #  define ARDUINOJSON_ENABLE_STD_STRING 1
 #endif
 
+/**
+ * Deep-sleep for the ESP8266 we need some form of indicator that we have posted the measurements and am ready to deep sleep.
+ * Set this to true in the sensor code after publishing the measurement.
+ */
+#ifdef ESP8266_DEEP_SLEEP_IN_US
+bool ready_to_sleep = false;
+#endif
+
 #include <ArduinoJson.h>
 #include <ArduinoLog.h>
 #include <PubSubClient.h>
@@ -766,6 +774,11 @@ void setup() {
   modules.add(ZdisplaySSD1306);
 #    endif
   Log.notice(F("OpenMQTTGateway Version: " OMG_VERSION CR));
+#  endif
+
+#  ifdef ESP8266_DEEP_SLEEP_IN_US
+  Log.notice(F("Setting wake pin for deep sleep." CR));
+  pinMode(ESP8266_DEEP_SLEEP_WAKE_PIN, WAKEUP_PULLUP);
 #  endif
 
 /*
@@ -1773,6 +1786,17 @@ void loop() {
 #endif
 #if defined(ZdisplaySSD1306)
   loopSSD1306();
+#endif
+
+/**
+ * Deep-sleep for the ESP8266 - e.g. ESP8266_DEEP_SLEEP_IN_US 30000000 for 30 seconds.
+ * Everything is off and (almost) all execution state is lost.
+ */
+#ifdef ESP8266_DEEP_SLEEP_IN_US
+  if (ready_to_sleep) {
+    Log.notice(F("Entering deep sleep for : %l us." CR), ESP8266_DEEP_SLEEP_IN_US);
+    ESP.deepSleep(ESP8266_DEEP_SLEEP_IN_US);
+  }
 #endif
 }
 

--- a/prod_env.ini.example
+++ b/prod_env.ini.example
@@ -125,3 +125,47 @@ build_flags =
 board_build.flash_mode = dout
 extra_scripts = scripts/compressFirmware.py
 board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad. Should also be uses for initial flash via serial
+
+;Wemos D1 with an MQ2 flammable gas sensor at custom interval
+[env:wemosd1-mq2-gas]
+platform = ${com.esp8266_platform}
+board = d1_mini
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
+  ${libraries.esp8266_mdns}
+build_flags =
+  ${com-esp.build_flags}
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
+;  '-UZmqttDiscovery="HADiscovery"'
+  '-DvalueAsATopic=true'       ; MQTT topic includes model and device
+  '-DGateway_Name="OpenMQTTGateway_MQ2_GAS"'
+  '-DZsensorMQ2="MQ2"'
+  '-DTimeBetweenReadingmq2=8000'
+board_build.flash_mode = dout
+custom_description = Gas flammable sensor gateway 
+custom_hardware = Gas flammable sensor first version
+
+;ESP12E with an DS1820 waterproof temperature probe, custom interval, max temperature resolution and DEEP SLEEP to conserve battery power
+[env:esp12e-ds18b20-deepsleep-pool]
+platform = ${com.esp8266_platform}
+board = esp12e
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager8266}
+  ${libraries.esp8266_mdns}
+  ${libraries.dallastemperature}
+build_flags =
+  ${com-esp.build_flags}
+  '-UZmqttDiscovery'          ; disables MQTT Discovery
+;  '-UZmqttDiscovery="HADiscovery"'
+  '-DvalueAsATopic=true'       ; MQTT topic includes model and device
+  '-DGateway_Name="OpenMQTTGatewayDS1820Pool"'
+  '-DZsensorDS1820="DS1820"'
+  '-DDS1820_OWBUS_GPIO=D2'
+  '-DESP8266_DEEP_SLEEP_IN_US=120000000'
+  '-DDS1820_RESOLUTION=12'
+  '-DDS1820_INTERVAL_SEC=15UL'
+board_build.flash_mode = dout
+custom_description = Pool temp sensor gateway 
+custom_hardware = Pool temp sensor first version


### PR DESCRIPTION
## Description:

Add support for ESP8266 deep sleep and the sensor ds18b20.  Also updated the documentation on how to use the feature and an example use case as used by me.

Further reading on deep sleep on ESP8266:
https://starbeamrainbowlabs.com/blog/article.php?article=posts%2F295-ESP-Deep-Sleep.html
https://blog.creations.de/?p=149
https://randomnerdtutorials.com/esp8266-deep-sleep-with-arduino-ide/

Jumper required when using deep sleep, e.g.

![image](https://user-images.githubusercontent.com/15066052/230168144-6817d463-464f-430d-af90-f7111307abe9.png)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
