### PR TITLE
[SYS] Add payload level filtering

### DIFF
--- a/docs/use/gateway.md
+++ b/docs/use/gateway.md
@@ -42,6 +42,40 @@ OpenHAB does not support the key `is_defined` in the json template, to remove it
 This command can also be used with other controllers that does not support the is_defined key.
 :::
 
+## Filter messages
+OpenMQTTGateway enables to set whitelist and blacklist to filter messages, the filter can be defined for any keys of the json containing a string, here is an example:
+
+`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"whitelist":{"name": "ATC*"},"blacklist":{"name": ["TP_*"]}}'`
+
+This example allow all messages with the name starting by ATC to be published and does not publish the ones that start with TP.
+
+Alternatively you can also filter at sensor level with their ids:
+
+```
+{
+  "whitelist": {
+    "id": ["11:22:33:44:55:66","AA:BB:CC:DD:EE:FF"]
+  },
+  "blacklist": {
+    "name": ["BCPro_*"]
+  }
+}
+```
+
+or a part of their ids:
+
+```
+{
+  "whitelist": {
+    "id": ["11:22*"]
+  },
+  "blacklist": {
+    "name": ["BCPro_*"]
+  }
+}
+```
+
+
 ## Change the WiFi credentials
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"wifi_ssid":"ssid", "wifi_pass":"password"}'`

--- a/main/main.ino
+++ b/main/main.ino
@@ -2498,6 +2498,7 @@ void MQTTHttpsFWUpdate(char* topicOri, JsonObject& HttpsFwUpdateData) {
 }
 #endif
 
+#if defined(ESP8266) || defined(ESP32)
 bool SYSConfig_load() {
   preferences.begin(Gateway_Short_Name, true);
   if (preferences.isKey("SYSConfig")) {
@@ -2526,6 +2527,7 @@ void SYSConfig_save(std::string jsonSYSConfigString) {
   preferences.end();
   Log.notice(F("SYS Config_save: %s, result: %d" CR), jsonSYSConfigString.c_str(), result);
 }
+#endif
 
 void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
   if (cmpToMainTopic(topicOri, subjectMQTTtoSYSset)) {
@@ -2544,6 +2546,12 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
         stateMeasures();
       }
     }
+    if ((SYSdata.containsKey("whitelist") || SYSdata.containsKey("blacklist"))) {
+      std::string SYSfilter;
+      serializeJson(SYSdata, SYSfilter);
+      SYSConfig_save(SYSfilter);
+      SYSConfig_load();
+    }
 #  ifdef ZmqttDiscovery
     if (SYSdata.containsKey("ohdiscovery") && SYSdata["ohdiscovery"].is<bool>()) {
       OpenHABDisc = SYSdata["ohdiscovery"];
@@ -2551,12 +2559,6 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
       stateMeasures();
     }
 #  endif
-    if ((SYSdata.containsKey("whitelist") || SYSdata.containsKey("blacklist"))) {
-      std::string SYSfilter;
-      serializeJson(SYSdata, SYSfilter);
-      SYSConfig_save(SYSfilter);
-      SYSConfig_load();
-    }
 
     if (SYSdata.containsKey("wifi_ssid") && SYSdata.containsKey("wifi_pass")) {
 #  if defined(ZgatewayBT) && defined(ESP32)


### PR DESCRIPTION
## Description:
Payload level filtering to whitelist or blacklist messages following the string value of their keys:

```json
{
  "whitelist": {
    "id": ["11:22*"]
  },
  "blacklist": {
    "name": ["BCPro_*"]
  }
}
```

This could be used for any gateways, BT, RTL or sensors. It will deprecate the current BLE white list and black list functions.

TODO: 
  - [ ] discovery filtering 
  - [ ] impact for webUI and display
  - [ ] use a default filter to replace the current filter for random Macs
  - [ ] handle ignoreWBlist impacts
  - [ ] optimize json load after change from mqtt command

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
