### PR TITLE
[OTA] Stop the BLE scan when doing OTA

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -850,7 +850,11 @@ void BLEconnect() {
 
 void stopProcessing() {
   ProcessLock = true;
-  delay(BTConfig.scanDuration < 2000 ? BTConfig.scanDuration : 2000);
+  // We stop the scan
+  BLEScan* pBLEScan = BLEDevice::getScan();
+  if (pBLEScan->isScanning()) {
+    pBLEScan->stop();
+  }
   //Suspending, deleting tasks and stopping BT to free memory
   vTaskSuspend(xCoreTaskHandle);
   vTaskDelete(xCoreTaskHandle);


### PR DESCRIPTION
## Description:
Rather than waiting for its end. This will improve the success rate of OTA especially when the scan duration is high

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
