### PR TITLE
[BT] Fix BLE MQTT action command trigger a reset

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -287,7 +287,7 @@ To specify the MAC address type add the parameter `"mac_type"` to the command. F
 
 ### Example write command
 ```
-mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
+mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT -m '{
   "ble_write_address":"AA:BB:CC:DD:EE:FF",
   "ble_write_service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
   "ble_write_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
@@ -308,7 +308,7 @@ Response:
 ```
 ### Example read command
 ```
-mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
+mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT -m '{
   "ble_read_address":"AA:BB:CC:DD:EE:FF",
   "ble_read_service":"cba20d00-224d-11e6-9fb8-0002a5d5c51b",
   "ble_read_char":"cba20002-224d-11e6-9fb8-0002a5d5c51b",
@@ -343,7 +343,7 @@ The device can also be controlled over MQTT with a simplified BLE write command.
 
 ### Example command to set the SwitchBot state to ON:
 ```
-mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{
+mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT -m '{
   "SBS1":"on",
   "mac":"AA:BB:CC:DD:EE:FF"
 }'

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1361,7 +1361,8 @@ void MQTTtoBTAction(JsonObject& BTdata) {
   if (BTdata.containsKey("SBS1")) {
     strcpy(action.addr, (const char*)BTdata["mac"]);
     action.write = true;
-    action.value = BTdata["SBS1"].as<std::string>();
+    std::string val = BTdata["SBS1"].as<std::string>(); // Fix #1694
+    action.value = val;
     action.ttl = 1;
     createOrUpdateDevice(action.addr, device_flags_connect,
                          TheengsDecoder::BLE_ID_NUM::SBS1, 1);
@@ -1397,7 +1398,8 @@ void MQTTtoBTAction(JsonObject& BTdata) {
     strcpy(action.addr, (const char*)BTdata["ble_write_address"]);
     action.service = NimBLEUUID((const char*)BTdata["ble_write_service"]);
     action.characteristic = NimBLEUUID((const char*)BTdata["ble_write_char"]);
-    action.value = std::string((const char*)BTdata["ble_write_value"]);
+    std::string val = BTdata["ble_write_value"].as<std::string>(); // Fix #1694
+    action.value = val;
     action.write = true;
     Log.trace(F("BLE ACTION Write" CR));
   } else if (BTdata.containsKey("ble_read_address") &&
@@ -1464,7 +1466,7 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
     if (BTdata.containsKey("lowpowermode")) {
       changelowpowermode((int)BTdata["lowpowermode"]);
     }
-
+  } else if (cmpToMainTopic(topicOri, subjectMQTTtoBT)) {
     MQTTtoBTAction(BTdata);
   }
 }

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -46,6 +46,7 @@ extern int btQueueLengthCount;
 /*-----------BT TOPICS & COMPILATION PARAMETERS-----------*/
 #define subjectBTtoMQTT    "/BTtoMQTT"
 #define subjectMQTTtoBTset "/commands/MQTTtoBT/config"
+#define subjectMQTTtoBT    "/commands/MQTTtoBT"
 // Uncomment to send undecoded device data to another gateway device for decoding
 // #define MQTTDecodeTopic    "undecoded"
 #ifndef UseExtDecoder


### PR DESCRIPTION
## Description:
Problem introduced with the bump of ESP32 platform from 3.5.0 to 6.1.0
fix #1694 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
