### PR TITLE
[WebUI] WebUI MQTT command fix

### DIFF
--- a/docs/use/displays.md
+++ b/docs/use/displays.md
@@ -5,7 +5,7 @@ Several options are available for the display of information on the SSD1306 disp
 
 The current SSD1306 display states are being published to the `SSD1306toMQTT` topic, e.g.
 
-`{"onstate":true,"brightness":50,"displaymetric":true,"display-flip":true,"idlelogo":true,"log-oled":false,"json-oled":true}`
+`{"onstate":true,"brightness":50,"display-flip":true,"idlelogo":true,"log-oled":false,"json-oled":true}`
 
 ### Display ON/OFF
 To turn the SSD1306 display on or off.
@@ -36,9 +36,9 @@ To have applicable device properties displayed in Imperial units, e.g. °F for t
 
 This can be set with the compiler directive `-DDISPLAY_METRIC=false`.
 
-or with the runtime command
+As the display Metric setting is being defined in the WebUI part of OpenMQTTGateway changes need to be sent there with the runtime command
 
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m {"displaymetric":false}`
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoWebUI/config -m {"displayMetric":false}`
 
 ### Rotating the display by 180 degrees
 

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -507,11 +507,11 @@ void pubMqttDiscovery() {
                   "false", "true" //state_off, state_on
   );
   createDiscovery("switch", //set Type
-                  subjectSSD1306toMQTT, "SSD1306: Display metric", (char*)getUniqueId("displaymetric", "").c_str(), //set state_topic,name,uniqueId
-                  will_Topic, "", "{{ value_json.displaymetric }}", //set availability_topic,device_class,value_template,
-                  "{\"displaymetric\":true,\"save\":true}", "{\"displaymetric\":false,\"save\":true}", "", //set,payload_on,payload_off,unit_of_meas,
+                  subjectWebUItoMQTT, "SSD1306: Display metric", (char*)getUniqueId("displayMetric", "").c_str(), //set state_topic,name,uniqueId
+                  will_Topic, "", "{{ value_json.displayMetric }}", //set availability_topic,device_class,value_template,
+                  "{\"displayMetric\":true,\"save\":true}", "{\"displayMetric\":false,\"save\":true}", "", //set,payload_on,payload_off,unit_of_meas,
                   0, //set  off_delay
-                  Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoSSD1306set, //set,payload_available,payload_not available   ,is a gateway entity, command topic
+                  Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoWebUIset, //set,payload_available,payload_not available   ,is a gateway entity, command topic
                   "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain
                   stateClassNone, //State Class
                   "false", "true" //state_off, state_on

--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -1307,9 +1307,9 @@ void MQTTtoWebUI(char* topicOri, JsonObject& WebUIdata) { // json object decodin
   if (cmpToMainTopic(topicOri, subjectMQTTtoWebUIset)) {
     WEBUI_TRACE_LOG(F("MQTTtoWebUI json set" CR));
     // properties
-    if (WebUIdata.containsKey("displaymetric")) {
-      displayMetric = WebUIdata["displaymetric"].as<bool>();
-      Log.notice(F("Set displaymetric: %T" CR), displayMetric);
+    if (WebUIdata.containsKey("displayMetric")) {
+      displayMetric = WebUIdata["displayMetric"].as<bool>();
+      Log.notice(F("Set displayMetric: %T" CR), displayMetric);
       success = true;
     }
     // save, load, init, erase

--- a/main/main.ino
+++ b/main/main.ino
@@ -2270,6 +2270,9 @@ void receivingMQTT(char* topicOri, char* datacallback) {
 #  ifdef MQTT_HTTPS_FW_UPDATE
     MQTTHttpsFWUpdate(topicOri, jsondata);
 #  endif
+#  ifdef ZwebUI
+    MQTTtoWebUI(topicOri, jsondata);
+#  endif
 #endif
     SendReceiveIndicatorON();
 


### PR DESCRIPTION
• renamed command displaymetric to displayMetric for consistency with reported displayMetric 
• added WebUI to receivingMQTT to be able to receive commands
• redefined displayMetric discovery message - needs verification with HA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
