### PR TITLE
[BLE] When BLE watchdog is triggered, only deinit and reinit BLE

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -154,6 +154,7 @@ String stateBTMeasures(bool start) {
   jo["btqsnd"] = btQueueLengthCount;
   jo["btqavg"] = (btQueueLengthCount > 0 ? btQueueLengthSum / (float)btQueueLengthCount : 0);
   jo["bletaskstack"] = uxTaskGetStackHighWaterMark(xProcBLETaskHandle);
+  jo["blecoretaskstack"] = uxTaskGetStackHighWaterMark(xCoreTaskHandle);
   jo["blestarts"] = BLEstarts;
 
   if (start) {

--- a/main/main.ino
+++ b/main/main.ino
@@ -1951,11 +1951,14 @@ String stateMeasures() {
 #  if defined(ESP8266) || defined(ESP32)
   SYSdata["env"] = ENV_NAME;
   uint32_t freeMem;
+  uint32_t minFreeMem;
   freeMem = ESP.getFreeHeap();
   SYSdata["freemem"] = freeMem;
   SYSdata["mqttport"] = mqtt_port;
   SYSdata["mqttsecure"] = mqtt_secure;
 #    ifdef ESP32
+  minFreeMem = ESP.getMinFreeHeap();
+  SYSdata["minfreemem"] = minFreeMem;
 #      ifndef NO_INT_TEMP_READING
   SYSdata["tempc"] = intTemperatureRead();
 #      endif


### PR DESCRIPTION
## Description:
to avoid a full board restart,

Also add new indicators mininum free heap, ble core task and able restarts

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
