### PR TITLE
console log formatting

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -870,7 +870,8 @@ void setup() {
   //Launch serial for debugging purposes
   Serial.begin(SERIAL_BAUD);
   Log.begin(LOG_LEVEL, &Serial);
-  Log.notice(F(CR "************* WELCOME TO OpenMQTTGateway **************" CR));
+  Serial.print(CR);
+  Log.notice(F("************* WELCOME TO OpenMQTTGateway **************" CR));
 #if defined(TRIGGER_GPIO) && !defined(ESPWifiManualSetup)
   pinMode(TRIGGER_GPIO, INPUT_PULLUP);
   checkButton();
@@ -1536,7 +1537,9 @@ void setup_wifimanager(bool reset_settings) {
       if (error) {
         Log.error(F("deserialize config failed: %s, buffer capacity: %u" CR), error.c_str(), json.capacity());
       }
+      Log.notice(F("Configuration:" CR));
       serializeJsonPretty(json, Serial);
+      Serial.print(CR);
       if (!json.isNull()) {
         Log.trace(F("\nparsed json, size: %u" CR), json.memoryUsage());
         if (json.containsKey("mqtt_server"))


### PR DESCRIPTION
## Description:
Fix some console log formatting that is actually mixed with LF and CRLF.

To work properly still is need to change in ArduinoLog/ArduinoLog.h
`#define CR "\n"` <<< actually LF
to
`#define CR "\r\n"`
or to use NL instead of CR in all the relevant files.
NL is available in the latest version of ArduinoLog.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).