### PR TITLE
[RF] Added Pilight RAW packet return support

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -263,6 +263,24 @@ Generate your RF signals by pressing a remote button or other and you will see :
 
 ![](../img/OpenMQTTGateway_Pilight_Digoo-DG-R8S.png)
 
+#### Enabling RAW packet return support
+First, you need to compile a binary with `Pilight_rawEnabled true` uncommented in config_RF.h.
+
+Once the device is online, you can turn on the RAW packet return support with the following MQTT command:
+
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols" -m '{"rawEnabled":true}'`
+
+The returned JSON looks like this:
+`Client (null) received PUBLISH (d0, q0, r0, m0, 'home/OpenMQTTGateway/PilighttoMQTT', ... (176 bytes))
+{"format":"RAW","rawlen":106,"pulsesString":"c:0102010102020202020101010101010102020201020102020202020201010101010101010101010102010102010201020201010203;p:521,944,1924,3845@"}`
+
+The pulseString format is Pilight's native. For those who are not familiar with it:
+c:* are the indexes for the p:* array, which are the different pulse length. (e.g. pulse[0] = 521ms, pulse[1]=944ms..., so c[0], which is a '0' = 521ms pulse, c[1], which is a '1' =944ms pulse etc)
+
+After gathering all the packets you need, simply turn off the RAW packet support via MQTT:
+
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols" -m '{"rawEnabled":false}'`
+
 ### Limit Protocols
 It is possible to limit the protocols that Pilight will respond to, this can help reduce noise from unwanted devices and in some cases disable conflicting protocols.
 
@@ -279,7 +297,7 @@ eg: `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols" -m
 
 #### Reset protocols
 To reset and listen to all protocols -
-`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols -m '{"reset": true}`'
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols -m '{"reset": true}'`
 
 #### Enabled protocols
 To list the enabled protocols on the Serial - 

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -323,7 +323,6 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 //#define ZgatewayIR     "IR"       //ESP8266, Arduino,         Sonoff RF Bridge
 //#define ZgatewayLORA   "LORA"       //ESP8266, Arduino, ESP32
 //#define ZgatewayPilight "Pilight" //ESP8266, Arduino, ESP32
-//#define ZgatewayPilight_rawEnabled true // enables Pilight RAW return - switchable via MQTT
 //#define ZgatewayWeatherStation "WeatherStation" //ESP8266, Arduino, ESP32
 //#define ZgatewayGFSunInverter "GFSunInverter"   //ESP32
 //#define ZgatewayBT     "BT"       //ESP8266, ESP32

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -323,6 +323,7 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 //#define ZgatewayIR     "IR"       //ESP8266, Arduino,         Sonoff RF Bridge
 //#define ZgatewayLORA   "LORA"       //ESP8266, Arduino, ESP32
 //#define ZgatewayPilight "Pilight" //ESP8266, Arduino, ESP32
+//#define ZgatewayPilight_rawEnabled true // enables Pilight RAW return - switchable via MQTT
 //#define ZgatewayWeatherStation "WeatherStation" //ESP8266, Arduino, ESP32
 //#define ZgatewayGFSunInverter "GFSunInverter"   //ESP32
 //#define ZgatewayBT     "BT"       //ESP8266, ESP32

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -36,10 +36,10 @@
 #  include <ESPiLight.h>
 ESPiLight rf(RF_EMITTER_GPIO); // use -1 to disable transmitter
 
-# ifdef ZgatewayPilight_rawEnabled
+#  ifdef ZgatewayPilight_rawEnabled
 // raw output support
 byte pilightRawEnabled = 0;
-# endif
+#  endif
 
 void pilightCallback(const String& protocol, const String& message, int status,
                      size_t repeats, const String& deviceID) {
@@ -83,11 +83,11 @@ void pilightCallback(const String& protocol, const String& message, int status,
   }
 }
 
-# ifdef ZgatewayPilight_rawEnabled
+#  ifdef ZgatewayPilight_rawEnabled
 void pilightRawCallback(const uint16_t* pulses, size_t length) {
   uint16_t pulse;
 
-  if (!pilightRawEnabled ) {
+  if (!pilightRawEnabled) {
     Log.trace(F("Pilight RAW not enabled" CR));
     return;
   }
@@ -99,12 +99,11 @@ void pilightRawCallback(const uint16_t* pulses, size_t length) {
   RFPiLightdata["format"] = "RAW";
   RFPiLightdata["rawlen"] = length;
   RFPiLightdata["pulsesString"] = rf.pulseTrainToString(pulses, length); // c=pulse_array_key;p=pulse_types
-    
-  // length chekc might be a good idea
+
   // publish data
   pub(subjectPilighttoMQTT, RFPiLightdata);
 }
-# endif
+#  endif
 
 void setupPilight() {
 #  ifdef ZradioCC1101 //receiving with CC1101

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -36,6 +36,11 @@
 #  include <ESPiLight.h>
 ESPiLight rf(RF_EMITTER_GPIO); // use -1 to disable transmitter
 
+#ifdef ZgatewayPilight_rawEnabled
+// raw output support
+byte pilightRawEnabled = 0;
+#endif
+
 void pilightCallback(const String& protocol, const String& message, int status,
                      size_t repeats, const String& deviceID) {
   if (status == VALID) {
@@ -77,6 +82,29 @@ void pilightCallback(const String& protocol, const String& message, int status,
     }
   }
 }
+
+#ifdef ZgatewayPilight_rawEnabled
+void pilightRawCallback(const uint16_t* pulses, size_t length) {
+  uint16_t pulse;
+
+  if ( ! pilightRawEnabled ) {
+    Log.trace(F("Pilight RAW not enabled" CR));
+    return;
+  }
+
+  Log.trace(F("Creating RF PiLight buffer" CR));
+  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
+  JsonObject RFPiLightdata = jsonBuffer.to<JsonObject>();
+
+  RFPiLightdata["format"] = "RAW";
+  RFPiLightdata["rawlen"] = length;
+  RFPiLightdata["pulsesString"] = rf.pulseTrainToString(pulses, length); // c=pulse_array_key;p=pulse_types
+    
+  // length chekc might be a good idea
+  // publish data
+  pub(subjectPilighttoMQTT, RFPiLightdata);
+}
+#endif
 
 void setupPilight() {
 #  ifdef ZradioCC1101 //receiving with CC1101
@@ -157,6 +185,16 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       Log.notice(F("PiLight protocols available: %s" CR), rf.availableProtocols().c_str());
       success = true;
     }
+    #ifdef ZgatewayPilight_rawEnabled
+    if (Pilightdata.containsKey("rawEnabled")) {
+      Log.notice(F("Setting PiLight raw output enabled: %s" CR), Pilightdata["rawEnabled"]);
+      pilightRawEnabled = (byte)Pilightdata["rawEnabled"];
+      disablePilightReceive();
+      delay(1);
+      enablePilightReceive();
+      success = true;
+    }
+    #endif
 
     if (success) {
       pub(subjectGTWPilighttoMQTT, Pilightdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
@@ -297,6 +335,11 @@ extern void enablePilightReceive() {
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
   rf.setCallback(pilightCallback);
+  #ifdef ZgatewayPilight_rawEnabled
+  if ( pilightRawEnabled) {
+    rf.setPulseTrainCallBack(pilightRawCallback);
+  }
+  #endif
   rf.initReceiver(RF_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
   rf.enableReceiver();

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -184,7 +184,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       Log.notice(F("PiLight protocols available: %s" CR), rf.availableProtocols().c_str());
       success = true;
     }
-    # ifdef ZgatewayPilight_rawEnabled
+#  ifdef ZgatewayPilight_rawEnabled
     if (Pilightdata.containsKey("rawEnabled")) {
       Log.notice(F("Setting PiLight raw output enabled: %s" CR), Pilightdata["rawEnabled"]);
       pilightRawEnabled = (byte)Pilightdata["rawEnabled"];
@@ -193,7 +193,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       enablePilightReceive();
       success = true;
     }
-    # endif
+#  endif
 
     if (success) {
       pub(subjectGTWPilighttoMQTT, Pilightdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
@@ -334,11 +334,11 @@ extern void enablePilightReceive() {
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
   rf.setCallback(pilightCallback);
-  # ifdef ZgatewayPilight_rawEnabled
+#  ifdef ZgatewayPilight_rawEnabled
   if (pilightRawEnabled) {
     rf.setPulseTrainCallBack(pilightRawCallback);
   }
-  # endif
+#  endif
   rf.initReceiver(RF_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
   rf.enableReceiver();

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -36,9 +36,9 @@
 #  include <ESPiLight.h>
 ESPiLight rf(RF_EMITTER_GPIO); // use -1 to disable transmitter
 
-#  ifdef ZgatewayPilight_rawEnabled
+#  ifdef Pilight_rawEnabled
 // raw output support
-byte pilightRawEnabled = 0;
+bool pilightRawEnabled = 0;
 #  endif
 
 void pilightCallback(const String& protocol, const String& message, int status,
@@ -83,7 +83,7 @@ void pilightCallback(const String& protocol, const String& message, int status,
   }
 }
 
-#  ifdef ZgatewayPilight_rawEnabled
+#  ifdef Pilight_rawEnabled
 void pilightRawCallback(const uint16_t* pulses, size_t length) {
   uint16_t pulse;
 
@@ -184,7 +184,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       Log.notice(F("PiLight protocols available: %s" CR), rf.availableProtocols().c_str());
       success = true;
     }
-#  ifdef ZgatewayPilight_rawEnabled
+#  ifdef Pilight_rawEnabled
     if (Pilightdata.containsKey("rawEnabled")) {
       Log.notice(F("Setting PiLight raw output enabled: %s" CR), Pilightdata["rawEnabled"]);
       pilightRawEnabled = (byte)Pilightdata["rawEnabled"];
@@ -334,7 +334,7 @@ extern void enablePilightReceive() {
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
   rf.setCallback(pilightCallback);
-#  ifdef ZgatewayPilight_rawEnabled
+#  ifdef Pilight_rawEnabled
   if (pilightRawEnabled) {
     rf.setPulseTrainCallBack(pilightRawCallback);
   }

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -187,7 +187,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
 #  ifdef Pilight_rawEnabled
     if (Pilightdata.containsKey("rawEnabled")) {
       Log.notice(F("Setting PiLight raw output enabled: %s" CR), Pilightdata["rawEnabled"]);
-      pilightRawEnabled = (byte)Pilightdata["rawEnabled"];
+      pilightRawEnabled = (bool)Pilightdata["rawEnabled"];
       disablePilightReceive();
       delay(1);
       enablePilightReceive();

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -36,10 +36,10 @@
 #  include <ESPiLight.h>
 ESPiLight rf(RF_EMITTER_GPIO); // use -1 to disable transmitter
 
-#ifdef ZgatewayPilight_rawEnabled
+# ifdef ZgatewayPilight_rawEnabled
 // raw output support
 byte pilightRawEnabled = 0;
-#endif
+# endif
 
 void pilightCallback(const String& protocol, const String& message, int status,
                      size_t repeats, const String& deviceID) {
@@ -83,11 +83,11 @@ void pilightCallback(const String& protocol, const String& message, int status,
   }
 }
 
-#ifdef ZgatewayPilight_rawEnabled
+# ifdef ZgatewayPilight_rawEnabled
 void pilightRawCallback(const uint16_t* pulses, size_t length) {
   uint16_t pulse;
 
-  if ( ! pilightRawEnabled ) {
+  if (!pilightRawEnabled ) {
     Log.trace(F("Pilight RAW not enabled" CR));
     return;
   }
@@ -104,7 +104,7 @@ void pilightRawCallback(const uint16_t* pulses, size_t length) {
   // publish data
   pub(subjectPilighttoMQTT, RFPiLightdata);
 }
-#endif
+# endif
 
 void setupPilight() {
 #  ifdef ZradioCC1101 //receiving with CC1101
@@ -185,7 +185,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       Log.notice(F("PiLight protocols available: %s" CR), rf.availableProtocols().c_str());
       success = true;
     }
-    #ifdef ZgatewayPilight_rawEnabled
+    # ifdef ZgatewayPilight_rawEnabled
     if (Pilightdata.containsKey("rawEnabled")) {
       Log.notice(F("Setting PiLight raw output enabled: %s" CR), Pilightdata["rawEnabled"]);
       pilightRawEnabled = (byte)Pilightdata["rawEnabled"];
@@ -194,7 +194,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
       enablePilightReceive();
       success = true;
     }
-    #endif
+    # endif
 
     if (success) {
       pub(subjectGTWPilighttoMQTT, Pilightdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
@@ -335,11 +335,11 @@ extern void enablePilightReceive() {
   ELECHOUSE_cc1101.SetRx(receiveMhz); // set Receive on
 #  endif
   rf.setCallback(pilightCallback);
-  #ifdef ZgatewayPilight_rawEnabled
-  if ( pilightRawEnabled) {
+  # ifdef ZgatewayPilight_rawEnabled
+  if (pilightRawEnabled) {
     rf.setPulseTrainCallBack(pilightRawCallback);
   }
-  #endif
+  # endif
   rf.initReceiver(RF_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
   rf.enableReceiver();

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -167,6 +167,7 @@ const char parameters[40][4][24] = {
 #define subjectPilighttoMQTT         "/PilighttoMQTT"
 #define subjectGTWPilighttoMQTT      "/PilighttoMQTT"
 #define repeatPilightwMQTT           false // do we repeat a received signal by using MQTT with Pilight gateway
+//#define Pilight_rawEnabled true   // enables Pilight RAW return - switchable via MQTT
 
 /*-------------------RTL_433 topics & parameters----------------------*/
 //433Mhz RTL_433 MQTT Subjects and keys


### PR DESCRIPTION
## Description:
This PR adds RAW packet support for Pilight module. Once the ability is enabled before compile, the RAW packet return can be enable/disabled with MQTT command:

mosquitto_pub -h 127.0.0.1 -m '{"rawEnabled":true}' -t "home/SonOff_RFB/commands/MQTTtoPilight/protocols" -d

The returned JSON looks like this:
Client (null) received PUBLISH (d0, q0, r0, m0, 'home/SonOff_RFB/PilighttoMQTT', ... (176 bytes))
{"format":"RAW","rawlen":106,"pulsesString":"c:0102010102020202020101010101010102020201020102020202020201010101010101010101010102010102010201020201010203;p:521,944,1924,3845@"}

The pulseString format is Pilight's native. For those who are not familiar with it:
c:* are the indexes for the p:* array, which are the different pulse length. (e.g. pulse[0] = 521ms, pulse[1]=944ms..., so c[0], which is a '0' = 521ms pulse, c[1], which is a '1' =944ms pulse etc)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
