### PR TITLE
fix wrong time format for UTC timestamp

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -1963,8 +1963,8 @@ int unixtimestamp() {
 String UTCtimestamp() {
   time_t now;
   time(&now);
-  char buffer[sizeof "yyyy-MM-ddThh:mm:ssZGMT"];
-  strftime(buffer, sizeof buffer, "%FT%TZGMT", gmtime(&now));
+  char buffer[sizeof "yyyy-MM-ddThh:mm:ssZ"];
+  strftime(buffer, sizeof buffer, "%FT%TZ", gmtime(&now));
   return buffer;
 }
 


### PR DESCRIPTION
## Description:
fixes wrong format of timestamp introduced with #1677 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
