### PR TITLE
[SYS] Add failsafe mode

### DIFF
--- a/main/ZsensorGPIOInput.ino
+++ b/main/ZsensorGPIOInput.ino
@@ -66,6 +66,15 @@ void MeasureGPIOInput() {
         resetTime = millis();
       } else if ((millis() - resetTime) > 3000) {
         Log.trace(F("Button Held" CR));
+        InfoIndicatorOFF();
+        SendReceiveIndicatorOFF();
+// Switching off the relay during reset or failsafe operations
+#    ifdef ZactuatorONOFF
+        uint8_t level = digitalRead(ACTUATOR_ONOFF_GPIO);
+        if (level == ACTUATOR_ON) {
+          ActuatorTrigger();
+        }
+#    endif
         Log.notice(F("Erasing ESP Config, restarting" CR));
         setup_wifimanager(true);
       }

--- a/main/config_RN8209.h
+++ b/main/config_RN8209.h
@@ -48,7 +48,7 @@ extern void RN8209toMQTT();
 #endif
 
 #ifndef TimeOutWDTRN8209
-#  define TimeOutWDTRN8209 60 // time out if RN8209 task is stuck in seconds (should be more than TimeBetweenReadingRN8209/1000), the WDT will reset the ESP
+#  define TimeOutWDTRN8209 3 // time out if RN8209 task is stuck in seconds (should be more than TimeBetweenReadingRN8209/1000), the WDT will reset the ESP
 #endif
 #ifndef TimeBetweenPublishingRN8209
 #  define TimeBetweenPublishingRN8209 60000 // time between 2 RN8209 publishing in ms


### PR DESCRIPTION
## Description:
A press at start during more than 30s after a previous reset will start the board in failsafe mode. WifiManager will be loaded without LED, sensors and actuators to enable a wifi connection or a firmware switch

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
