### PR TITLE
[LORA] Allow LORA CUSTOM PINS

### DIFF
--- a/main/config_LORA.h
+++ b/main/config_LORA.h
@@ -52,13 +52,29 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 
 /*-------------------PIN DEFINITIONS----------------------*/
 
-#ifndef LORA_CUSTOM_PINS
 //TTGO LORA BOARD ESP32 PIN DEFINITION
+
+#ifndef LORA_SCK
 #  define LORA_SCK  5 // GPIO5  -- SX1278's SCK
+#endif
+
+#ifndef LORA_MISO
 #  define LORA_MISO 19 // GPIO19 -- SX1278's MISO
+#endif
+
+#ifndef LORA_MOSI
 #  define LORA_MOSI 27 // GPIO27 -- SX1278's MOSI
+#endif
+
+#ifndef LORA_SS
 #  define LORA_SS   18 // GPIO18 -- SX1278's CS
+#endif
+
+#ifndef LORA_RST
 #  define LORA_RST  14 // GPIO14 -- SX1278's RESET
+#endif
+
+#ifndef LORA_DI0
 #  define LORA_DI0  26 // GPIO26 -- SX1278's IRQ(Interrupt Request)
 #endif
 

--- a/main/config_LORA.h
+++ b/main/config_LORA.h
@@ -55,7 +55,7 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 //TTGO LORA BOARD ESP32 PIN DEFINITION
 
 #ifndef LORA_SCK
-#  define LORA_SCK  5 // GPIO5  -- SX1278's SCK
+#  define LORA_SCK 5 // GPIO5  -- SX1278's SCK
 #endif
 
 #ifndef LORA_MISO
@@ -67,15 +67,15 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 #endif
 
 #ifndef LORA_SS
-#  define LORA_SS   18 // GPIO18 -- SX1278's CS
+#  define LORA_SS 18 // GPIO18 -- SX1278's CS
 #endif
 
 #ifndef LORA_RST
-#  define LORA_RST  14 // GPIO14 -- SX1278's RESET
+#  define LORA_RST 14 // GPIO14 -- SX1278's RESET
 #endif
 
 #ifndef LORA_DI0
-#  define LORA_DI0  26 // GPIO26 -- SX1278's IRQ(Interrupt Request)
+#  define LORA_DI0 26 // GPIO26 -- SX1278's IRQ(Interrupt Request)
 #endif
 
 #endif

--- a/main/config_LORA.h
+++ b/main/config_LORA.h
@@ -51,6 +51,8 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 #define repeatLORAwMQTT false // do we repeat a received signal by using MQTT with LORA gateway
 
 /*-------------------PIN DEFINITIONS----------------------*/
+
+#ifndef LORA_CUSTOM_PINS
 //TTGO LORA BOARD ESP32 PIN DEFINITION
 #define LORA_SCK  5 // GPIO5  -- SX1278's SCK
 #define LORA_MISO 19 // GPIO19 -- SX1278's MISO
@@ -58,5 +60,6 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 #define LORA_SS   18 // GPIO18 -- SX1278's CS
 #define LORA_RST  14 // GPIO14 -- SX1278's RESET
 #define LORA_DI0  26 // GPIO26 -- SX1278's IRQ(Interrupt Request)
+#endif
 
 #endif

--- a/main/config_LORA.h
+++ b/main/config_LORA.h
@@ -54,12 +54,12 @@ extern void MQTTtoLORA(char* topicOri, JsonObject& RFdata);
 
 #ifndef LORA_CUSTOM_PINS
 //TTGO LORA BOARD ESP32 PIN DEFINITION
-#define LORA_SCK  5 // GPIO5  -- SX1278's SCK
-#define LORA_MISO 19 // GPIO19 -- SX1278's MISO
-#define LORA_MOSI 27 // GPIO27 -- SX1278's MOSI
-#define LORA_SS   18 // GPIO18 -- SX1278's CS
-#define LORA_RST  14 // GPIO14 -- SX1278's RESET
-#define LORA_DI0  26 // GPIO26 -- SX1278's IRQ(Interrupt Request)
+#  define LORA_SCK  5 // GPIO5  -- SX1278's SCK
+#  define LORA_MISO 19 // GPIO19 -- SX1278's MISO
+#  define LORA_MOSI 27 // GPIO27 -- SX1278's MOSI
+#  define LORA_SS   18 // GPIO18 -- SX1278's CS
+#  define LORA_RST  14 // GPIO14 -- SX1278's RESET
+#  define LORA_DI0  26 // GPIO26 -- SX1278's IRQ(Interrupt Request)
 #endif
 
 #endif


### PR DESCRIPTION
## Description:

Fix change pins via *_env.ini

Example code:

```ini
  '-DGateway_Name="OMG_ESP32_LORA"'
  '-DZgatewayLORA="LORA"'
  '-DLORA_BAND=868E6'
  '-DLORA_CUSTOM_PINS'
  '-DLORA_SCK=14'
  '-DLORA_MISO=12'
  '-DLORA_MOSI=13'
  '-DLORA_SS=15'
  '-DLORA_RST=16'
  '-DLORA_DI0=5'
```


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
