### PR TITLE
User friendly manual network configuration

### DIFF
--- a/docs/upload/builds.md
+++ b/docs/upload/builds.md
@@ -95,7 +95,7 @@ build_flags =
   '-DLED_RECEIVE_ON=LOW'             ; Comment 2
   '-DRF_RECEIVER_GPIO=13'
   '-DRF_EMITTER_GPIO=15'
-  '-DsimpleReceiving=false'          
+  '-DsimpleReceiving=false'
   '-UZmqttDiscovery'                 ; Disable HA discovery
 monitor_speed = 115200
 
@@ -112,6 +112,18 @@ upload_flags =
 Adding manual WiFi and MQTT credentials to an environment also requires to define
 `'-DESPWifiManualSetup=true'`
 for the credetials to be registered correctly.
+:::
+
+::: warning Note
+Manual network configuration (IP, netmask, gateway, DNS) requires to define
+`'-DNetworkAdvancedSetup=true'`
+and related network parameters, e.g.:
+```
+'-DNET_IP="192.168.1.99"'
+'-DNET_MASK="255.255.255.0"'
+'-DNET_GW="192.168.1.1"'
+'-DNET_DNS="1.1.1.1"'
+```
 :::
 
 The first new environment we create, `nodemcuv2-pilight-bme280`, inherits the default `nodemcuv2-pilight` environment in `platformio.ini` with the `extends = env:nodemcuv2-pilight` line. In the `lib_deps` section, it imports all the `lib_deps` of `nodemcuv2-pilight` with the `${env:nodemcuv2-pilight.lib_deps}` line, and adds BME280 on top of it. (Since the environment we're extending already has this `lib_deps` attribute, specifying it again would normally replace it completely with our new attribute; instead, to keep its value but simply append to it, we import the original in the beginning of our `lib_deps` attribute.) In the `build_flags` section, it again imports all the `build_flags` of `nodemcuv2-pilight` and many of its own overrides, e.g. changing `Base_Topic` found in `User_config.h` from the default to "rf/" by using the `'-DBase_Topic="rf/"'` line. It also unsets previously set configurations (i.e. `mqttDiscovery`) by using `'-UZmqttDiscovery'`. This environment will work over serial upload.
@@ -150,7 +162,7 @@ board = esp32dev
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.rc-switch}
-build_flags = 
+build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
   '-DZgatewayIR="IR"'
@@ -173,7 +185,7 @@ This can be useful especially before the first upload or when you change the boa
 
 Once done the gateway should connect to your network and your broker, you should see it into the broker in the form of the following messages:
 ```
-home/OpenMQTTGateway/LWT Online 
+home/OpenMQTTGateway/LWT Online
 home/OpenMQTTGateway/version
 ```
 
@@ -239,7 +251,7 @@ You can deactivate Json or simple mode following theses instructions:
 #define jsonPublishing true //define false if you don't want to use Json publishing (one topic for all the parameters)
 //example home/OpenMQTTGateway_ESP32_DEVKIT/BTtoMQTT/4XXXXXXXXXX4 {"rssi":-63,"servicedata":"fe0000000000000000000000000000000000000000"}
 #define simplePublishing false //define true if you want to use simple publishing (one topic for one parameter)
-//example 
+//example
 // home/OpenMQTTGateway_ESP32_DEVKIT/BTtoMQTT/4XXXXXXXXXX4/rssi -63.0
 // home/OpenMQTTGateway_ESP32_DEVKIT/BTtoMQTT/4XXXXXXXXXX4/servicedata fe0000000000000000000000000000000000000000
 #define simpleReceiving true //define false if you don't want to use old way reception analysis
@@ -260,7 +272,7 @@ Note that depending on the environment the default platformio.ini has common opt
 [com-esp]
 ```
 
-If you want to use HASS MQTT discovery you need to have 
+If you want to use HASS MQTT discovery you need to have
 `#define jsonPublishing true`
 &
 `#define ZmqttDiscovery "HADiscovery"`

--- a/environments.ini
+++ b/environments.ini
@@ -118,6 +118,11 @@ build_flags =
   '-DESP32_EXT0_WAKE_PIN=GPIO_NUM_14' ;Should a water leak be detected immediatly wake the ESP32 and report the problem
   '-DESP32_EXT0_WAKE_PIN_STATE=0' ;Should a water leak be detected immediatly wake the ESP32 and report the problem, sensor state to look for wakeup
   '-UMQTT_HTTPS_FW_UPDATE' ;disable HTTPS firmware updating
+  '-DNetworkAdvancedSetup=true'
+  '-DNET_IP="192.168.1.99"'
+  '-DNET_MASK="255.255.255.0"'
+  '-DNET_GW="192.168.1.1"'
+  '-DNET_DNS="1.1.1.1"'
 [env:esp32dev-rf]
 platform = ${com.esp32_platform}
 board = esp32dev
@@ -591,7 +596,7 @@ custom_hardware = M5 ATOM Lite
 
 [env:esp32doitv1-aithinker-r01-sx1278]
 platform = ${com.esp32_platform}
-board = esp32doit-devkit-v1 
+board = esp32doit-devkit-v1
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
@@ -607,7 +612,7 @@ build_flags =
   '-DZgatewayRTL_433="rtl_433"'
   '-DZradioSX127x="SX127x"'
 ; *** rtl_433_ESP Options ***
-   '-DONBOARD_LED=LED_BUILTIN'  
+   '-DONBOARD_LED=LED_BUILTIN'
 ;  '-DRTL_DEBUG=4'           ; rtl_433 verbose mode
 ;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
 ;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
@@ -979,7 +984,7 @@ lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.ble}
   ${libraries.decoder}
-build_flags = 
+build_flags =
   ${env.build_flags}
   ${com-esp32.build_flags}
   '-DZgatewayBT="BT"'
@@ -1568,7 +1573,7 @@ build_flags =
   '-DWM_DEBUG_LEVEL=1' ;DEBUG_NOTIFY=1, default value
 ; Serial output via USB
   '-DCONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=true'
-  '-DCONFIG_ESP_CONSOLE_UART=ESP_CONSOLE_USB_SERIAL_JTAG'   
+  '-DCONFIG_ESP_CONSOLE_UART=ESP_CONSOLE_USB_SERIAL_JTAG'
 
 [env:thingpulse-espgateway]
 platform = ${com.esp32_platform}
@@ -1630,4 +1635,4 @@ build_flags =
 ;  '-DsimplePublishing=true'
 custom_description = BLE Gateway using ethernet, requires PIO configuration
 custom_hardware = ThingPulse gateway single ESP32
-  
+

--- a/environments.ini
+++ b/environments.ini
@@ -123,6 +123,7 @@ build_flags =
   '-DNET_MASK="255.255.255.0"'
   '-DNET_GW="192.168.1.1"'
   '-DNET_DNS="1.1.1.1"'
+
 [env:esp32dev-rf]
 platform = ${com.esp32_platform}
 board = esp32dev

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -68,12 +68,18 @@
 
 //#define NetworkAdvancedSetup true //uncomment if you want to set advanced network parameters, not uncommented you can set the IP and MAC only
 #ifdef NetworkAdvancedSetup
-#  if defined(ESP8266) || defined(ESP32)
-const byte ip[] = {192, 168, 1, 99}; //IP address of the gateway, already defined for arduino below
+#  ifndef NET_IP
+#    define NET_IP "192.168.1.99"
 #  endif
-const byte gateway[] = {0, 0, 0, 0};
-const byte Dns[] = {0, 0, 0, 0};
-const byte subnet[] = {255, 255, 255, 0};
+#  ifndef NET_MASK
+#    define NET_MASK "255.255.255.0"
+#  endif
+#  ifndef NET_GW
+#    define NET_GW "192.168.1.1"
+#  endif
+#  ifndef NET_DNS
+#    define NET_DNS "192.168.1.1"
+#  endif
 #endif
 
 #if defined(ESP8266) || defined(ESP32) // for nodemcu, weemos and esp8266

--- a/main/main.ino
+++ b/main/main.ino
@@ -1277,10 +1277,15 @@ void setup_wifi() {
   // We start by connecting to a WiFi network
 
 #  ifdef NetworkAdvancedSetup
-  IPAddress ip_adress(ip);
-  IPAddress gateway_adress(gateway);
-  IPAddress subnet_adress(subnet);
-  IPAddress dns_adress(Dns);
+  IPAddress ip_adress;
+  IPAddress gateway_adress;
+  IPAddress subnet_adress;
+  IPAddress dns_adress;
+  ip_adress.fromString(NET_IP);
+  gateway_adress.fromString(NET_GW);
+  subnet_adress.fromString(NET_MASK);
+  dns_adress.fromString(NET_DNS);
+
   if (!WiFi.config(ip_adress, gateway_adress, subnet_adress, dns_adress)) {
     Log.error(F("Wifi STA Failed to configure" CR));
   }
@@ -1515,10 +1520,15 @@ void setup_wifimanager(bool reset_settings) {
 //set static IP
 #  ifdef NetworkAdvancedSetup
   Log.trace(F("Adv wifi cfg" CR));
-  IPAddress gateway_adress(gateway);
-  IPAddress subnet_adress(subnet);
-  IPAddress ip_adress(ip);
-  wifiManager.setSTAStaticIPConfig(ip_adress, gateway_adress, subnet_adress);
+  IPAddress ip_adress;
+  IPAddress gateway_adress;
+  IPAddress subnet_adress;
+  IPAddress dns_adress;
+  ip_adress.fromString(NET_IP);
+  gateway_adress.fromString(NET_GW);
+  subnet_adress.fromString(NET_MASK);
+  dns_adress.fromString(NET_DNS);
+  wifiManager.setSTAStaticIPConfig(ip_adress, gateway_adress, subnet_adress, dns_adress);
 #  endif
 
 #  ifndef WIFIMNG_HIDE_MQTT_CONFIG
@@ -1617,6 +1627,15 @@ void setup_ethernet_esp32() {
   bool ethBeginSuccess = false;
   WiFi.onEvent(WiFiEvent);
 #    ifdef NetworkAdvancedSetup
+  IPAddress ip_adress;
+  IPAddress gateway_adress;
+  IPAddress subnet_adress;
+  IPAddress dns_adress;
+  ip.fromString(NET_IP);
+  gateway.fromString(NET_GW);
+  subnet.fromString(NET_MASK);
+  Dns.fromString(NET_DNS);
+
   Log.trace(F("Adv eth cfg" CR));
   ETH.config(ip, gateway, subnet, Dns);
   ethBeginSuccess = ETH.begin();
@@ -1662,6 +1681,15 @@ void WiFiEvent(WiFiEvent_t event) {
 #else // Arduino case
 void setup_ethernet() {
 #  ifdef NetworkAdvancedSetup
+  IPAddress ip_adress;
+  IPAddress gateway_adress;
+  IPAddress subnet_adress;
+  IPAddress dns_adress;
+  ip.fromString(NET_IP);
+  gateway.fromString(NET_GW);
+  subnet.fromString(NET_MASK);
+  Dns.fromString(NET_DNS);
+
   Log.trace(F("Adv eth cfg" CR));
   Ethernet.begin(mac, ip, Dns, gateway, subnet);
 #  else


### PR DESCRIPTION
## Description:

1. Add ability for user friendly IP address override without the need to touch `User_config.h`
2. Add DNS server option for ESP WiFi STA

NOTE: Tested on Wemos D1 mini (ESP8266) **ONLY**, unfortunately I do not have a possibility to test on Arduino and ESP32

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
