### PR TITLE
BM2 name extension

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1230,7 +1230,7 @@ void process_bledata(JsonObject& BLEdata) {
           model_id = BLEconectable::id::LYWSD03MMC;
         else if (name.compare("DT24-BLE") == 0)
           model_id = BLEconectable::id::DT24_BLE;
-        else if (name.compare("Battery Monitor") == 0)
+        else if ((name.compare("Battery Monitor") | name.compare("Li Battery Monitor") | name.compare("ZX-1689")) == 0)
           model_id = BLEconectable::id::BM2;
         else if (name.compare("MHO-C401") == 0)
           model_id = BLEconectable::id::MHO_C401;


### PR DESCRIPTION
BM2 name extension for retrieving connection value voltage

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
