### PR TITLE
[SYS] Configuration portal for Ethernet board and HA link to config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,6 @@ jobs:
           - "airm2m_core_esp32c3"
           - "lolin_c3_mini"
           - "thingpulse-espgateway"
-          - "thingpulse-espgateway-ethernet"
     runs-on: ubuntu-latest
     name: Build with PlatformIO
     steps:

--- a/docs/upload/portal.md
+++ b/docs/upload/portal.md
@@ -1,14 +1,18 @@
-# WiFi and MQTT configuration
+# Wifi and MQTT configuration
 
-## WiFi and MQTT configuration portal for WiFi boards
+## Configuration portal
 
 Once loaded into your ESP, and if you don't use the manual configuration, you have to set your network parameters with WiFi Manager portal.
 
-From your smartphone, search for  OpenMQTTGateway or OMG WiFi network and connect to it with the `WifiManager_password` you have defined (the default password is **"your_password"**), or if you are using a device sold by Theengs or the macro `-DWM_PWD_FROM_MAC=true`, the password will be the last eight digits of the device MAC Address with upper case.
+From your smartphone, search for  OpenMQTTGateway or OMG_ WiFi network and connect to it with the `WifiManager_password` you have defined (the default password is **"your_password"**), or if you are using a device sold by Theengs or the macro `-DWM_PWD_FROM_MAC=true`, the password will be the last eight digits of the device MAC Address with upper case.
 Example, the password would be `CCDDEEFF` for a MAC Address `AABBCCDDEEFF`. 
-For Theengs devices, the MAC Address can be found on the device sticker, and for all the devices, it is printed on the serial monitor logs.
+For the Theengs Plug, the MAC Address can be found on the device sticker, and for all the devices, it is printed on the serial monitor logs.
 
 Once connected to the WiFi, a web page should appear. On Android, you may also have a popup asking you if you want to connect to it without an internet connection. Answer yes always/all the time. If the web page doesn't appear, click on the WiFi Access Point and "Manage router".
+
+::: tip
+For boards with an ethernet port you can also access to the Wifi Manager portal through the LAN board IP address.
+:::
 
 ![WiFi manager menu](../img/OpenMQTTGateway_Wifi_Manager_menu.png)
 
@@ -17,7 +21,12 @@ Once connected to the WiFi, a web page should appear. On Android, you may also h
 ![WiFi manager parameters](../img/OpenMQTTGateway_Wifi_Manager_enter_parameters.png)
 
 * Select your WiFi
-* Set your WiFi password
+* Set your WiFi password 
+
+::: note
+If the board is connected by ethernet, the Wifi and password can be empty. If you fill them the board will use this wifi as a fallback connectivity method.
+:::
+
 * Set your MQTT Server IP
 * Set your MQTT Server Port (default: 1883)
 * Set the MQTT secure connection box to select whether or not the connection should be secure
@@ -37,12 +46,11 @@ The ESP restart and connect to your network. Note that your credentials are save
 Once done the gateway should connect to your network and your broker, you should see it into the broker in the form of the following messages:
 ```
 home/OpenMQTTGateway/LWT Online 
-home/OpenMQTTGateway/version
 ```
 
-Note that the web portal appears only on first boot, if you want to configure again the setting you can do a long press on TRIGGER_GPIO or [erase the settings](../use/gateway.md#erase-the-esp-settings).
+Note that the web portal appears only on first boot, if you want to configure again the setting you can do a long press on TRIGGER_GPIO, [erase the settings](../use/gateway.md#erase-the-esp-settings) or Reset the configuration from the WebUI.
 
-## MQTT and network configuration for Ethernet and WiFi boards
+## Build time configuration
 
 You can configure your MQTT server credentials and network configuration before building the application. It can be done either in Arduino or in Platformio IDE thought the User_config.h file. Note that with Platformio IDE you can also set your credentials into the platformio.ini file or an *_env.ini file, here is an example with the Olimex ESP32 gateway:
 

--- a/environments.ini
+++ b/environments.ini
@@ -1623,34 +1623,6 @@ build_flags =
   '-DZgatewayBT="BT"'
   '-DLED_SEND_RECEIVE=2'
   '-DLED_SEND_RECEIVE_ON=0'
-  '-DpubBLEServiceUUID=true'
-  '-DGateway_Name="OMG_THINGPULSE_BLE"'
-  '-DANEOPIX_IND_DATA_GPIO=32'
-  '-DANEOPIX_IND_NUM_LEDS=4'
-  '-DANEOPIX_INFO_LED=0'
-  '-DANEOPIX_SEND_RECEIVE_LED=1'
-  '-DANEOPIX_ERROR_LED=2'
-  '-DANEOPIX_BRIGHTNESS=255'
-  '-DRGB_INDICATORS=true'
-;  '-DsimplePublishing=true'
-custom_description = BLE Gateway using Wifi
-custom_hardware = ThingPulse gateway single ESP32
-
-[env:thingpulse-espgateway-ethernet]
-platform = ${com.esp32_platform}
-board = esp32dev
-board_build.partitions = min_spiffs.csv
-lib_deps =
-  ${com-esp32.lib_deps}
-  ${libraries.ble}
-  ${libraries.adafruit_neopixel}
-  ${libraries.decoder}
-build_flags =
-  ${com-esp32.build_flags}
-  '-DZgatewayBT="BT"'
-  '-DLED_SEND_RECEIVE=2'
-  '-DLED_SEND_RECEIVE_ON=0'
-  '-DpubBLEServiceUUID=true'
   '-DGateway_Name="OMG_THINGPULSE_ETH_BLE"'
   '-DESP32_ETHERNET=true'
   '-DETH_PHY_TYPE=ETH_PHY_LAN8720'
@@ -1667,6 +1639,5 @@ build_flags =
   '-DANEOPIX_BRIGHTNESS=255'
   '-DRGB_INDICATORS=true'
 ;  '-DsimplePublishing=true'
-custom_description = BLE Gateway using ethernet, requires PIO configuration
+custom_description = BLE Gateway using ethernet or wifi with external antenna
 custom_hardware = ThingPulse gateway single ESP32
-

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -140,9 +140,8 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 
 /*-------------DEFINE YOUR ADVANCED NETWORK PARAMETERS BELOW----------------*/
 //#define MDNS_SD //uncomment if you  want to use mDNS for discovering automatically your IP server, please note that mDNS with ESP32 can cause the BLE to not work
-#define maxConnectionRetry     10 //maximum MQTT connection attempts before going to wifimanager setup if never connected once
-#define maxConnectionRetryWifi 5 //maximum Wifi connection attempts with existing credential at start (used to bypass ESP32 issue on wifi connect)
-#define maxRetryWatchDog       11 //maximum Wifi or MQTT re-connection attempts before restarting
+#define maxConnectionRetryNetwork 5 //maximum Wifi connection attempts with existing credential at start (used to bypass ESP32 issue on wifi connect)
+#define maxRetryWatchDog          11 //maximum Wifi or MQTT re-connection attempts before restarting
 
 //set minimum quality of signal so it ignores AP's under that quality
 #define MinimumWifiSignalQuality 8

--- a/platformio.ini
+++ b/platformio.ini
@@ -100,7 +100,6 @@ extra_configs =
 ;default_envs = esp32c3-dev-c2-ble
 ;default_envs = lolin_c3_mini
 ;default_envs = thingpulse-espgateway
-;default_envs = thingpulse-espgateway-ethernet
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                              ENVIRONMENTS PARAMETERS                                 ;


### PR DESCRIPTION
## Description:
Enable Wifi Manager as a configuration portal for Ethernet boards, also leverage the Wifi Access point given in the configuration portal as a fallback connectivity method.

With this PR users can now use pre-built binaries with ethernet, wifi manager is used to configure the parameters, it is accessible through ethernet and the wifi access point.
The user can still add a Wifi Access point to connect, it will be used as a fallback connectivity method. The SSID and password can also be left blank to use only ethernet connection.

This PR is interesting for boards like the ThingPulse and Olimex gateways.

Add "visit" link to the WebUI from HA to make the configuration access easier and reduce key length
![image](https://github.com/1technophile/OpenMQTTGateway/assets/12672732/f465d276-6f12-4a1e-8020-40d14dfeec44)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
