### PR TITLE
[INDICATORS] Neopixel 2leds

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -1588,6 +1588,8 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DANEOPIX_IND_DATA_GPIO=8'
   '-DANEOPIX_IND_NUM_LEDS=1'
+ ; '-DANEOPIX_BRIGHTNESS=10'   ; 0 - 255, default 20
+  '-DANEOPIX_COLOR_SCHEME=1'   ; blue based signalling colors
   '-DRGB_INDICATORS=2'         ; 2 = use Adafruit NeoPixel library
   '-DNO_INT_TEMP_READING=true' ; No internal temperature reading on ESP32 C3 or S3
   '-DTRIGGER_GPIO=7'

--- a/environments.ini
+++ b/environments.ini
@@ -1607,8 +1607,7 @@ custom_description = BLE gateway on Espressiv ESP32-C3-DevKitC-02 without loggin
 
 ; Wemos Lolin C3 mini v2.1.0
 [env:lolin_c3_mini]
-platform = ${com.esp32_platform} ; standard is now @6.1.x, should not have `assert rwble.c 261` error anymore
-;platform = espressif32@5.3.0  ; override to @5.3.0. Includes a fixed for the `assert rwble.c 261` error
+platform = ${com.esp32_platform}
 board = lolin_c3_mini
 board_build.partitions = min_spiffs.csv
 monitor_speed = 115200

--- a/environments.ini
+++ b/environments.ini
@@ -1595,9 +1595,9 @@ build_flags =
 custom_description = BLE gateway on Espressiv ESP32-C3-DevKitC-02
 
 [env:esp32c3-dev-c2-ble-no-serial]
-extends = env:esp32c3-dev-c02-ble
+extends = env:esp32c3-dev-c2-ble
 build_flags =
-  ${env:esp32c3-dev-c02-ble.build_flags}
+  ${env:esp32c3-dev-c2-ble.build_flags}
   '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; ommit logging for increased stability
   '-DWM_DEBUG_LEVEL=0'
 custom_description = BLE gateway on Espressiv ESP32-C3-DevKitC-02 without logging

--- a/environments.ini
+++ b/environments.ini
@@ -1614,16 +1614,16 @@ lib_deps =
   ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
+; 07 Mar 2023: usage FastLED results in nearly immediate reboots
+; therefore the Adafruit NeoPixel library is used for the RGB LED
+  adafruit/Adafruit NeoPixel@^1.11.0
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-; FastLED must be disabled. FastLED is not compatible with this board at the current moment.
-; The LED pins must still be defined, to avoid an error loop on pin definitions.
-; These are dummy definitions and are not actually used. Any choice 2 - 10, 20, 21 should be fine.
-; See https://community.openmqttgateway.com/t/watchdog-kills-omg-on-esp32-c3-within-seconds/2192/15
-  '-DLED_SEND_RECEIVE=10'
-  '-DLED_INFO=6'
-  '-DLED_ERROR=7'
+  '-DANEOPIX_IND_DATA_GPIO=7'
+  '-DANEOPIX_IND_NUM_LEDS=1'
+ ; '-DANEOPIX_BRIGHTNESS=10'  ; 0 - 255, default 20
+  '-DRGB_INDICATORS=2'        ; 2 = use Adafruit NeoPixel library
 ; The momentary switch on the board is connected to GPIO9
   '-DTRIGGER_GPIO=9'
   '-DNO_INT_TEMP_READING=true' ; No internal temperature on ESP32 C3 or S3

--- a/environments.ini
+++ b/environments.ini
@@ -1588,7 +1588,7 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DANEOPIX_IND_DATA_GPIO=8'
   '-DANEOPIX_IND_NUM_LEDS=1'
-  '-DRGB_INDICATORS=2'
+  '-DRGB_INDICATORS=2          ; 2 = use Adafruit NeoPixel library
   '-DNO_INT_TEMP_READING=true' ; No internal temperature reading on ESP32 C3 or S3
   '-DTRIGGER_GPIO=7'
   '-DGateway_Name="OpenMQTTGateway_ESP32C3_DKC02"'

--- a/environments.ini
+++ b/environments.ini
@@ -1588,7 +1588,7 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DANEOPIX_IND_DATA_GPIO=8'
   '-DANEOPIX_IND_NUM_LEDS=1'
-  '-DRGB_INDICATORS=2          ; 2 = use Adafruit NeoPixel library
+  '-DRGB_INDICATORS=2'         ; 2 = use Adafruit NeoPixel library
   '-DNO_INT_TEMP_READING=true' ; No internal temperature reading on ESP32 C3 or S3
   '-DTRIGGER_GPIO=7'
   '-DGateway_Name="OpenMQTTGateway_ESP32C3_DKC02"'

--- a/environments.ini
+++ b/environments.ini
@@ -894,16 +894,11 @@ lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.ble}
-;  ${libraries.fastled}
   ${libraries.decoder}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
   '-DGateway_Name="OpenMQTTGateway_ESP32_TINYPICO_BLE"'
-;  '-DRGB_LED_POWER=13'
-;  '-DFASTLED_IND_DATA_GPIO=2,12,RGB'
-;  '-DFASTLED_IND_TYPE=APA102'
-;  '-DFASTLED_IND_NUM_LEDS=1'
 board_build.flash_mode = dio
 custom_description = BLE gateway
 custom_hardware = ESP32 TinyPICO
@@ -1662,7 +1657,7 @@ build_flags =
   '-DANEOPIX_IND_DATA_GPIO=32'
   '-DANEOPIX_IND_NUM_LEDS=4'
   '-DANEOPIX_INFO_LED=0'
-  '-DANEOPIX_SEND_RECEIVCE_LED=1'
+  '-DANEOPIX_SEND_RECEIVE_LED=1'
   '-DANEOPIX_ERROR_LED=2'
   '-DANEOPIX_BRIGHTNESS=255'
   '-DRGB_INDICATORS=true'
@@ -1697,7 +1692,7 @@ build_flags =
   '-DANEOPIX_IND_DATA_GPIO=32'
   '-DANEOPIX_IND_NUM_LEDS=4'
   '-DANEOPIX_INFO_LED=0'
-  '-DANEOPIX_SEND_RECEIVCE_LED=1'
+  '-DANEOPIX_SEND_RECEIVE_LED=1'
   '-DANEOPIX_ERROR_LED=2'
   '-DANEOPIX_BRIGHTNESS=255'
   '-DRGB_INDICATORS=true'

--- a/environments.ini
+++ b/environments.ini
@@ -1590,7 +1590,7 @@ build_flags =
   '-DANEOPIX_IND_DATA_GPIO=8'
   '-DANEOPIX_IND_NUM_LEDS=1'
  ; '-DANEOPIX_BRIGHTNESS=10'   ; 0 - 255, default 20
-  '-DANEOPIX_COLOR_SCHEME=1'   ; blue based signalling colors
+  '-DANEOPIX_COLOR_SCHEME=2'   ; blue based signalling colors
   '-DRGB_INDICATORS=2'         ; 2 = use Adafruit NeoPixel library
   '-DNO_INT_TEMP_READING=true' ; No internal temperature reading on ESP32 C3 or S3
   '-DTRIGGER_GPIO=7'
@@ -1625,7 +1625,7 @@ build_flags =
   '-DANEOPIX_IND_DATA_GPIO=7'
   '-DANEOPIX_IND_NUM_LEDS=1'
  ; '-DANEOPIX_BRIGHTNESS=10'  ; 0 - 255, default 20
- ; '-DANEOPIX_COLOR_SCHEME=1' ; Alternative LED colour scheme: 1 = blue/gold. 0 = green/gold
+  '-DANEOPIX_COLOR_SCHEME=1'  ; Alternative LED colour scheme: 2 = blue/gold. 1 = green/gold
   '-DRGB_INDICATORS=2'        ; 2 = use Adafruit NeoPixel library
 ; The momentary switch on the board is connected to GPIO9
   '-DTRIGGER_GPIO=9'

--- a/environments.ini
+++ b/environments.ini
@@ -1571,8 +1571,9 @@ build_flags =
 custom_description = BLE gateway on the C3
 custom_hardware = AirM2M ESP32C3-CORE
 
+; Espressiv ESP32-C3-DevKitC-02
 [env:esp32c3-dev-c2-ble]
-platform = espressif32@6.1.0  ; override
+platform = ${com.esp32_platform}
 board = esp32-c3-devkitm-1
 board_build.partitions = min_spiffs.csv
 lib_deps =

--- a/environments.ini
+++ b/environments.ini
@@ -1625,6 +1625,7 @@ build_flags =
   '-DANEOPIX_IND_DATA_GPIO=7'
   '-DANEOPIX_IND_NUM_LEDS=1'
  ; '-DANEOPIX_BRIGHTNESS=10'  ; 0 - 255, default 20
+ ; '-DANEOPIX_COLOR_SCHEME=1' ; Alternative LED colour scheme: 1 = blue/gold. 0 = green/gold
   '-DRGB_INDICATORS=2'        ; 2 = use Adafruit NeoPixel library
 ; The momentary switch on the board is connected to GPIO9
   '-DTRIGGER_GPIO=9'

--- a/environments.ini
+++ b/environments.ini
@@ -1571,6 +1571,37 @@ build_flags =
 custom_description = BLE gateway on the C3
 custom_hardware = AirM2M ESP32C3-CORE
 
+[env:esp32c3-dev-c2-ble]
+platform = espressif32@6.1.0  ; override
+board = esp32-c3-devkitm-1
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.ble}
+  ${libraries.decoder}
+; 07 Mar 2023: usage FastLED results in nearly immediate reboots
+; therefore the Adafruit NeoPixel library is used for the RGB LED
+  adafruit/Adafruit NeoPixel@^1.11.0
+build_flags =
+  ${com-esp.build_flags}
+  '-DZgatewayBT="BT"'
+  '-DANEOPIX_IND_DATA_GPIO=8'
+  '-DANEOPIX_IND_NUM_LEDS=1'
+  '-DRGB_INDICATORS=2'
+  '-DNO_INT_TEMP_READING=true' ; No internal temperature reading on ESP32 C3 or S3
+  '-DTRIGGER_GPIO=7'
+  '-DGateway_Name="OpenMQTTGateway_ESP32C3_DKC02"'
+custom_description = BLE gateway on Espressiv ESP32-C3-DevKitC-02
+
+[env:esp32c3-dev-c2-ble-no-serial]
+extends = env:esp32c3-dev-c02-ble
+build_flags =
+  ${env:esp32c3-dev-c02-ble.build_flags}
+  '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; ommit logging for increased stability
+  '-DWM_DEBUG_LEVEL=0'
+custom_description = BLE gateway on Espressiv ESP32-C3-DevKitC-02 without logging
+
 ; Wemos Lolin C3 mini v2.1.0
 [env:lolin_c3_mini]
 platform = ${com.esp32_platform} ; standard is now @6.1.x, should not have `assert rwble.c 261` error anymore

--- a/environments.ini
+++ b/environments.ini
@@ -1583,7 +1583,7 @@ lib_deps =
   ${libraries.decoder}
 ; 07 Mar 2023: usage FastLED results in nearly immediate reboots
 ; therefore the Adafruit NeoPixel library is used for the RGB LED
-  adafruit/Adafruit NeoPixel@^1.11.0
+  ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
@@ -1618,7 +1618,7 @@ lib_deps =
   ${libraries.decoder}
 ; 07 Mar 2023: usage FastLED results in nearly immediate reboots
 ; therefore the Adafruit NeoPixel library is used for the RGB LED
-  adafruit/Adafruit NeoPixel@^1.11.0
+  ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'

--- a/environments.ini
+++ b/environments.ini
@@ -73,6 +73,7 @@ lib_deps =
   ${libraries.tsl2561}
   ${libraries.ina226}
   ${libraries.fastled}
+  ${libraries.adafruit_neopixel}
   ${libraries.onewire}
   ${libraries.dallastemperature}
   ${libraries.rfWeatherStation}
@@ -584,7 +585,7 @@ lib_deps =
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.irremoteesp}
-  ${libraries.fastled}
+  ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
@@ -592,9 +593,8 @@ build_flags =
   '-DTRIGGER_GPIO=39'
   '-DSLEEP_BUTTON=39'
   '-DIR_EMITTER_GPIO=12'
-  '-DFASTLED_IND_DATA_GPIO=27,GRB'
-  '-DFASTLED_IND_TYPE=WS2812'
-  '-DFASTLED_IND_NUM_LEDS=25'
+  '-DANEOPIX_IND_DATA_GPIO=27'
+  '-DANEOPIX_IND_NUM_LEDS=25'
   '-DRGB_INDICATORS=true'
   '-DGateway_Name="OpenMQTTGateway_ATOM_M"'
 board_upload.speed = 1500000
@@ -611,7 +611,7 @@ lib_deps =
   ${libraries.ble}
   ${libraries.decoder}
   ${libraries.irremoteesp}
-  ${libraries.fastled}
+  ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
@@ -619,9 +619,8 @@ build_flags =
   '-DTRIGGER_GPIO=39'
   '-DSLEEP_BUTTON=39'
   '-DIR_EMITTER_GPIO=12'
-  '-DFASTLED_IND_DATA_GPIO=27,GRB'
-  '-DFASTLED_IND_TYPE=WS2812'
-  '-DFASTLED_IND_NUM_LEDS=1'
+  '-DANEOPIX_IND_DATA_GPIO=27'
+  '-DANEOPIX_IND_NUM_LEDS=1'
   '-DRGB_INDICATORS=true'
   '-DGateway_Name="OpenMQTTGateway_ATOM_L"'
 board_upload.speed = 1500000
@@ -895,16 +894,16 @@ lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.ble}
-  ${libraries.fastled}
+;  ${libraries.fastled}
   ${libraries.decoder}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
   '-DGateway_Name="OpenMQTTGateway_ESP32_TINYPICO_BLE"'
-  '-DRGB_LED_POWER=13'
-  '-DFASTLED_IND_DATA_GPIO=2,12,RGB'
-  '-DFASTLED_IND_TYPE=APA102'
-  '-DFASTLED_IND_NUM_LEDS=1'
+;  '-DRGB_LED_POWER=13'
+;  '-DFASTLED_IND_DATA_GPIO=2,12,RGB'
+;  '-DFASTLED_IND_TYPE=APA102'
+;  '-DFASTLED_IND_NUM_LEDS=1'
 board_build.flash_mode = dio
 custom_description = BLE gateway
 custom_hardware = ESP32 TinyPICO
@@ -1519,13 +1518,12 @@ lib_deps =
   ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
-  ${libraries.fastled}
+  ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-  '-DFASTLED_IND_DATA_GPIO=48'
-  '-DFASTLED_IND_TYPE=NEOPIXEL'
-  '-DFASTLED_IND_NUM_LEDS=1'
+  '-DANEOPIX_IND_DATA_GPIO=48'
+  '-DANEOPIX_IND_NUM_LEDS=1'
   '-DRGB_INDICATORS=true'
   '-DNO_INT_TEMP_READING=true' ; Internal temperature reading not building on ESP32 C3 or S3
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
@@ -1540,13 +1538,12 @@ lib_deps =
   ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
-  ${libraries.fastled}
+  ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
   '-DZgatewayBT="BT"'
-  '-DFASTLED_IND_DATA_GPIO=8'
-  '-DFASTLED_IND_TYPE=NEOPIXEL'
-  '-DFASTLED_IND_NUM_LEDS=1'
+  '-DANEOPIX_IND_DATA_GPIO=8'
+  '-DANEOPIX_IND_NUM_LEDS=1'
   '-DRGB_INDICATORS=true'
   '-DNO_INT_TEMP_READING=true' ; Internal temperature reading not building on ESP32 C3 or S3
   '-DGateway_Name="OpenMQTTGateway_ESP32_BLE"'
@@ -1581,8 +1578,6 @@ lib_deps =
   ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
-; 07 Mar 2023: usage FastLED results in nearly immediate reboots
-; therefore the Adafruit NeoPixel library is used for the RGB LED
   ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
@@ -1591,7 +1586,7 @@ build_flags =
   '-DANEOPIX_IND_NUM_LEDS=1'
  ; '-DANEOPIX_BRIGHTNESS=10'   ; 0 - 255, default 20
   '-DANEOPIX_COLOR_SCHEME=2'   ; blue based signalling colors
-  '-DRGB_INDICATORS=2'         ; 2 = use Adafruit NeoPixel library
+  '-DRGB_INDICATORS=true'
   '-DNO_INT_TEMP_READING=true' ; No internal temperature reading on ESP32 C3 or S3
   '-DTRIGGER_GPIO=7'
   '-DGateway_Name="OpenMQTTGateway_ESP32C3_DKC02"'
@@ -1616,8 +1611,6 @@ lib_deps =
   ${libraries.wifimanager32}
   ${libraries.ble}
   ${libraries.decoder}
-; 07 Mar 2023: usage FastLED results in nearly immediate reboots
-; therefore the Adafruit NeoPixel library is used for the RGB LED
   ${libraries.adafruit_neopixel}
 build_flags =
   ${com-esp.build_flags}
@@ -1626,7 +1619,7 @@ build_flags =
   '-DANEOPIX_IND_NUM_LEDS=1'
  ; '-DANEOPIX_BRIGHTNESS=10'  ; 0 - 255, default 20
   '-DANEOPIX_COLOR_SCHEME=1'  ; Alternative LED colour scheme: 2 = blue/gold. 1 = green/gold
-  '-DRGB_INDICATORS=2'        ; 2 = use Adafruit NeoPixel library
+  '-DRGB_INDICATORS=true'
 ; The momentary switch on the board is connected to GPIO9
   '-DTRIGGER_GPIO=9'
   '-DNO_INT_TEMP_READING=true' ; No internal temperature on ESP32 C3 or S3
@@ -1657,7 +1650,7 @@ lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.ble}
-  ${libraries.fastled}
+  ${libraries.adafruit_neopixel}
   ${libraries.decoder}
 build_flags =
   ${com-esp.build_flags}
@@ -1666,13 +1659,12 @@ build_flags =
   '-DLED_SEND_RECEIVE_ON=0'
   '-DpubBLEServiceUUID=true'
   '-DGateway_Name="OpenMQTTGateway_THINGPULSE_BLE"'
-  '-DFASTLED_IND_DATA_GPIO=32,GRB'
-  '-DFASTLED_IND_TYPE=WS2812'
-  '-DFASTLED_IND_NUM_LEDS=4'
-  '-DFASTLED_INFO_LED=0'
-  '-DFASTLED_SEND_RECEIVCE_LED=1'
-  '-DFASTLED_ERROR_LED=2'
-  '-DFASTLED_BRIGHTNESS=255'
+  '-DANEOPIX_IND_DATA_GPIO=32'
+  '-DANEOPIX_IND_NUM_LEDS=4'
+  '-DANEOPIX_INFO_LED=0'
+  '-DANEOPIX_SEND_RECEIVCE_LED=1'
+  '-DANEOPIX_ERROR_LED=2'
+  '-DANEOPIX_BRIGHTNESS=255'
   '-DRGB_INDICATORS=true'
 ;  '-DsimplePublishing=true'
 custom_description = BLE Gateway using Wifi
@@ -1686,7 +1678,7 @@ lib_deps =
   ${com-esp.lib_deps}
   ${libraries.wifimanager32}
   ${libraries.ble}
-  ${libraries.fastled}
+  ${libraries.adafruit_neopixel}
   ${libraries.decoder}
 build_flags =
   ${com-esp.build_flags}
@@ -1702,13 +1694,12 @@ build_flags =
   '-DETH_PHY_MDC=23'
   '-DETH_PHY_MDIO=18'
   '-DETH_CLK_MODE=ETH_CLOCK_GPIO16_OUT'
-  '-DFASTLED_IND_DATA_GPIO=32,GRB'
-  '-DFASTLED_IND_TYPE=WS2812'
-  '-DFASTLED_IND_NUM_LEDS=4'
-  '-DFASTLED_INFO_LED=0'
-  '-DFASTLED_SEND_RECEIVCE_LED=1'
-  '-DFASTLED_ERROR_LED=2'
-  '-DFASTLED_BRIGHTNESS=255'
+  '-DANEOPIX_IND_DATA_GPIO=32'
+  '-DANEOPIX_IND_NUM_LEDS=4'
+  '-DANEOPIX_INFO_LED=0'
+  '-DANEOPIX_SEND_RECEIVCE_LED=1'
+  '-DANEOPIX_ERROR_LED=2'
+  '-DANEOPIX_BRIGHTNESS=255'
   '-DRGB_INDICATORS=true'
 ;  '-DsimplePublishing=true'
 custom_description = BLE Gateway using ethernet, requires PIO configuration

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -511,6 +511,9 @@ Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_
 #  ifndef ANEOPIX_BRIGHTNESS
 #    define ANEOPIX_BRIGHTNESS 20 // Set Default RGB brightness to approx 10% (0-255 scale)
 #  endif
+#  ifndef ANEOPIX_COLOR_SCHEME    // allow for different color combinations
+#    define ANEOPIX_COLOR_SCHEME 0
+#  endif
 // Allow to set LED used (for example thingpulse gateway has 4 we use them independently)
 #  ifndef ANEOPIX_INFO_LED
 #    define ANEOPIX_INFO_LED 0 // First Led
@@ -521,36 +524,61 @@ Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_
 #  ifndef ANEOPIX_ERROR_LED
 #    define ANEOPIX_ERROR_LED 0 // First Led
 #  endif
+#  ifndef ANEOPIX_BOOT_LED
+#    define ANEOPIX_BOOT_LED 0 // First Led
+#  endif
 // no ANEOPIX_CRITICAL_LED and FASTLED_IND_DATA_GPIO2 with Adafruit_NeoPixel
 // preprocessor calculates color values
-#  define ANEOPIX_RED ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 16          // dimmed /4
+#  define ANEOPIX_HOTPINK (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) |  \
+                            (((0x69 * ANEOPIX_BRIGHTNESS) >> 8) << 8) | \
+                            (0xB4 * ANEOPIX_BRIGHTNESS) >> 8
+#  define ANEOPIX_RED_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 16      // dimmed /4
 #  define ANEOPIX_GOLD (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) | \
                          (((0xD7 * ANEOPIX_BRIGHTNESS) >> 8) << 8)
-#  define ANEOPIX_GREEN ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8
-#  define ANEOPIX_BLUE (0x3F * ANEOPIX_BRIGHTNESS) >> 8                 // dimmed /4
+#  define ANEOPIX_GREEN ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8         // bright
+#  define ANEOPIX_GREEN_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 8     // dimmed /4
+#  define ANEOPIX_AQUA (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8) | \
+                        (0xFF * ANEOPIX_BRIGHTNESS) >> 8
+#  define ANEOPIX_BLUE_DIM (0x3F * ANEOPIX_BRIGHTNESS) >> 8             // dimmed /4
 #  define ANEOPIX_BLACK 0
+// signalling color combinations tested for good visibility
+#  if ANEOPIX_COLOR_SCHEME == 0
+#    define ANEOPIX_ERROR ANEOPIX_RED_DIM
+#    define ANEOPIX_SENDRECEIVE ANEOPIX_GREEN   // bright green = sending
+#    define ANEOPIX_INFO ANEOPIX_GREEN_DIM      // dimmed green = info
+#    define ANEOPIX_OFF ANEOPIX_BLACK
+#    define ANEOPIX_BOOT ANEOPIX_HOTPINK
+#  else
+#    define ANEOPIX_ERROR ANEOPIX_RED_DIM
+#    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD    // bright gold = sending
+#    define ANEOPIX_INFO ANEOPIX_BLUE_DIM       // dimmed blue = info
+#    define ANEOPIX_OFF ANEOPIX_BLACK
+#    define ANEOPIX_BOOT ANEOPIX_AQUA
+#  endif
 
-#  define SetupIndicators()                      \
-    pinMode(RGB_LED_POWER, OUTPUT);              \
-    digitalWrite(RGB_LED_POWER, HIGH);           \
-    leds.begin();
-#  define ErrorIndicatorON()                               \
-    leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_RED);    \
+#  define SetupIndicators()                             \
+    pinMode(RGB_LED_POWER, OUTPUT);                     \
+    digitalWrite(RGB_LED_POWER, HIGH);                  \
+    leds.begin();                                       \
+    leds.setPixelColor(ANEOPIX_BOOT_LED, ANEOPIX_BOOT); \
     leds.show();
-#  define ErrorIndicatorOFF()                              \
-    leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_BLACK);  \
+#  define ErrorIndicatorON()                              \
+    leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_ERROR); \
     leds.show();
-#  define SendReceiveIndicatorON()                                \
-    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_GOLD);  \
+#  define ErrorIndicatorOFF()                           \
+    leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_OFF); \
     leds.show();
-#  define SendReceiveIndicatorOFF()                               \
-    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_BLACK); \
+#  define SendReceiveIndicatorON()                                      \
+    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_SENDRECEIVE); \
     leds.show();
-#  define InfoIndicatorON()                              \
-    leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_BLUE); \
+#  define SendReceiveIndicatorOFF()                             \
+    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_OFF); \
     leds.show();
-#  define InfoIndicatorOFF()                             \
-    leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_BLACK); \
+#  define InfoIndicatorON()                             \
+    leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_INFO); \
+    leds.show();
+#  define InfoIndicatorOFF()                           \
+    leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_OFF); \
     leds.show();
 #  define SetupIndicatorInfo()
 #  define SetupIndicatorSendReceive()

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -521,8 +521,8 @@ Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_LE
 #  ifndef ANEOPIX_INFO_LED
 #    define ANEOPIX_INFO_LED 0 // First Led
 #  endif
-#  ifndef ANEOPIX_SEND_RECEIVCE_LED
-#    define ANEOPIX_SEND_RECEIVCE_LED 0 // First Led
+#  ifndef ANEOPIX_SEND_RECEIVE_LED
+#    define ANEOPIX_SEND_RECEIVE_LED 0 // First Led
 #  endif
 #  ifndef ANEOPIX_ERROR_LED
 #    define ANEOPIX_ERROR_LED 0 // First Led
@@ -593,11 +593,11 @@ Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_LE
 #  define ErrorIndicatorOFF()                           \
     leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_OFF); \
     leds.show();
-#  define SendReceiveIndicatorON()                                      \
-    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_SENDRECEIVE); \
+#  define SendReceiveIndicatorON()                                     \
+    leds.setPixelColor(ANEOPIX_SEND_RECEIVE_LED, ANEOPIX_SENDRECEIVE); \
     leds.show();
-#  define SendReceiveIndicatorOFF()                             \
-    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_OFF); \
+#  define SendReceiveIndicatorOFF()                            \
+    leds.setPixelColor(ANEOPIX_SEND_RECEIVE_LED, ANEOPIX_OFF); \
     leds.show();
 #  define InfoIndicatorON()                             \
     leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_INFO); \

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -544,10 +544,10 @@ Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_
 // signalling color combinations tested for good visibility
 #  if ANEOPIX_COLOR_SCHEME == 0
 #    define ANEOPIX_ERROR ANEOPIX_RED_DIM
-#    define ANEOPIX_SENDRECEIVE ANEOPIX_GREEN   // bright green = sending
+#    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD    // bright gold  = sending
 #    define ANEOPIX_INFO ANEOPIX_GREEN_DIM      // dimmed green = info
 #    define ANEOPIX_OFF ANEOPIX_BLACK
-#    define ANEOPIX_BOOT ANEOPIX_HOTPINK
+#    define ANEOPIX_BOOT ANEOPIX_AQUA
 #  else
 #    define ANEOPIX_ERROR ANEOPIX_RED_DIM
 #    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD    // bright gold = sending

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -498,10 +498,10 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #  define PowerIndicatorOFF()   // Not used
 #  define SetupIndicators()     // Not used
 // Management of Errors, reception/emission and informations indicators with RGB LED
-#elif RGB_INDICATORS == 2   // using Adafruit_NeoPixel
+#elif RGB_INDICATORS == 2 // using Adafruit_NeoPixel
 #  include <Adafruit_NeoPixel.h>
-#  ifndef ANEOPIX_LED_TYPE                           // needs library constants
-#    define ANEOPIX_LED_TYPE NEO_GRB + NEO_KHZ800    // ws2812 and alike
+#  ifndef ANEOPIX_LED_TYPE // needs library constants
+#    define ANEOPIX_LED_TYPE NEO_GRB + NEO_KHZ800 // ws2812 and alike
 #  endif
 Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_TYPE);
 #  ifdef ANEOPIX_IND_DATA_GPIO2 // Only used for Critical Indicator
@@ -515,7 +515,7 @@ Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_LE
 #  ifndef ANEOPIX_BRIGHTNESS
 #    define ANEOPIX_BRIGHTNESS 20 // Set Default RGB brightness to approx 10% (0-255 scale)
 #  endif
-#  ifndef ANEOPIX_COLOR_SCHEME    // allow for different color combinations
+#  ifndef ANEOPIX_COLOR_SCHEME // allow for different color combinations
 #    define ANEOPIX_COLOR_SCHEME 0
 #  endif
 // Allow to set LED used (for example thingpulse gateway has 4 we use them independently)
@@ -532,46 +532,46 @@ Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_LE
 #    define ANEOPIX_CRITICAL_LED 0 // First Led
 #  endif
 // preprocessor calculates color values
-#  define ANEOPIX_RED ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16
-#  define ANEOPIX_RED_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 16      // dimmed /4
-#  define ANEOPIX_ORANGE (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) | \
-                         (((0xA5 * ANEOPIX_BRIGHTNESS) >> 8) << 8)
+#  define ANEOPIX_RED     ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16
+#  define ANEOPIX_RED_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 16 // dimmed /4
+#  define ANEOPIX_ORANGE  (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) | \
+                             (((0xA5 * ANEOPIX_BRIGHTNESS) >> 8) << 8)
 #  define ANEOPIX_GOLD (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) | \
-                         (((0xD7 * ANEOPIX_BRIGHTNESS) >> 8) << 8)
-#  define ANEOPIX_GREEN ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8
-#  define ANEOPIX_GREEN_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 8     // dimmed /4
-#  define ANEOPIX_AQUA (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8) | \
-                        (0xFF * ANEOPIX_BRIGHTNESS) >> 8
-#  define ANEOPIX_BLUE (0xFF * ANEOPIX_BRIGHTNESS) >> 8
-#  define ANEOPIX_BLUE_DIM (0x3F * ANEOPIX_BRIGHTNESS) >> 8             // dimmed /4
-#  define ANEOPIX_BLACK 0
+                           (((0xD7 * ANEOPIX_BRIGHTNESS) >> 8) << 8)
+#  define ANEOPIX_GREEN     ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8
+#  define ANEOPIX_GREEN_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 8 // dimmed /4
+#  define ANEOPIX_AQUA      (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8) | \
+                           (0xFF * ANEOPIX_BRIGHTNESS) >> 8
+#  define ANEOPIX_BLUE     (0xFF * ANEOPIX_BRIGHTNESS) >> 8
+#  define ANEOPIX_BLUE_DIM (0x3F * ANEOPIX_BRIGHTNESS) >> 8 // dimmed /4
+#  define ANEOPIX_BLACK    0
 
 #  if ANEOPIX_COLOR_SCHEME == 0
 // original color combination remains default
-#    define ANEOPIX_INFO ANEOPIX_GREEN
-#    define ANEOPIX_ERROR ANEOPIX_ORANGE
+#    define ANEOPIX_INFO        ANEOPIX_GREEN
+#    define ANEOPIX_ERROR       ANEOPIX_ORANGE
 #    define ANEOPIX_SENDRECEIVE ANEOPIX_BLUE
-#    define ANEOPIX_CRITICAL ANEOPIX_RED        // second led
-#    define ANEOPIX_POWER ANEOPIX_GREEN         // second led
-#    define ANEOPIX_BOOT ANEOPIX_BLACK          // unused
-#    define ANEOPIX_OFF ANEOPIX_BLACK
+#    define ANEOPIX_CRITICAL    ANEOPIX_RED // second led
+#    define ANEOPIX_POWER       ANEOPIX_GREEN // second led
+#    define ANEOPIX_BOOT        ANEOPIX_BLACK // unused
+#    define ANEOPIX_OFF         ANEOPIX_BLACK
 // color combinations tested for good visibility of onboard leds
 #  elif ANEOPIX_COLOR_SCHEME == 1
-#    define ANEOPIX_INFO ANEOPIX_GREEN_DIM      // dimmed green info background
-#    define ANEOPIX_ERROR ANEOPIX_RED_DIM
-#    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD    // bright gold  = sending
-#    define ANEOPIX_CRITICAL ANEOPIX_BLACK      // unused
-#    define ANEOPIX_POWER ANEOPIX_BLACK         // unused
-#    define ANEOPIX_BOOT ANEOPIX_AQUA
-#    define ANEOPIX_OFF ANEOPIX_BLACK
+#    define ANEOPIX_INFO        ANEOPIX_GREEN_DIM // dimmed green info background
+#    define ANEOPIX_ERROR       ANEOPIX_RED_DIM
+#    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD // bright gold  = sending
+#    define ANEOPIX_CRITICAL    ANEOPIX_BLACK // unused
+#    define ANEOPIX_POWER       ANEOPIX_BLACK // unused
+#    define ANEOPIX_BOOT        ANEOPIX_AQUA
+#    define ANEOPIX_OFF         ANEOPIX_BLACK
 #  else
-#    define ANEOPIX_INFO ANEOPIX_BLUE_DIM       // dimmed blue info background
-#    define ANEOPIX_ERROR ANEOPIX_RED_DIM
-#    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD    // bright gold  = sending
-#    define ANEOPIX_CRITICAL ANEOPIX_BLACK      // unused
-#    define ANEOPIX_POWER ANEOPIX_BLACK         // unused
-#    define ANEOPIX_BOOT ANEOPIX_AQUA
-#    define ANEOPIX_OFF ANEOPIX_BLACK
+#    define ANEOPIX_INFO        ANEOPIX_BLUE_DIM // dimmed blue info background
+#    define ANEOPIX_ERROR       ANEOPIX_RED_DIM
+#    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD // bright gold  = sending
+#    define ANEOPIX_CRITICAL    ANEOPIX_BLACK // unused
+#    define ANEOPIX_POWER       ANEOPIX_BLACK // unused
+#    define ANEOPIX_BOOT        ANEOPIX_AQUA
+#    define ANEOPIX_OFF         ANEOPIX_BLACK
 #  endif
 #  ifndef ANEOPIX_IND_DATA_GPIO2
 // during boot the RGB LED is on to signal also reboots
@@ -609,20 +609,20 @@ Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_LE
 #  ifdef ANEOPIX_IND_DATA_GPIO2 // Used for relay power indicator
 // For the critical ON indicator there is no method to turn it off, the only way is to unplug the device
 // This enable to have persistence of the indicator to inform the user
-#   define CriticalIndicatorON()                              \
+#    define CriticalIndicatorON()                             \
       leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_CRITICAL); \
       leds.show();
-#   define PowerIndicatorON()                              \
+#    define PowerIndicatorON()                             \
       leds2.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_INFO); \
       leds2.show();
-#   define PowerIndicatorOFF()                            \
+#    define PowerIndicatorOFF()                           \
       leds2.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_OFF); \
       leds2.show();
 #  endif
 #  define SetupIndicatorInfo()
 #  define SetupIndicatorSendReceive()
 #  define SetupIndicatorError()
-#else   // FastLED remains standard for RGB_INDICATORS
+#else // FastLED remains standard for RGB_INDICATORS
 #  if !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32C3) //I2S not available yet with Fastled on S3 and C3
 #    define FASTLED_ESP32_I2S // To avoid ESP32 instabilities https://github.com/FastLED/FastLED/issues/1438
 #  endif

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -505,7 +505,7 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_IND_TYPE);
 #  ifdef ANEOPIX_IND_DATA_GPIO2 // Only used for Critical Indicator
 // assume the same LED type
-Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_LED_TYPE);
+Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_IND_TYPE);
 #  endif
 
 #  ifndef RGB_LED_POWER

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -529,33 +529,27 @@ Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_
 #  endif
 // no ANEOPIX_CRITICAL_LED and FASTLED_IND_DATA_GPIO2 with Adafruit_NeoPixel
 // preprocessor calculates color values
-#  define ANEOPIX_HOTPINK (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) |  \
-                            (((0x69 * ANEOPIX_BRIGHTNESS) >> 8) << 8) | \
-                            (0xB4 * ANEOPIX_BRIGHTNESS) >> 8
 #  define ANEOPIX_RED_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 16      // dimmed /4
 #  define ANEOPIX_GOLD (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) | \
                          (((0xD7 * ANEOPIX_BRIGHTNESS) >> 8) << 8)
-#  define ANEOPIX_GREEN ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8         // bright
 #  define ANEOPIX_GREEN_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 8     // dimmed /4
 #  define ANEOPIX_AQUA (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8) | \
                         (0xFF * ANEOPIX_BRIGHTNESS) >> 8
 #  define ANEOPIX_BLUE_DIM (0x3F * ANEOPIX_BRIGHTNESS) >> 8             // dimmed /4
 #  define ANEOPIX_BLACK 0
 // signalling color combinations tested for good visibility
-#  if ANEOPIX_COLOR_SCHEME == 0
+// colors common to the schemes
 #    define ANEOPIX_ERROR ANEOPIX_RED_DIM
 #    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD    // bright gold  = sending
+#    define ANEOPIX_OFF ANEOPIX_BLACK
+#    define ANEOPIX_BOOT ANEOPIX_AQUA
+// color differences
+#  if ANEOPIX_COLOR_SCHEME == 0
 #    define ANEOPIX_INFO ANEOPIX_GREEN_DIM      // dimmed green = info
-#    define ANEOPIX_OFF ANEOPIX_BLACK
-#    define ANEOPIX_BOOT ANEOPIX_AQUA
 #  else
-#    define ANEOPIX_ERROR ANEOPIX_RED_DIM
-#    define ANEOPIX_SENDRECEIVE ANEOPIX_GOLD    // bright gold = sending
 #    define ANEOPIX_INFO ANEOPIX_BLUE_DIM       // dimmed blue = info
-#    define ANEOPIX_OFF ANEOPIX_BLACK
-#    define ANEOPIX_BOOT ANEOPIX_AQUA
 #  endif
-
+// during boot the RGB LED is on to signal also reboots
 #  define SetupIndicators()                             \
     pinMode(RGB_LED_POWER, OUTPUT);                     \
     digitalWrite(RGB_LED_POWER, HIGH);                  \

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -524,9 +524,6 @@ Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_
 #  ifndef ANEOPIX_ERROR_LED
 #    define ANEOPIX_ERROR_LED 0 // First Led
 #  endif
-#  ifndef ANEOPIX_BOOT_LED
-#    define ANEOPIX_BOOT_LED 0 // First Led
-#  endif
 // no ANEOPIX_CRITICAL_LED and FASTLED_IND_DATA_GPIO2 with Adafruit_NeoPixel
 // preprocessor calculates color values
 #  define ANEOPIX_RED_DIM ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 16      // dimmed /4
@@ -554,7 +551,7 @@ Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_
     pinMode(RGB_LED_POWER, OUTPUT);                     \
     digitalWrite(RGB_LED_POWER, HIGH);                  \
     leds.begin();                                       \
-    leds.setPixelColor(ANEOPIX_BOOT_LED, ANEOPIX_BOOT); \
+    leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_BOOT); \
     leds.show();
 #  define ErrorIndicatorON()                              \
     leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_ERROR); \

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -497,7 +497,65 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 #  define PowerIndicatorON()    // Not used
 #  define PowerIndicatorOFF()   // Not used
 #  define SetupIndicators()     // Not used
-#else // Management of Errors, reception/emission and informations indicators with RGB LED
+// Management of Errors, reception/emission and informations indicators with RGB LED
+#elif RGB_INDICATORS == 2   // using Adafruit_NeoPixel
+#  include <Adafruit_NeoPixel.h>
+#  ifndef ANEOPIX_LED_TYPE                           // needs library constants
+#    define ANEOPIX_LED_TYPE NEO_GRB + NEO_KHZ800    // ws2812 and alike
+#  endif
+Adafruit_NeoPixel leds(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO, ANEOPIX_LED_TYPE);
+
+#  ifndef RGB_LED_POWER
+#    define RGB_LED_POWER -1 // If the RGB Led is linked to GPIO pin for power define it here
+#  endif
+#  ifndef ANEOPIX_BRIGHTNESS
+#    define ANEOPIX_BRIGHTNESS 20 // Set Default RGB brightness to approx 10% (0-255 scale)
+#  endif
+// Allow to set LED used (for example thingpulse gateway has 4 we use them independently)
+#  ifndef ANEOPIX_INFO_LED
+#    define ANEOPIX_INFO_LED 0 // First Led
+#  endif
+#  ifndef ANEOPIX_SEND_RECEIVCE_LED
+#    define ANEOPIX_SEND_RECEIVCE_LED 0 // First Led
+#  endif
+#  ifndef ANEOPIX_ERROR_LED
+#    define ANEOPIX_ERROR_LED 0 // First Led
+#  endif
+// no ANEOPIX_CRITICAL_LED and FASTLED_IND_DATA_GPIO2 with Adafruit_NeoPixel
+// preprocessor calculates color values
+#  define ANEOPIX_RED ((0x3F * ANEOPIX_BRIGHTNESS) >> 8) << 16          // dimmed /4
+#  define ANEOPIX_GOLD (((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 16) | \
+                         (((0xD7 * ANEOPIX_BRIGHTNESS) >> 8) << 8)
+#  define ANEOPIX_GREEN ((0xFF * ANEOPIX_BRIGHTNESS) >> 8) << 8
+#  define ANEOPIX_BLUE (0x3F * ANEOPIX_BRIGHTNESS) >> 8                 // dimmed /4
+#  define ANEOPIX_BLACK 0
+
+#  define SetupIndicators()                      \
+    pinMode(RGB_LED_POWER, OUTPUT);              \
+    digitalWrite(RGB_LED_POWER, HIGH);           \
+    leds.begin();
+#  define ErrorIndicatorON()                               \
+    leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_RED);    \
+    leds.show();
+#  define ErrorIndicatorOFF()                              \
+    leds.setPixelColor(ANEOPIX_ERROR_LED, ANEOPIX_BLACK);  \
+    leds.show();
+#  define SendReceiveIndicatorON()                                \
+    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_GOLD);  \
+    leds.show();
+#  define SendReceiveIndicatorOFF()                               \
+    leds.setPixelColor(ANEOPIX_SEND_RECEIVCE_LED, ANEOPIX_BLACK); \
+    leds.show();
+#  define InfoIndicatorON()                              \
+    leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_BLUE); \
+    leds.show();
+#  define InfoIndicatorOFF()                             \
+    leds.setPixelColor(ANEOPIX_INFO_LED, ANEOPIX_BLACK); \
+    leds.show();
+#  define SetupIndicatorInfo()
+#  define SetupIndicatorSendReceive()
+#  define SetupIndicatorError()
+#else   // FastLED remains standard for RGB_INDICATORS
 #  if !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32C3) //I2S not available yet with Fastled on S3 and C3
 #    define FASTLED_ESP32_I2S // To avoid ESP32 instabilities https://github.com/FastLED/FastLED/issues/1438
 #  endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -139,6 +139,7 @@ ethernet = Ethernet
 esp8266_mdns = esp8266_mdns
 wire = Wire
 fastled = fastled/FastLED@3.5.0
+adafruit_neopixel = adafruit/Adafruit NeoPixel@^1.11.0
 onewire = paulstoffregen/OneWire@2.3.7
 dallastemperature = DallasTemperature
 m5stickc = M5StickC@0.2.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -98,6 +98,7 @@ extra_configs =
 ;default_envs = esp32s3-dev-c1-ble
 ;default_envs = esp32c3-dev-m1-ble
 ;default_envs = airm2m_core_esp32c3
+;default_envs = esp32c3-dev-c2-ble
 ;default_envs = lolin_c3_mini
 ;default_envs = thingpulse-espgateway
 ;default_envs = thingpulse-espgateway-ethernet


### PR DESCRIPTION
## Description:  Addition of the Adafruit NeoPixel library to replace FastLED
The Adafruit NeoPixel library is used as a full alternative to FastLED to address RGB LEDs. This solves the problem that FastLED results in nearly immediate reboots of ESP32C3 boards.
The request also includes new [env:esp32c3-dev-c2-ble] environments and a change to [env:lolin_c3_mini] for the boards on which the addition was developed.
coauthor Argafal <dev.omg@argafal.de>
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
