### PR TITLE
[BT] BLE Scan watchdog relying on scan count rather than msgs processed

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -101,20 +101,20 @@ void BTConfig_init() {
   BTConfig.presenceAwayTimer = PresenceAwayTimer;
 }
 
-// Watchdog, if there was no change of btQueueLengthSum for 5 minutes, restart ESP
+// Watchdog, if there was no change of BLE scanCount, restart ESP
 void btScanWDG() {
-  static unsigned long previousbtQueueLengthSum = 0;
-  static unsigned long lastBtMsgTime = 0;
+  static unsigned long previousBtScanCount = 0;
+  static unsigned long lastBtScan = 0;
   unsigned long now = millis();
   if (!ProcessLock &&
-      previousbtQueueLengthSum == btQueueLengthSum &&
-      btQueueLengthSum != 0 &&
-      (now - lastBtMsgTime > BTConfig.BLEinterval)) {
-    Log.error(F("BLE Scan watchdog triggered at : %ds" CR), lastBtMsgTime / 1000);
-    ESPRestart();
+      previousBtScanCount == scanCount &&
+      scanCount != 0 &&
+      (now - lastBtScan > BTConfig.BLEinterval)) {
+    Log.error(F("BLE Scan watchdog triggered at : %ds" CR), lastBtScan / 1000);
+    watchdogReboot(4);
   } else {
-    previousbtQueueLengthSum = btQueueLengthSum;
-    lastBtMsgTime = now;
+    previousBtScanCount = scanCount;
+    lastBtScan = now;
   }
 }
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -744,7 +744,8 @@ void BLEscan() {
   pBLEScan->setInterval(BLEScanInterval);
   pBLEScan->setWindow(BLEScanWindow);
   BLEScanResults foundDevices = pBLEScan->start(BTConfig.scanDuration / 1000, false);
-  scanCount++;
+  if (foundDevices.getCount())
+    scanCount++;
   Log.notice(F("Found %d devices, scan number %d end" CR), foundDevices.getCount(), scanCount);
   Log.trace(F("Process BLE stack free: %u" CR), uxTaskGetStackHighWaterMark(xProcBLETaskHandle));
 }

--- a/main/main.ino
+++ b/main/main.ino
@@ -2597,6 +2597,7 @@ String toString(uint32_t input) {
   1 - Repeated MQTT Connection Failure
   2 - Repeated WiFi Connection Failure
   3 - Failed WiFiManager configuration portal
+  4 - BLE Scan watchdog
 */
 void watchdogReboot(byte reason) {
   Log.warning(F("Rebooting for reason code %d" CR), reason);


### PR DESCRIPTION
## Description:
And consider only the successful scans in the scanCount

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
