### PR TITLE
add custom SPI config for CC1101 + added board

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -5,48 +5,6 @@
 ;List of environments that can be build                                                ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
-[env:esp32dev-multi_receiver-eth01]
-platform = ${com.esp32_platform}
-board = wt32-eth01
-board_build.partitions = min_spiffs.csv
-lib_deps =
-  ${com-esp.lib_deps}
-  ${libraries.wifimanager32}
-  ${libraries.rc-switch}
-  ${libraries.smartrc-cc1101-driver-lib}
-  ${libraries.rtl_433_ESP}
-  ${libraries.esppilight}
-  ${libraries.newremoteswitch}
-build_flags =
-  ${com-esp.build_flags}
-  '-DESP32_ETHERNET=true'
-  '-DETH_PHY_ADDR=1'
-  '-DETH_PHY_POWER=16'
-  '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN'
-  '-DZgatewayRF="RF"'
-  '-DZgatewayRF2="RF2"'
-  '-DZgatewayRTL_433="RTL_433"'
-  '-DZgatewayPilight="Pilight"'
-  '-DZradioCC1101="CC1101"'
-  '-DGateway_Name="OpenMQTTGateway"'
-  '-DvalueAsATopic=true'  ; MQTT topic includes model and device (rtl_433) or protocol and id (RF and PiLight)
-  '-DDEFAULT_RECEIVER=2'  ; Default receiver to enable on startup
-; *** RF Module Options ***
-  '-DMQTT_USER=""'
-  '-DMQTT_PASS=""'
-  '-DMQTT_SERVER="192.168.2.3"'
-  '-DMQTT_PORT="1883"'
-  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
-  '-DRF_MODULE_CS=2'      ; pin to be used as chip select
-  '-DRF_MODULE_GDO0=4'   ; CC1101 pin GDO0
-  '-DRF_MODULE_GDO2=17'   ; CC1101 pin GDO2
-  '-DRF_RECEIVER_GPIO=17'
-  '-DRF_EMITTER_GPIO=4'
-  '-DRADIOLIB_DEBUG=true'
-  '-DRADIOLIB_VERBOSE=true'
-  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
- 
 [env:rfbridge]
 platform = ${com.esp8266_platform}
 board = esp8285
@@ -256,6 +214,7 @@ custom_description = RS232 reading of GridFree Sun Inverter
 [env:esp32dev-ir]
 platform = ${com.esp32_platform}
 board = esp32dev
+board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.irremoteesp}
@@ -435,34 +394,6 @@ build_flags =
   '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN'
   '-DGateway_Name="OMG_ESP32_WT32-ETH01"'
 custom_description = BLE gateway using ethernet, need to be configured through PIO
-custom_hardware = WT32
-
-[env:esp32-wt32-eth01-rf-eth]
-platform = ${com.esp32_platform}
-board = wt32-eth01
-lib_deps =
-  ${com-esp32.lib_deps}
-  ${libraries.wifimanager32}
-  ${libraries.rc-switch}
-  ${libraries.smartrc-cc1101-driver-lib}
-build_flags =
-  ${com-esp32.build_flags}
-  '-DESP32_ETHERNET=true'
-  '-DETH_PHY_ADDR=1'
-  '-DETH_PHY_POWER=16'
-  '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN'
-  '-DZgatewayRF="RF"'
-  '-DGateway_Name="OMG_ESP32_RF"'
-  '-DZradioCC1101="CC1101"'
-  '-DRF_MODULE_SCK=12'
-  '-DRF_MODULE_MISO=15'
-  '-DRF_MODULE_MOSI=14'
-  '-DRF_MODULE_CS=2'
-  '-DLED_INFO=5'
-  '-DLED_INFO_ON=17'
-  '-DRF_RECEIVER_GPIO=4'
-  '-DRF_EMITTER_GPIO=17'
-custom_description = RF gateway using RCSwitch library and ethernet
 custom_hardware = WT32
 
 [env:esp32-olimex-gtw-ble-wifi]
@@ -1129,6 +1060,8 @@ build_flags =
   '-DsimplePublishing=true'
   '-DGateway_Name="OMG_ESP8266_ALL"'
   '-DDEEP_SLEEP_IN_US=120000000'
+  '-DWifiGMode=true'
+  '-DWifiPower=11'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-fastled-test]
@@ -1698,3 +1631,30 @@ build_flags =
 custom_description = BLE Gateway using ethernet, requires PIO configuration
 custom_hardware = ThingPulse gateway single ESP32
   
+[env:esp32-wt32-eth01-rf-eth]
+platform = ${com.esp32_platform}
+board = wt32-eth01
+lib_deps =
+  ${com-esp32.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.rc-switch}
+  ${libraries.smartrc-cc1101-driver-lib}
+build_flags =
+  ${com-esp32.build_flags}
+  '-DESP32_ETHERNET=true'
+  '-DETH_PHY_ADDR=1'
+  '-DETH_PHY_POWER=16'
+  '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN'
+  '-DZgatewayRF="RF"'
+  '-DGateway_Name="OMG_ESP32_RF"'
+  '-DZradioCC1101="CC1101"'
+  '-DRF_MODULE_SCK=12'
+  '-DRF_MODULE_MISO=15'
+  '-DRF_MODULE_MOSI=14'
+  '-DRF_MODULE_CS=2'
+  '-DLED_INFO=5'
+  '-DLED_INFO_ON=17'
+  '-DRF_RECEIVER_GPIO=4'
+  '-DRF_EMITTER_GPIO=17'
+custom_description = RF gateway using RCSwitch library and ethernet
+custom_hardware = WT32

--- a/environments.ini
+++ b/environments.ini
@@ -5,6 +5,48 @@
 ;List of environments that can be build                                                ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+
+[env:esp32dev-multi_receiver-eth01]
+platform = ${com.esp32_platform}
+board = wt32-eth01
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.rc-switch}
+  ${libraries.smartrc-cc1101-driver-lib}
+  ${libraries.rtl_433_ESP}
+  ${libraries.esppilight}
+  ${libraries.newremoteswitch}
+build_flags =
+  ${com-esp.build_flags}
+  '-DESP32_ETHERNET=true'
+  '-DETH_PHY_ADDR=1'
+  '-DETH_PHY_POWER=16'
+  '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN'
+  '-DZgatewayRF="RF"'
+  '-DZgatewayRF2="RF2"'
+  '-DZgatewayRTL_433="RTL_433"'
+  '-DZgatewayPilight="Pilight"'
+  '-DZradioCC1101="CC1101"'
+  '-DGateway_Name="OpenMQTTGateway"'
+  '-DvalueAsATopic=true'  ; MQTT topic includes model and device (rtl_433) or protocol and id (RF and PiLight)
+  '-DDEFAULT_RECEIVER=2'  ; Default receiver to enable on startup
+; *** RF Module Options ***
+  '-DMQTT_USER=""'
+  '-DMQTT_PASS=""'
+  '-DMQTT_SERVER="192.168.2.3"'
+  '-DMQTT_PORT="1883"'
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+  '-DRF_MODULE_CS=2'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=4'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=17'   ; CC1101 pin GDO2
+  '-DRF_RECEIVER_GPIO=17'
+  '-DRF_EMITTER_GPIO=4'
+  '-DRADIOLIB_DEBUG=true'
+  '-DRADIOLIB_VERBOSE=true'
+  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
+ 
 [env:rfbridge]
 platform = ${com.esp8266_platform}
 board = esp8285
@@ -214,7 +256,6 @@ custom_description = RS232 reading of GridFree Sun Inverter
 [env:esp32dev-ir]
 platform = ${com.esp32_platform}
 board = esp32dev
-board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.irremoteesp}
@@ -394,6 +435,34 @@ build_flags =
   '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN'
   '-DGateway_Name="OMG_ESP32_WT32-ETH01"'
 custom_description = BLE gateway using ethernet, need to be configured through PIO
+custom_hardware = WT32
+
+[env:esp32-wt32-eth01-rf-eth]
+platform = ${com.esp32_platform}
+board = wt32-eth01
+lib_deps =
+  ${com-esp32.lib_deps}
+  ${libraries.wifimanager32}
+  ${libraries.rc-switch}
+  ${libraries.smartrc-cc1101-driver-lib}
+build_flags =
+  ${com-esp32.build_flags}
+  '-DESP32_ETHERNET=true'
+  '-DETH_PHY_ADDR=1'
+  '-DETH_PHY_POWER=16'
+  '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_IN'
+  '-DZgatewayRF="RF"'
+  '-DGateway_Name="OMG_ESP32_RF"'
+  '-DZradioCC1101="CC1101"'
+  '-DRF_MODULE_SCK=12'
+  '-DRF_MODULE_MISO=15'
+  '-DRF_MODULE_MOSI=14'
+  '-DRF_MODULE_CS=2'
+  '-DLED_INFO=5'
+  '-DLED_INFO_ON=17'
+  '-DRF_RECEIVER_GPIO=4'
+  '-DRF_EMITTER_GPIO=17'
+custom_description = RF gateway using RCSwitch library and ethernet
 custom_hardware = WT32
 
 [env:esp32-olimex-gtw-ble-wifi]
@@ -1060,8 +1129,6 @@ build_flags =
   '-DsimplePublishing=true'
   '-DGateway_Name="OMG_ESP8266_ALL"'
   '-DDEEP_SLEEP_IN_US=120000000'
-  '-DWifiGMode=true'
-  '-DWifiPower=11'
 board_build.flash_mode = dout
 
 [env:nodemcuv2-fastled-test]

--- a/main/ZactuatorSomfy.ino
+++ b/main/ZactuatorSomfy.ino
@@ -35,6 +35,13 @@
 
 void setupSomfy() {
 #  ifdef ZradioCC1101 //using with CC1101
+  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+  #  endif
   ELECHOUSE_cc1101.Init();
 #  endif
   pinMode(RF_EMITTER_GPIO, OUTPUT);

--- a/main/ZactuatorSomfy.ino
+++ b/main/ZactuatorSomfy.ino
@@ -35,13 +35,13 @@
 
 void setupSomfy() {
 #  ifdef ZradioCC1101 //using with CC1101
-  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
-    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
-    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
-    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
-    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
-    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
-  #  endif
+#    if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+  Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+  Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+  Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+  Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+  ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+#    endif
   ELECHOUSE_cc1101.Init();
 #  endif
   pinMode(RF_EMITTER_GPIO, OUTPUT);

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -107,13 +107,13 @@ void pilightRawCallback(const uint16_t* pulses, size_t length) {
 
 void setupPilight() {
 #  ifdef ZradioCC1101 //receiving with CC1101
-  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
-    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
-    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
-    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
-    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
-    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
-  #  endif
+#    if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+  Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+  Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+  Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+  Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+  ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+#    endif
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.setMHZ(CC1101_FREQUENCY);
   ELECHOUSE_cc1101.SetRx(CC1101_FREQUENCY);

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -107,6 +107,13 @@ void pilightRawCallback(const uint16_t* pulses, size_t length) {
 
 void setupPilight() {
 #  ifdef ZradioCC1101 //receiving with CC1101
+  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+  #  endif
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.setMHZ(CC1101_FREQUENCY);
   ELECHOUSE_cc1101.SetRx(CC1101_FREQUENCY);

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -110,7 +110,15 @@ void setupRF() {
   //RF init parameters
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
   Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
+
 #  ifdef ZradioCC1101 //receiving with CC1101
+  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+  #  endif
   if (ELECHOUSE_cc1101.getCC1101()) {
     Log.notice(F("C1101 spi Connection OK" CR));
   } else {

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -112,13 +112,13 @@ void setupRF() {
   Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
 
 #  ifdef ZradioCC1101 //receiving with CC1101
-  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
-    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
-    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
-    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
-    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
-    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
-  #  endif
+#    if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+  Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+  Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+  Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+  Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+  ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+#    endif
   if (ELECHOUSE_cc1101.getCC1101()) {
     Log.notice(F("C1101 spi Connection OK" CR));
   } else {

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -57,13 +57,13 @@ RF2rxd rf2rd;
 
 void setupRF2() {
 #  ifdef ZradioCC1101 //receiving with CC1101
-  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
-    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
-    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
-    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
-    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
-    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
-  #  endif
+#    if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+  Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+  Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+  Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+  Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+  ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+#    endif
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.setMHZ(receiveMhz);
   ELECHOUSE_cc1101.SetRx(receiveMhz);

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -57,6 +57,13 @@ RF2rxd rf2rd;
 
 void setupRF2() {
 #  ifdef ZradioCC1101 //receiving with CC1101
+  #  if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+    Log.notice(F("RF_MODULE_SCK: %d " CR), RF_MODULE_SCK);
+    Log.notice(F("RF_MODULE_MISO: %d " CR), RF_MODULE_MISO);
+    Log.notice(F("RF_MODULE_MOSI: %d " CR), RF_MODULE_MOSI);
+    Log.notice(F("RF_MODULE_CS: %d " CR), RF_MODULE_CS);
+    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+  #  endif
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.setMHZ(receiveMhz);
   ELECHOUSE_cc1101.SetRx(receiveMhz);


### PR DESCRIPTION
## Description:
You can now configure the SPI connection pins via the following defines:

- RF_MODULE_SCK
- RF_MODULE_MISO
- RF_MODULE_MOSI
- RF_MODULE_CS

Also added a board config for WT32-ETH01 with CC11101 and RF.
fixes #1665 


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
