### PR TITLE
[OTA] Fix BLE memory release when not using "latest" version during an OTA update

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -2195,9 +2195,6 @@ void MQTTHttpsFWUpdate(char* topicOri, JsonObject& HttpsFwUpdateData) {
 #  endif
 #  ifdef ESP32
       } else if (strcmp(version, "latest") == 0) {
-#    if defined(ZgatewayBT)
-        stopProcessing();
-#    endif
         systemUrl = RELEASE_LINK + latestVersion + "/" + ENV_NAME + "-firmware.bin";
         url = systemUrl.c_str();
         Log.notice(F("Using system OTA url with latest version %s" CR), url);
@@ -2214,7 +2211,9 @@ void MQTTHttpsFWUpdate(char* topicOri, JsonObject& HttpsFwUpdateData) {
         Log.error(F("Invalid URL" CR));
         return;
       }
-
+#  if defined(ZgatewayBT)
+      stopProcessing();
+#  endif
       Log.warning(F("Starting firmware update" CR));
       SendReceiveIndicatorON();
       ErrorIndicatorON();


### PR DESCRIPTION
## Description:
This will enable reverting back to versions before the `latest` and also retrieve back the capability to point directly to an https binary

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
