### PR TITLE
[SYS] Implement a central queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules
 *.ps1
 main/certs/private*
+lib

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -774,6 +774,9 @@ bool isAduplicateSignal(SIGNAL_SIZE_UL_ULL);
 void storeSignalValue(SIGNAL_SIZE_UL_ULL);
 #endif
 
+// Origin topics
+#define subjectBTtoMQTT "/BTtoMQTT"
+
 #define convertTemp_CtoF(c) ((c * 1.8) + 32)
 #define convertTemp_FtoC(f) ((f - 32) * 5 / 9)
 

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -354,9 +354,6 @@ int lowpowermode = DEFAULT_LOW_POWER_MODE;
 //#define ZgatewayRS232   "RS232"  //ESP8266, Arduino, ESP32
 
 /*-------------DEFINE YOUR MQTT ADVANCED PARAMETERS BELOW----------------*/
-#ifndef version_Topic
-#  define version_Topic "/version"
-#endif
 #ifndef will_Topic
 #  define will_Topic "/LWT"
 #endif

--- a/main/ZactuatorONOFF.ino
+++ b/main/ZactuatorONOFF.ino
@@ -144,11 +144,10 @@ void MQTTtoONOFF(char* topicOri, JsonObject& ONOFFdata) {
       if (ONOFFConfig.useLastStateOnStart) {
         ONOFFdata["save"] = true;
         ONOFFConfig_fromJson(ONOFFdata);
-        ONOFFdata.remove("save");
       }
 #    endif
       // we acknowledge the sending by publishing the value to an acknowledgement topic
-      pub(subjectGTWONOFFtoMQTT, ONOFFdata);
+      stateONOFFMeasures();
     } else {
       if (ONOFFdata["cmd"] == "high_pulse") {
         Log.notice(F("MQTTtoONOFF high_pulse ok" CR));
@@ -290,10 +289,9 @@ void ActuatorTrigger() {
   if (ONOFFConfig.useLastStateOnStart) {
     ONOFFdata["save"] = true;
     ONOFFConfig_fromJson(ONOFFdata);
-    ONOFFdata.remove("save");
   }
 #  endif
-  pub(subjectGTWONOFFtoMQTT, ONOFFdata);
+  stateONOFFMeasures();
 }
 
 void stateONOFFMeasures() {
@@ -301,6 +299,7 @@ void stateONOFFMeasures() {
   StaticJsonDocument<64> jsonBuffer;
   JsonObject ONOFFdata = jsonBuffer.to<JsonObject>();
   ONOFFdata["cmd"] = (int)digitalRead(ACTUATOR_ONOFF_GPIO);
-  pub(subjectGTWONOFFtoMQTT, ONOFFdata);
+  ONOFFdata["origin"] = subjectGTWONOFFtoMQTT;
+  enqueueJsonObject(ONOFFdata);
 }
 #endif

--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -188,7 +188,6 @@ void MQTTtoSSD1306(char* topicOri, JsonObject& SSD1306data) { // json object dec
     if (success) {
       stateSSD1306Display();
     } else {
-      // pub(subjectSSD1306toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("[ SSD1306 ] MQTTtoSSD1306 Fail json" CR), SSD1306data);
     }
   }
@@ -459,15 +458,16 @@ void OledSerial::drawLogo(int xshift, int yshift) {
 
 String stateSSD1306Display() {
   //Publish display state
-  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-  JsonObject DISPLAYdata = jsonBuffer.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> DISPLAYdataBuffer;
+  JsonObject DISPLAYdata = DISPLAYdataBuffer.to<JsonObject>();
   DISPLAYdata["onstate"] = (bool)displayState;
   DISPLAYdata["brightness"] = (int)displayBrightness;
   DISPLAYdata["display-flip"] = (bool)displayFlip;
   DISPLAYdata["idlelogo"] = (bool)idlelogo;
   DISPLAYdata["log-oled"] = (bool)logToOLEDDisplay;
   DISPLAYdata["json-oled"] = (bool)jsonDisplay;
-  pub(subjectSSD1306toMQTT, DISPLAYdata);
+  DISPLAYdata["origin"] = subjectSSD1306toMQTT;
+  enqueueJsonObject(DISPLAYdata);
   // apply
   Oled.display->setBrightness(round(displayBrightness * 2.55));
 

--- a/main/Zgateway2G.ino
+++ b/main/Zgateway2G.ino
@@ -80,8 +80,8 @@ bool _2GtoMQTT() {
   // Get the memory locations of unread SMS messages.
   unreadSMSNum = A6l.getUnreadSMSLocs(unreadSMSLocs, 512);
   Log.trace(F("Creating SMS  buffer" CR));
-  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-  JsonObject SMSdata = jsonBuffer.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> SMSdataBuffer;
+  JsonObject SMSdata = SMSdataBuffer.to<JsonObject>();
   for (int i = 0; i < unreadSMSNum; i++) {
     Log.notice(F("New  message at index: %d" CR), unreadSMSNum);
     sms = A6l.readSMS(unreadSMSLocs[i]);
@@ -90,7 +90,8 @@ bool _2GtoMQTT() {
     SMSdata["phone"] = (const char*)sms.number.c_str();
     A6l.deleteSMS(unreadSMSLocs[i]); // we delete the SMS received
     Log.trace(F("Adv data 2GtoMQTT" CR));
-    pub(subject2GtoMQTT, SMSdata);
+    SMSdata["origin"] = subject2GtoMQTT;
+    enqueueJsonObject(SMSdata);
     return true;
   }
   return false;

--- a/main/ZgatewayBLEConnect.h
+++ b/main/ZgatewayBLEConnect.h
@@ -6,8 +6,6 @@
 #  include "NimBLEDevice.h"
 #  include "config_BT.h"
 
-extern void pubBT(JsonObject& data);
-
 class zBLEConnect {
 public:
   NimBLEClient* m_pClient;

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -120,7 +120,7 @@ bool zBLEConnect::processActions(std::vector<BLEAction>& actions) {
         it.complete = result;
         BLEdata["success"] = result;
         if (result || it.ttl <= 1) {
-          buildBTtopic(BLEdata);
+          buildTopicFromId(BLEdata, subjectBTtoMQTT);
           enqueueJsonObject(BLEdata);
         }
       }
@@ -160,7 +160,7 @@ void LYWSD03MMC_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pD
       BLEdata["hum"] = (float)(pData[2]);
       BLEdata["volt"] = (float)(((pData[4] * 256) + pData[3]) / 1000.0);
       BLEdata["batt"] = (float)(((((pData[4] * 256) + pData[3]) / 1000.0) - 2.1) * 100);
-      buildBTtopic(BLEdata);
+      buildTopicFromId(BLEdata, subjectBTtoMQTT);
       enqueueJsonObject(BLEdata);
     } else {
       Log.notice(F("Invalid notification data" CR));
@@ -225,7 +225,7 @@ void DT24_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, s
       BLEdata["price"] = (float)(((m_data[17] * 256 * 256) + (m_data[18] * 256) + m_data[19]) / 100.0);
       BLEdata["tempc"] = (float)(m_data[24] * 256) + m_data[25];
       BLEdata["tempf"] = (float)(convertTemp_CtoF((m_data[24] * 256) + m_data[25]));
-      buildBTtopic(BLEdata);
+      buildTopicFromId(BLEdata, subjectBTtoMQTT);
       enqueueJsonObject(BLEdata);
     } else {
       Log.notice(F("Invalid notification data" CR));
@@ -302,7 +302,7 @@ void BM2_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, si
       float volt = ((output[2] | (output[1] << 8)) >> 4) / 100.0f;
       BLEdata["volt"] = volt;
       Log.trace(F("volt: %F" CR), volt);
-      buildBTtopic(BLEdata);
+      buildTopicFromId(BLEdata, subjectBTtoMQTT);
       enqueueJsonObject(BLEdata);
     } else {
       Log.notice(F("Invalid notification data" CR));
@@ -360,7 +360,7 @@ void HHCCJCY01HHCC_connect::publishData() {
       BLEdata["model"] = "HHCCJCY01HHCC";
       BLEdata["id"] = (char*)mac_address.c_str();
       BLEdata["batt"] = (int)batteryValue;
-      buildBTtopic(BLEdata);
+      buildTopicFromId(BLEdata, subjectBTtoMQTT);
       enqueueJsonObject(BLEdata);
     } else {
       Log.notice(F("Failed getting characteristic" CR));
@@ -392,7 +392,7 @@ void XMWSDJ04MMC_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* p
       BLEdata["hum"] = (float)((pData[2] | (pData[3] << 8)) * 0.1);
       BLEdata["volt"] = (float)((pData[4] | (pData[5] << 8)) / 1000.0);
       BLEdata["batt"] = (float)((((pData[4] | (pData[5] << 8)) / 1000.0) - 2.1) * 100);
-      buildBTtopic(BLEdata);
+      buildTopicFromId(BLEdata, subjectBTtoMQTT);
       enqueueJsonObject(BLEdata);
     } else {
       Log.notice(F("Invalid notification data" CR));
@@ -489,7 +489,7 @@ bool SBS1_connect::processActions(std::vector<BLEAction>& actions) {
           JsonObject BLEdata = BLEdataBuffer.to<JsonObject>();
           BLEdata["id"] = it.addr;
           BLEdata["state"] = result ? it.value : it.value == "on" ? "off" : "on";
-          buildBTtopic(BLEdata);
+          buildTopicFromId(BLEdata, subjectBTtoMQTT);
           enqueueJsonObject(BLEdata);
         }
       }

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -872,7 +872,7 @@ void setupBTTasksAndBLE() {
   xTaskCreatePinnedToCore(
       procBLETask, /* Function to implement the task */
       "procBLETask", /* Name of the task */
-      7000, /* Stack size in bytes */
+      8000, /* Stack size in bytes */
       NULL, /* Task input parameter */
       2, /* Priority of the task (set higher than core task) */
       &xProcBLETaskHandle, /* Task handle. */

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -113,7 +113,7 @@ void btScanWDG() {
   if (!ProcessLock &&
       previousBtScanCount == scanCount &&
       scanCount != 0 &&
-      (now - lastBtScan > BTConfig.BLEinterval)) {
+      (now - lastBtScan > ((BTConfig.BLEinterval + BTConfig.scanDuration) < GeneralTimeOut ? GeneralTimeOut + 1000 : (BTConfig.BLEinterval + BTConfig.scanDuration)))) {
     Log.error(F("BLE Scan watchdog triggered at : %ds" CR), lastBtScan / 1000);
     stopProcessing();
     ESPRestart(4);
@@ -633,9 +633,10 @@ void procBLETask(void* pvParameters) {
         if (advertisedDevice->haveServiceData()) {
           int serviceDataCount = advertisedDevice->getServiceDataCount();
           Log.trace(F("Get services data number: %d" CR), serviceDataCount);
-          // Copy jsonObject
-          JsonObject BLEdataTemp = BLEdata;
           for (int j = 0; j < serviceDataCount; j++) {
+            StaticJsonDocument<JSON_MSG_BUFFER> BLEdataBufferTemp;
+            JsonObject BLEdataTemp = BLEdataBufferTemp.to<JsonObject>();
+            BLEdataBufferTemp = BLEdataBuffer;
             std::string service_data = convertServiceData(advertisedDevice->getServiceData(j));
             Log.trace(F("Service data: %s" CR), service_data.c_str());
             std::string serviceDatauuid = advertisedDevice->getServiceDataUUID(j).toString();

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -115,6 +115,7 @@ void btScanWDG() {
       scanCount != 0 &&
       (now - lastBtScan > BTConfig.BLEinterval)) {
     Log.error(F("BLE Scan watchdog triggered at : %ds" CR), lastBtScan / 1000);
+    stopProcessing();
     ESPRestart(4);
   } else {
     previousBtScanCount = scanCount;
@@ -148,10 +149,6 @@ String stateBTMeasures(bool start) {
   jo["ignoreWBlist"] = BTConfig.ignoreWBlist;
   jo["presenceawaytimer"] = BTConfig.presenceAwayTimer;
   jo["movingtimer"] = BTConfig.movingTimer;
-  jo["btqblck"] = btQueueBlocked;
-  jo["btqsum"] = btQueueLengthSum;
-  jo["btqsnd"] = btQueueLengthCount;
-  jo["btqavg"] = (btQueueLengthCount > 0 ? btQueueLengthSum / (float)btQueueLengthCount : 0);
   jo["bletaskstack"] = uxTaskGetStackHighWaterMark(xProcBLETaskHandle);
   jo["blecoretaskstack"] = uxTaskGetStackHighWaterMark(xCoreTaskHandle);
 
@@ -163,7 +160,8 @@ String stateBTMeasures(bool start) {
   }
   String output;
   serializeJson(jo, output);
-  pub(subjectBTtoMQTT, jo);
+  jo["origin"] = subjectBTtoMQTT;
+  enqueueJsonObject(jo);
   return (output);
 }
 
@@ -315,102 +313,9 @@ void BTConfig_load() {
   }
 }
 
-void pubBTMainCore(JsonObject& data, bool haPresenceEnabled = true) {
-  if (abs((int)data["rssi"] | 0) < abs(BTConfig.minRssi) && data.containsKey("id")) {
-    String topic = data["id"].as<const char*>();
-    topic.replace(":", ""); // Initially publish topic ends with MAC address
-    if (BTConfig.pubBeaconUuidForTopic && !BTConfig.extDecoderEnable && data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON")
-      topic = data["uuid"].as<const char*>(); // If model_id is IBEACON, use uuid as topic
-    if (BTConfig.extDecoderEnable && !data.containsKey("model"))
-      topic = BTConfig.extDecoderTopic; // If external decoder, use this topic to send data
-    topic = subjectBTtoMQTT + String("/") + topic;
-    pub((char*)topic.c_str(), data);
-  }
-  if (haPresenceEnabled && data.containsKey("distance")) {
-    if (data.containsKey("servicedatauuid"))
-      data.remove("servicedatauuid");
-    if (data.containsKey("servicedata"))
-      data.remove("servicedata");
-    if (BTConfig.presenceUseBeaconUuid && data.containsKey("model_id") && data["model_id"].as<String>() == "IBEACON") {
-      data["mac"] = data["id"];
-      data["id"] = data["uuid"];
-    }
-    String topic = String(mqtt_topic) + BTConfig.presenceTopic + String(gateway_name);
-    Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
-    pub_custom_topic((char*)topic.c_str(), data, false);
-  }
-}
-
-class JsonBundle {
-public:
-  StaticJsonDocument<JSON_MSG_BUFFER> buffer;
-  JsonObject object;
-  bool haPresence;
-
-  JsonObject& createObject(const char* json = NULL, bool haPresenceEnabled = true) {
-    buffer.clear();
-    haPresence = haPresenceEnabled;
-    object = buffer.to<JsonObject>();
-
-    if (json != nullptr) {
-      auto error = deserializeJson(buffer, json);
-      if (error) {
-        Log.error(F("deserialize object failed: %s" CR), error.c_str());
-      }
-    }
-    return object;
-  }
-};
-
 void PublishDeviceData(JsonObject& BLEdata);
 
 atomic_int forceBTScan;
-
-JsonBundle jsonBTBufferQueue[BTQueueSize];
-atomic_int jsonBTBufferQueueNext, jsonBTBufferQueueLast;
-int btQueueBlocked = 0;
-int btQueueLengthSum = 0;
-int btQueueLengthCount = 0;
-
-JsonObject& getBTJsonObject(const char* json, bool haPresenceEnabled) {
-  int next, last;
-  for (bool blocked = false;;) {
-    next = atomic_load_explicit(&jsonBTBufferQueueNext, ::memory_order_seq_cst); // use namespace std -> ambiguous error...
-    last = atomic_load_explicit(&jsonBTBufferQueueLast, ::memory_order_seq_cst); // use namespace std -> ambiguous error...
-    if ((2 * BTQueueSize + last - next) % (2 * BTQueueSize) != BTQueueSize) break;
-    if (!blocked) {
-      blocked = true;
-      btQueueBlocked++;
-    }
-    delay(1);
-  }
-  return jsonBTBufferQueue[last % BTQueueSize].createObject(json, haPresenceEnabled);
-}
-
-// should run from the BT core
-void pubBT(JsonObject& data) {
-  int last = atomic_load_explicit(&jsonBTBufferQueueLast, ::memory_order_seq_cst);
-  atomic_store_explicit(&jsonBTBufferQueueLast, (last + 1) % (2 * BTQueueSize), ::memory_order_seq_cst); // use namespace std -> ambiguous error...
-}
-
-// should run from the main core
-void emptyBTQueue() {
-  for (bool first = true;;) {
-    int next = atomic_load_explicit(&jsonBTBufferQueueNext, ::memory_order_seq_cst); // use namespace std -> ambiguous error...
-    int last = atomic_load_explicit(&jsonBTBufferQueueLast, ::memory_order_seq_cst); // use namespace std -> ambiguous error...
-    if (last == next) break;
-    if (first) {
-      int diff = (2 * BTQueueSize + last - next) % (2 * BTQueueSize);
-      btQueueLengthSum += diff;
-      btQueueLengthCount++;
-      first = false;
-    }
-    JsonBundle& bundle = jsonBTBufferQueue[next % BTQueueSize];
-    pubBTMainCore(bundle.object, bundle.haPresence);
-    atomic_store_explicit(&jsonBTBufferQueueNext, (next + 1) % (2 * BTQueueSize), ::memory_order_seq_cst); // use namespace std -> ambiguous error...
-    vTaskDelay(1);
-  }
-}
 
 void createOrUpdateDevice(const char* mac, uint8_t flags, int model, int mac_type = 0);
 
@@ -509,11 +414,13 @@ void updateDevicesStatus() {
                                     p->sensorModel_id == TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2)) { // We apply the offline status only for tracking device, can be extended further to all the devices
       if ((p->lastUpdate != 0) && (p->lastUpdate < (now - BTConfig.presenceAwayTimer) && (now > BTConfig.presenceAwayTimer)) &&
           (BTConfig.ignoreWBlist || ((!oneWhite || isWhite(p)) && !isBlack(p)))) { // Only if WBlist is disabled OR ((no white MAC OR this MAC is white) AND not a black listed MAC)) {
-        JsonObject BLEdata = getBTJsonObject();
+        StaticJsonDocument<JSON_MSG_BUFFER> BLEdataBuffer;
+        JsonObject BLEdata = BLEdataBuffer.to<JsonObject>();
         BLEdata["id"] = p->macAdr;
         BLEdata["state"] = "offline";
-        pubBT(BLEdata);
-        // We set the lastUpdate to 0 to avoid republishing the offline state
+        buildBTtopic(BLEdata);
+        enqueueJsonObject(BLEdata);
+        // We set the lastUpdate to 0 to avoid replublishing the offline state
         p->lastUpdate = 0;
       }
     }
@@ -521,11 +428,13 @@ void updateDevicesStatus() {
     if (p->sensorModel_id == TheengsDecoder::BLE_ID_NUM::BC08) {
       if ((p->lastUpdate != 0) && (p->lastUpdate < (now - BTConfig.movingTimer) && (now > BTConfig.movingTimer)) &&
           (BTConfig.ignoreWBlist || ((!oneWhite || isWhite(p)) && !isBlack(p)))) { // Only if WBlist is disabled OR ((no white MAC OR this MAC is white) AND not a black listed MAC)) {
-        JsonObject BLEdata = getBTJsonObject();
+        StaticJsonDocument<JSON_MSG_BUFFER> BLEdataBuffer;
+        JsonObject BLEdata = BLEdataBuffer.to<JsonObject>();
         BLEdata["id"] = p->macAdr;
         BLEdata["state"] = "offline";
-        pubBT(BLEdata);
-        // We set the lastUpdate to 0 to avoid republishing the offline state
+        buildBTtopic(BLEdata);
+        enqueueJsonObject(BLEdata);
+        // We set the lastUpdate to 0 to avoid replublishing the offline state
         p->lastUpdate = 0;
       }
     }
@@ -677,21 +586,61 @@ std::string convertServiceData(std::string deviceServiceData) {
   return spr;
 }
 
+void buildBTtopic(JsonObject& BLEdata) {
+  if (!BLEdata.containsKey("id")) {
+    Log.error(F("No id in BLEdata" CR));
+    return;
+  }
+
+  std::string topic = BLEdata["id"].as<std::string>();
+
+  // Replace ":" in topic
+  size_t pos = topic.find(":");
+  while (pos != std::string::npos) {
+    topic.erase(pos, 1);
+    pos = topic.find(":", pos);
+  }
+
+  if (BTConfig.pubBeaconUuidForTopic && !BTConfig.extDecoderEnable && BLEdata.containsKey("model_id") && BLEdata["model_id"].as<std::string>() == "IBEACON") {
+    if (BLEdata.containsKey("uuid")) {
+      topic = BLEdata["uuid"].as<std::string>();
+    } else {
+      Log.error(F("No uuid in BLEdata" CR));
+    }
+  }
+
+  if (BTConfig.extDecoderEnable && !BLEdata.containsKey("model"))
+    topic = BTConfig.extDecoderTopic.c_str();
+
+  std::string subjectStr(subjectBTtoMQTT);
+  topic = subjectStr + "/" + topic;
+
+  BLEdata["origin"] = topic;
+
+  Log.trace(F("Origin: %s" CR), BLEdata["origin"].as<const char*>());
+}
+
 void procBLETask(void* pvParameters) {
   BLEAdvertisedDevice* advertisedDevice = nullptr;
 
   for (;;) {
     xQueueReceive(BLEQueue, &advertisedDevice, portMAX_DELAY);
-
+    // Feed the watchdog
+    //esp_task_wdt_reset();
     if (!ProcessLock) {
       Log.trace(F("Creating BLE buffer" CR));
-      JsonObject& BLEdata = getBTJsonObject();
-      String mac_adress = advertisedDevice->getAddress().toString().c_str();
-      mac_adress.toUpperCase();
-      BLEdata["id"] = (char*)mac_adress.c_str();
+      StaticJsonDocument<JSON_MSG_BUFFER> BLEdataBuffer;
+      JsonObject BLEdata = BLEdataBuffer.to<JsonObject>();
+      std::string mac_address = advertisedDevice->getAddress().toString();
+
+      for (char& c : mac_address) {
+        c = std::toupper(c);
+      }
+
+      BLEdata["id"] = mac_address;
       BLEdata["mac_type"] = advertisedDevice->getAddress().getType();
       BLEdata["adv_type"] = advertisedDevice->getAdvType();
-      Log.notice(F("Device detected: %s" CR), (char*)mac_adress.c_str());
+      Log.notice(F("Device detected: %s" CR), BLEdata["id"].as<const char*>());
       BLEdevice* device = getDeviceByMac(BLEdata["id"].as<const char*>());
 
       if (BTConfig.filterConnectable && device->connect) {
@@ -718,31 +667,20 @@ void procBLETask(void* pvParameters) {
         if (advertisedDevice->haveServiceData()) {
           int serviceDataCount = advertisedDevice->getServiceDataCount();
           Log.trace(F("Get services data number: %d" CR), serviceDataCount);
-          char initialBLEDataCharArray[JSON_MSG_BUFFER];
-          serializeJson(BLEdata, initialBLEDataCharArray);
+          // Copy jsonObject
+          JsonObject BLEdataTemp = BLEdata;
           for (int j = 0; j < serviceDataCount; j++) {
             std::string service_data = convertServiceData(advertisedDevice->getServiceData(j));
             Log.trace(F("Service data: %s" CR), service_data.c_str());
             std::string serviceDatauuid = advertisedDevice->getServiceDataUUID(j).toString();
             Log.trace(F("Service data UUID: %s" CR), (char*)serviceDatauuid.c_str());
-            if (j == 0) {
-              BLEdata["servicedata"] = (char*)service_data.c_str();
-              BLEdata["servicedatauuid"] = (char*)serviceDatauuid.c_str();
-              PublishDeviceData(BLEdata);
-            } else {
-              StaticJsonDocument<JSON_MSG_BUFFER> doc;
-              deserializeJson(doc, initialBLEDataCharArray);
-              JsonObject& BLEdataTemp = getBTJsonObject();
-              BLEdataTemp = doc.as<JsonObject>();
-              BLEdataTemp["servicedata"] = (char*)service_data.c_str();
-              BLEdataTemp["servicedatauuid"] = (char*)serviceDatauuid.c_str();
-              PublishDeviceData(BLEdataTemp);
-            }
+            BLEdataTemp["servicedata"] = (char*)service_data.c_str();
+            BLEdataTemp["servicedatauuid"] = (char*)serviceDatauuid.c_str();
+            PublishDeviceData(BLEdataTemp);
           }
         } else {
           PublishDeviceData(BLEdata);
         }
-
       } else {
         Log.trace(F("Filtered MAC device" CR));
       }
@@ -757,7 +695,7 @@ void procBLETask(void* pvParameters) {
  */
 void BLEscan() {
   // Don't start the next scan until processing of previous results is complete.
-  while (uxQueueMessagesWaiting(BLEQueue)) {
+  while (uxQueueMessagesWaiting(BLEQueue) || jsonQueue.size() != 0) {
     yield();
   }
   Log.notice(F("Scan begin" CR));
@@ -967,7 +905,7 @@ void setupBTTasksAndBLE() {
   xTaskCreatePinnedToCore(
       procBLETask, /* Function to implement the task */
       "procBLETask", /* Name of the task */
-      5120, /* Stack size in bytes */
+      7000, /* Stack size in bytes */
       NULL, /* Task input parameter */
       2, /* Priority of the task (set higher than core task) */
       &xProcBLETaskHandle, /* Task handle. */
@@ -1000,8 +938,6 @@ void setupBT() {
   Log.notice(F("Moving Timer: %d" CR), BTConfig.movingTimer);
 
   atomic_init(&forceBTScan, 0); // in theory, we don't need this
-  atomic_init(&jsonBTBufferQueueNext, 0); // in theory, we don't need this
-  atomic_init(&jsonBTBufferQueueLast, 0); // in theory, we don't need this
 
   semaphoreCreateOrUpdateDevice = xSemaphoreCreateBinary();
   xSemaphoreGive(semaphoreCreateOrUpdateDevice);
@@ -1009,7 +945,7 @@ void setupBT() {
   semaphoreBLEOperation = xSemaphoreCreateBinary();
   xSemaphoreGive(semaphoreBLEOperation);
 
-  BLEQueue = xQueueCreate(32, sizeof(NimBLEAdvertisedDevice*));
+  BLEQueue = xQueueCreate(QueueSize, sizeof(NimBLEAdvertisedDevice*));
 
   setupBTTasksAndBLE();
 
@@ -1191,6 +1127,7 @@ void PublishDeviceData(JsonObject& BLEdata) {
     process_bledata(BLEdata);
     // If the device is a random MAC and pubRandomMACs is false we don't publish this payload
     if (!BTConfig.pubRandomMACs && (BLEdata["type"].as<string>()).compare("RMAC") == 0) {
+      Log.trace(F("Random MAC, device filtered" CR));
       return;
     }
     // If pubAdvData is false we don't publish the adv data
@@ -1209,21 +1146,38 @@ void PublishDeviceData(JsonObject& BLEdata) {
     }
     // If the device is not a sensor and pubOnlySensors is true we don't publish this payload
     if (!BTConfig.pubOnlySensors || BLEdata.containsKey("model") || BLEdata.containsKey("distance")) { // Identified device
-      pubBT(BLEdata);
+      buildBTtopic(BLEdata);
+      enqueueJsonObject(BLEdata);
+    } else {
+      Log.notice(F("Not a sensor device filtered" CR));
+      return;
     }
   } else if (BLEdata.containsKey("distance")) {
-    pubBT(BLEdata);
+    if (BLEdata.containsKey("servicedatauuid"))
+      BLEdata.remove("servicedatauuid");
+    if (BLEdata.containsKey("servicedata"))
+      BLEdata.remove("servicedata");
+    if (BLEdata.containsKey("manufacturerdata"))
+      BLEdata.remove("manufacturerdata");
+    if (BTConfig.presenceUseBeaconUuid && BLEdata.containsKey("model_id") && BLEdata["model_id"].as<String>() == "IBEACON") {
+      BLEdata["mac"] = BLEdata["id"];
+      BLEdata["id"] = BLEdata["uuid"];
+    }
+    enqueueJsonObject(BLEdata);
   } else {
-    Log.trace(F("Low rssi, device filtered" CR));
+    Log.notice(F("Low rssi, device filtered" CR));
+    return;
   }
 }
 
 void process_bledata(JsonObject& BLEdata) {
+  yield();
   if (!BLEdata.containsKey("id")) {
     Log.error(F("No mac address in the payload" CR));
     return;
   }
   const char* mac = BLEdata["id"].as<const char*>();
+  Log.trace(F("Processing BLE data %s" CR), BLEdata["id"].as<const char*>());
   int model_id = BTConfig.extDecoderEnable ? -1 : decoder.decodeBLEJson(BLEdata);
   int mac_type = BLEdata["mac_type"].as<int>();
   if ((BLEdata["type"].as<string>()).compare("RMAC") != 0 && model_id != TheengsDecoder::BLE_ID_NUM::IBEACON) { // Do not store in memory the random mac devices and iBeacons
@@ -1350,10 +1304,12 @@ void immediateBTAction(void* pvParameters) {
       xSemaphoreGive(semaphoreBLEOperation);
     } else {
       Log.error(F("BLE busy - command not sent" CR));
-      JsonObject result = getBTJsonObject();
-      result["id"] = BLEactions.back().addr;
-      result["success"] = false;
-      pubBT(result);
+      StaticJsonDocument<JSON_MSG_BUFFER> BLEdataBuffer;
+      JsonObject BLEdata = BLEdataBuffer.to<JsonObject>();
+      BLEdata["id"] = BLEactions.back().addr;
+      BLEdata["success"] = false;
+      buildBTtopic(BLEdata);
+      enqueueJsonObject(BLEdata);
       BLEactions.pop_back();
       ProcessLock = false;
     }

--- a/main/ZgatewayGFSunInverter.ino
+++ b/main/ZgatewayGFSunInverter.ino
@@ -30,8 +30,8 @@
 GfSun2000 GF = GfSun2000();
 
 void GFSunInverterDataHandler(GfSun2000Data data) {
-  StaticJsonDocument<2 * JSON_MSG_BUFFER> jsonBuffer;
-  JsonObject jdata = jsonBuffer.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> jdataBuffer;
+  JsonObject jdata = jdataBuffer.to<JsonObject>();
 
   jdata["device_id"] = (char*)data.deviceID;
   Log.trace(F("Device ID     : %s\n" CR), data.deviceID);
@@ -47,8 +47,8 @@ void GFSunInverterDataHandler(GfSun2000Data data) {
   Log.trace(F("Total Energy  : %.1f\tkW/h\n" CR), data.totalEnergyCounter);
 
 #  ifdef GFSUNINVERTER_DEVEL
-  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer2;
-  JsonObject jregister = jsonBuffer2.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> jregisterBuffer;
+  JsonObject jregister = jregisterBuffer.to<JsonObject>();
   char buffer[4];
   std::map<int16_t, int16_t>::iterator itr;
   for (itr = data.modbusRegistry.begin(); itr != data.modbusRegistry.end(); ++itr) {
@@ -58,19 +58,21 @@ void GFSunInverterDataHandler(GfSun2000Data data) {
   }
   jdata["register"] = jregister;
 #  endif
-  pub(subjectRFtoMQTT, jdata);
+  jdata["origin"] = subjectRFtoMQTT;
+  enqueueJsonObject(jdata);
 }
 
 void GFSunInverterErrorHandler(int errorId, char* errorMessage) {
   char buffer[50];
   sprintf(buffer, "Error response: %02X - %s\n", errorId, errorMessage);
   Log.error(buffer);
-  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-  JsonObject jdata = jsonBuffer.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> jdataBuffer;
+  JsonObject jdata = jdataBuffer.to<JsonObject>();
   jdata["status"] = "error";
   jdata["msg"] = errorMessage;
   jdata["id"] = errorId;
-  pub(subjectRFtoMQTT, jdata);
+  jdata["origin"] = subjectRFtoMQTT;
+  enqueueJsonObject(jdata);
 }
 
 void setupGFSunInverter() {

--- a/main/ZgatewayIR.ino
+++ b/main/ZgatewayIR.ino
@@ -115,8 +115,8 @@ void IRtoMQTT() {
 
   if (irrecv.decode(&results)) {
     Log.trace(F("Creating IR buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject IRdata = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> IRdataBuffer;
+    JsonObject IRdata = IRdataBuffer.to<JsonObject>();
 
     Log.trace(F("Rcv. IR" CR));
 #  ifdef ESP32
@@ -168,7 +168,8 @@ void IRtoMQTT() {
       Log.notice(F("--no pub unknwn prt--" CR));
     } else if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of IR -->MQTT
       Log.trace(F("Adv data IRtoMQTT" CR));
-      pub(subjectIRtoMQTT, IRdata);
+      IRdata["origin"] = subjectIRtoMQTT;
+      enqueueJsonObject(IRdata);
       Log.trace(F("Store val: %D" CR), MQTTvalue);
       storeSignalValue(MQTTvalue);
       if (repeatIRwMQTT) {
@@ -273,7 +274,8 @@ void MQTTtoIR(char* topicOri, JsonObject& IRdata) {
       }
       if (signalSent) { // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
         Log.notice(F("MQTTtoIR OK" CR));
-        pub(subjectGTWIRtoMQTT, IRdata);
+        IRdata["origin"] = subjectGTWIRtoMQTT;
+        enqueueJsonObject(IRdata);
       }
       irrecv.enableIRIn(); // ReStart the IR receiver (if not restarted it is not able to receive data)
     } else {

--- a/main/ZgatewayIR.ino
+++ b/main/ZgatewayIR.ino
@@ -274,8 +274,7 @@ void MQTTtoIR(char* topicOri, JsonObject& IRdata) {
       }
       if (signalSent) { // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
         Log.notice(F("MQTTtoIR OK" CR));
-        IRdata["origin"] = subjectGTWIRtoMQTT;
-        enqueueJsonObject(IRdata);
+        pub(subjectGTWIRtoMQTT, IRdata);
       }
       irrecv.enableIRIn(); // ReStart the IR receiver (if not restarted it is not able to receive data)
     } else {

--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -488,8 +488,7 @@ void MQTTtoLORA(char* topicOri, JsonObject& LORAdata) { // json object decoding
       LoRa.endPacket();
       Log.trace(F("MQTTtoLORA OK" CR));
       // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
-      LORAdata["origin"] = subjectGTWLORAtoMQTT;
-      enqueueJsonObject(LORAdata);
+      pub(subjectGTWLORAtoMQTT, LORAdata);
     } else {
       Log.error(F("MQTTtoLORA Fail json" CR));
     }

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -49,30 +49,35 @@ void pilightCallback(const String& protocol, const String& message, int status,
     JsonObject RFPiLightdata = RFPiLightdataBuffer.to<JsonObject>();
     StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer2;
     JsonObject msg = jsonBuffer2.to<JsonObject>();
-    auto error = deserializeJson(jsonBuffer2, message);
-    if (error) {
-      Log.error(F("deserializeJson() failed: %s" CR), error.c_str());
-      return;
+    if (message.length() > 0) {
+      auto error = deserializeJson(jsonBuffer2, message);
+      if (error) {
+        Log.error(F("deserializeJson() failed: %s" CR), error.c_str());
+        return;
+      }
+      RFPiLightdata["message"] = msg;
     }
-    RFPiLightdata["message"] = msg;
-    RFPiLightdata["protocol"] = (const char*)protocol.c_str();
-    RFPiLightdata["length"] = (const char*)deviceID.c_str();
+    if (protocol.length() > 0) {
+      RFPiLightdata["protocol"] = protocol;
+    }
+    if (deviceID.length() > 0) {
+      RFPiLightdata["value"] = deviceID;
+      const char* device_id = deviceID.c_str();
+      if (!strlen(device_id) && !msg.isNull()) {
+        // deviceID returned from Pilight is only extracted from id field
+        // but some device may use another name as unique identifier
+        char* choices[] = {"key", "unit", "device_id", "systemcode", "unitcode", "programcode"};
 
-    const char* device_id = deviceID.c_str();
-    if (!strlen(device_id)) {
-      // deviceID returned from Pilight is only extracted from id field
-      // but some device may use another name as unique identifier
-      char* choices[] = {"key", "unit", "device_id", "systemcode", "unitcode", "programcode"};
-
-      for (uint8_t i = 0; i < 6; i++) {
-        if (msg[choices[i]]) {
-          device_id = (const char*)msg[choices[i]];
-          break;
+        for (uint8_t i = 0; i < 6; i++) {
+          if (msg[choices[i]]) {
+            device_id = (const char*)msg[choices[i]];
+            break;
+          }
         }
       }
+      RFPiLightdata["value"] = device_id;
     }
 
-    RFPiLightdata["value"] = device_id;
     RFPiLightdata["repeats"] = (int)repeats;
     RFPiLightdata["status"] = (int)status;
     RFPiLightdata["origin"] = subjectPilighttoMQTT;

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -204,8 +204,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
 
     if (success) {
       // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
-      Pilightdata["origin"] = subjectGTWPilighttoMQTT;
-      enqueueJsonObject(Pilightdata);
+      pub(subjectGTWPilighttoMQTT, Pilightdata);
     } else {
       pub(subjectGTWPilighttoMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("MQTTtoPilightProtocol Fail json" CR));
@@ -309,8 +308,7 @@ void MQTTtoPilight(char* topicOri, JsonObject& Pilightdata) {
 #  endif
     if (success) {
       // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
-      Pilightdata["origin"] = subjectGTWPilighttoMQTT;
-      enqueueJsonObject(Pilightdata);
+      pub(subjectGTWPilighttoMQTT, Pilightdata);
     } else {
       pub(subjectGTWPilighttoMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("MQTTtoPilight Fail json" CR));

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -133,8 +133,8 @@ void setupRF() {
 
 void RFtoMQTT() {
   if (mySwitch.available()) {
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject RFdata = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> RFdataBuffer;
+    JsonObject RFdata = RFdataBuffer.to<JsonObject>();
     Log.trace(F("Rcv. RF" CR));
 #  ifdef ESP32
     Log.trace(F("RF Task running on core :%d" CR), xPortGetCoreID());
@@ -167,13 +167,15 @@ void RFtoMQTT() {
       if (SYSConfig.discovery)
         RFtoMQTTdiscovery(MQTTvalue);
 #  endif
-      pub(subjectRFtoMQTT, RFdata);
+      RFdata["origin"] = subjectRFtoMQTT;
+      enqueueJsonObject(RFdata);
       // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's
       Log.trace(F("Store val: %u" CR), (unsigned long)MQTTvalue);
       storeSignalValue(MQTTvalue);
       if (repeatRFwMQTT) {
         Log.trace(F("Pub RF for rpt" CR));
-        pub(subjectMQTTtoRF, RFdata);
+        RFdata["origin"] = subjectMQTTtoRF;
+        enqueueJsonObject(RFdata);
       }
     }
   }
@@ -274,7 +276,9 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       mySwitch.setProtocol(valuePRT, valuePLSL);
       mySwitch.send(data, valueBITS);
       Log.notice(F("MQTTtoRF OK" CR));
-      pub(subjectGTWRFtoMQTT, RFdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+      // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+      RFdata["origin"] = subjectGTWRFtoMQTT;
+      enqueueJsonObject(RFdata);
       mySwitch.setRepeatTransmit(RF_EMITTER_REPEAT); // Restore the default value
     } else {
       bool success = false;
@@ -292,7 +296,9 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       }
 #    endif
       if (success) {
-        pub(subjectGTWRFtoMQTT, RFdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+        // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+        RFdata["origin"] = subjectGTWRFtoMQTT;
+        enqueueJsonObject(RFdata);
       } else {
 #    ifndef ARDUINO_AVR_UNO // Space issues with the UNO
         pub(subjectGTWRFtoMQTT, "{\"Status\": \"Error\"}"); // Fail feedback

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -150,13 +150,16 @@ void RFtoMQTT() {
     RFdata["tre_state"] = bin2tristate(binary);
     RFdata["binary"] = binary;
 
+#  if defined(ESP32) || defined(ESP8266)
     unsigned int* raw = mySwitch.getReceivedRawdata();
-    String rawDump = "";
-    for (unsigned int i = 0; i <= length * 2; i++) {
-      rawDump = rawDump + String(raw[i]) + ",";
+    std::string rawDump;
+    for (unsigned int i = 0; i < length * 2; i++) {
+      if (i != 0)
+        rawDump += ",";
+      rawDump += std::to_string(raw[i]);
     }
-    RFdata["raw"] = rawDump.c_str();
-
+    RFdata["raw"] = rawDump;
+#  endif
 #  ifdef ZradioCC1101 // set Receive off and Transmitt on
     RFdata["mhz"] = receiveMhz;
 #  endif

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -280,8 +280,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       mySwitch.send(data, valueBITS);
       Log.notice(F("MQTTtoRF OK" CR));
       // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
-      RFdata["origin"] = subjectGTWRFtoMQTT;
-      enqueueJsonObject(RFdata);
+      pub(subjectGTWRFtoMQTT, RFdata);
       mySwitch.setRepeatTransmit(RF_EMITTER_REPEAT); // Restore the default value
     } else {
       bool success = false;
@@ -300,8 +299,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
 #    endif
       if (success) {
         // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
-        RFdata["origin"] = subjectGTWRFtoMQTT;
-        enqueueJsonObject(RFdata);
+        pub(subjectGTWRFtoMQTT, RFdata);
       } else {
 #    ifndef ARDUINO_AVR_UNO // Space issues with the UNO
         pub(subjectGTWRFtoMQTT, "{\"Status\": \"Error\"}"); // Fail feedback

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -118,10 +118,8 @@ void RF2toMQTTdiscovery(JsonObject& data) {
 
 void RF2toMQTT() {
   if (rf2rd.hasNewData) {
-    Log.trace(F("Creating RF2 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject RF2data = jsonBuffer.to<JsonObject>();
-
+    StaticJsonDocument<JSON_MSG_BUFFER> RF2dataBuffer;
+    JsonObject RF2data = RF2dataBuffer.to<JsonObject>();
     rf2rd.hasNewData = false;
 
     Log.trace(F("Rcv. RF2" CR));
@@ -134,8 +132,8 @@ void RF2toMQTT() {
     if (SYSConfig.discovery)
       RF2toMQTTdiscovery(RF2data);
 #  endif
-
-    pub(subjectRF2toMQTT, RF2data);
+    RF2data["origin"] = subjectRF2toMQTT;
+    enqueueJsonObject(RF2data);
   }
 }
 
@@ -327,7 +325,9 @@ void MQTTtoRF2(char* topicOri, JsonObject& RF2data) { // json object decoding
     }
 #    endif
     if (success) {
-      pub(subjectGTWRF2toMQTT, RF2data); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+      // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+      RF2data["origin"] = subjectGTWRF2toMQTT;
+      enqueueJsonObject(RF2data);
     } else {
 #    ifndef ARDUINO_AVR_UNO // Space issues with the UNO
       pub(subjectGTWRF2toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -326,8 +326,7 @@ void MQTTtoRF2(char* topicOri, JsonObject& RF2data) { // json object decoding
 #    endif
     if (success) {
       // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
-      RF2data["origin"] = subjectGTWRF2toMQTT;
-      enqueueJsonObject(RF2data);
+      pub(subjectRF2toMQTT, RF2data);
     } else {
 #    ifndef ARDUINO_AVR_UNO // Space issues with the UNO
       pub(subjectGTWRF2toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback

--- a/main/ZgatewayRFM69.ino
+++ b/main/ZgatewayRFM69.ino
@@ -141,9 +141,8 @@ void setupRFM69(void) {
 bool RFM69toMQTT(void) {
   //check if something was received (could be an interrupt from the radio)
   if (radio.receiveDone()) {
-    Log.trace(F("Creating RFM69 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject RFM69data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> RFM69dataBuffer;
+    JsonObject RFM69data = RFM69dataBuffer.to<JsonObject>();
     uint8_t data[RF69_MAX_DATA_LEN + 1]; // For the null character
     uint8_t SENDERID = radio.SENDERID;
     uint8_t DATALEN = radio.DATALEN;
@@ -216,7 +215,8 @@ void MQTTtoRFM69(char* topicOri, JsonObject& RFM69data) {
       if (radio.sendWithRetry(valueRCV, data, strlen(data), 10)) {
         Log.notice(F(" OK " CR));
         // Acknowledgement to the GTWRF topic
-        pub(subjectGTWRFM69toMQTT, RFM69data); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
+        RFM69data["origin"] = subjectGTWRFM69toMQTT;
+        enqueueJsonObject(RFM69data);
       } else {
         Log.error(F("MQTTtoRFM69 sending failed" CR));
       }

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -257,7 +257,8 @@ void rtl_433_Callback(char* message) {
     if (SYSConfig.discovery)
       storeRTL_433Discovery(RFrtl_433_ESPdata, (char*)model.c_str(), (char*)uniqueid.c_str());
 #  endif
-    pub((char*)topic.c_str(), RFrtl_433_ESPdata);
+    RFrtl_433_ESPdata["origin"] = (char*)topic.c_str();
+    enqueueJsonObject(RFrtl_433_ESPdata);
     storeSignalValue(MQTTvalue);
     pubOled((char*)topic.c_str(), RFrtl_433_ESPdata);
   }
@@ -321,7 +322,8 @@ extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
       success = true;
     }
     if (success) {
-      pub(subjectRTL_433toMQTT, RTLdata);
+      RTLdata["origin"] = subjectRTL_433toMQTT;
+      enqueueJsonObject(RTLdata);
     } else {
       pub(subjectRTL_433toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("[rtl_433] MQTTtoRTL_433 Fail json" CR));

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -322,8 +322,7 @@ extern void MQTTtoRTL_433(char* topicOri, JsonObject& RTLdata) {
       success = true;
     }
     if (success) {
-      RTLdata["origin"] = subjectRTL_433toMQTT;
-      enqueueJsonObject(RTLdata);
+      pub(subjectRTL_433toMQTT, RTLdata);
     } else {
       pub(subjectRTL_433toMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("[rtl_433] MQTTtoRTL_433 Fail json" CR));

--- a/main/ZgatewaySRFB.ino
+++ b/main/ZgatewaySRFB.ino
@@ -300,9 +300,7 @@ void MQTTtoSRFB(char* topicOri, JsonObject& SRFBdata) {
 
         Log.notice(F("MQTTtoSRFB OK" CR));
         _rfbSend(message_b, valueRPT);
-        // Acknowledgement to the GTWRF topic
-        SRFBdata["origin"] = subjectGTWSRFBtoMQTT;
-        enqueueJsonObject(SRFBdata);
+        pub(subjectGTWSRFBtoMQTT, SRFBdata); // we acknowledge the sending by publishing the value to an acknowledgement topic, for the moment even if it is a signal repetition we acknowledge also
       } else {
         Log.error(F("MQTTtoSRFB error decoding value" CR));
       }

--- a/main/ZgatewayWeatherStation.ino
+++ b/main/ZgatewayWeatherStation.ino
@@ -36,11 +36,12 @@ void PairedDeviceAdded(byte newID) {
   Serial.print("ZgatewayWeatherStation: New device paired ");
   Serial.println(newID, DEC);
 #  endif
-  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-  JsonObject RFdata = jsonBuffer.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> RFdataBuffer;
+  JsonObject RFdata = RFdataBuffer.to<JsonObject>();
   RFdata["sensor"] = newID;
   RFdata["action"] = "paired";
-  pub(subjectRFtoMQTT, RFdata);
+  RFdata["origin"] = subjectRFtoMQTT;
+  enqueueJsonObject(RFdata);
   wsdr.pair(NULL, PairedDeviceAdded);
 }
 
@@ -54,12 +55,13 @@ void setupWeatherStation() {
 void sendWindSpeedData(byte id, float wind_speed, byte battery_status) {
   unsigned long MQTTvalue = 10000 + round(wind_speed);
   if (!isAduplicateSignal(MQTTvalue)) { // conditions to avoid duplications of RF -->MQTT
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject RFdata = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> RFdataBuffer;
+    JsonObject RFdata = RFdataBuffer.to<JsonObject>();
     RFdata["sensor"] = id;
     RFdata["wind_speed"] = wind_speed;
     RFdata["battery"] = bitRead(battery_status, 0) == 0 ? "OK" : "Low";
-    pub(subjectRFtoMQTT, RFdata);
+    RFdata["origin"] = subjectRFtoMQTT;
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store wind speed val: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }
@@ -68,12 +70,13 @@ void sendWindSpeedData(byte id, float wind_speed, byte battery_status) {
 void sendRainData(byte id, float rain_volume, byte battery_status) {
   unsigned long MQTTvalue = 11000 + round(rain_volume * 10.0);
   if (!isAduplicateSignal(MQTTvalue)) { // conditions to avoid duplications of RF -->MQTT
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject RFdata = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> RFdataBuffer;
+    JsonObject RFdata = RFdataBuffer.to<JsonObject>();
     RFdata["sensor"] = id;
     RFdata["rain_volume"] = rain_volume;
     RFdata["battery"] = bitRead(battery_status, 1) == 0 ? "OK" : "Low";
-    pub(subjectRFtoMQTT, RFdata);
+    RFdata["origin"] = subjectRFtoMQTT;
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store rain_volume: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }
@@ -82,13 +85,14 @@ void sendRainData(byte id, float rain_volume, byte battery_status) {
 void sendWindData(byte id, int wind_direction, float wind_gust, byte battery_status) {
   unsigned long MQTTvalue = 20000 + round(wind_gust * 10.0) + wind_direction;
   if (!isAduplicateSignal(MQTTvalue)) { // conditions to avoid duplications of RF -->MQTT
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject RFdata = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> RFdataBuffer;
+    JsonObject RFdata = RFdataBuffer.to<JsonObject>();
     RFdata["sensor"] = id;
     RFdata["wind_direction"] = wind_direction;
     RFdata["wind_gust"] = wind_gust;
     RFdata["battery"] = bitRead(battery_status, 0) == 0 ? "OK" : "Low";
-    pub(subjectRFtoMQTT, RFdata);
+    RFdata["origin"] = subjectRFtoMQTT;
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store wind data val: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }
@@ -97,14 +101,15 @@ void sendWindData(byte id, int wind_direction, float wind_gust, byte battery_sta
 void sendTemperatureData(byte id, float temperature, int humidity, byte battery_status) {
   unsigned long MQTTvalue = 40000 + abs(round(temperature * 100.0)) + humidity;
   if (!isAduplicateSignal(MQTTvalue)) { // conditions to avoid duplications of RF -->MQTT
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject RFdata = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> RFdataBuffer;
+    JsonObject RFdata = RFdataBuffer.to<JsonObject>();
     RFdata["sensor"] = id;
     RFdata["tempc"] = temperature;
     RFdata["tempf"] = wsdr.convertCtoF(temperature);
     RFdata["humidity"] = humidity;
     RFdata["battery"] = bitRead(battery_status, 0) == 0 ? "OK" : "Low";
-    pub(subjectRFtoMQTT, RFdata);
+    RFdata["origin"] = subjectRFtoMQTT;
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store temp val: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }

--- a/main/ZsensorADC.ino
+++ b/main/ZsensorADC.ino
@@ -64,8 +64,8 @@ void MeasureADC() {
       if (val >= persistedadc + ThresholdReadingADC || val <= persistedadc - ThresholdReadingADC || (MinTimeInSecBetweenPublishingADC > 0 && millis() - timeadcpub > (MinTimeInSecBetweenPublishingADC * 1000UL))) {
         timeadcpub = millis();
         Log.trace(F("Creating ADC buffer" CR));
-        StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-        JsonObject ADCdata = jsonBuffer.to<JsonObject>();
+        StaticJsonDocument<JSON_MSG_BUFFER> ADCdataBuffer;
+        JsonObject ADCdata = ADCdataBuffer.to<JsonObject>();
         ADCdata["adc"] = (int)val;
         if (NumberOfReadingsADC > 1) {
           ADCdata["adc_reads"] = NumberOfReadingsADC;
@@ -93,7 +93,8 @@ void MeasureADC() {
         ADCdata["adc_sum"] = (int)sum_val;
         ADCdata["mvolt_scaled"] = (int)voltage; // real scaled/calibrated value in mV
 #  endif
-        pub(ADCTOPIC, ADCdata);
+        ADCdata["origin"] = ADCTOPIC;
+        enqueueJsonObject(ADCdata);
         persistedadc = val;
       }
     }

--- a/main/ZsensorAHTx0.ino
+++ b/main/ZsensorAHTx0.ino
@@ -86,8 +86,8 @@ void MeasureAHTTempHum() {
       Log.error(F("Failed to read from sensor AHTx0!" CR));
     } else {
       Log.notice(F("Creating AHTx0 buffer" CR));
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject AHTx0data = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> AHTx0dataBuffer;
+      JsonObject AHTx0data = AHTx0dataBuffer.to<JsonObject>();
       // Generate Temperature in degrees C
       if (ahtTempC.temperature != persisted_aht_tempc || AHTx0_always) {
         float ahtTempF = convertTemp_CtoF(ahtTempC.temperature);
@@ -103,10 +103,8 @@ void MeasureAHTTempHum() {
       } else {
         Log.notice(F("Same Humidity. Don't send it" CR));
       }
-
-      if (AHTx0data.size() > 0) {
-        pub(AHTTOPIC, AHTx0data);
-      }
+      AHTx0data["origin"] = AHTTOPIC;
+      enqueueJsonObject(AHTx0data);
     }
     persisted_aht_tempc = ahtTempC.temperature;
     persisted_aht_hum = ahtHum.relative_humidity;

--- a/main/ZsensorBH1750.ino
+++ b/main/ZsensorBH1750.ino
@@ -54,8 +54,8 @@ void setupZsensorBH1750() {
 void MeasureLightIntensity() {
   if (millis() > (timebh1750 + TimeBetweenReadingBH1750)) { //retrieving value of Lux, FtCd and Wattsm2 from BH1750
     Log.trace(F("Creating BH1750 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject BH1750data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> BH1750dataBuffer;
+    JsonObject BH1750data = BH1750dataBuffer.to<JsonObject>();
 
     timebh1750 = millis();
     unsigned int i = 0;
@@ -100,8 +100,8 @@ void MeasureLightIntensity() {
       } else {
         Log.trace(F("Same wattsm2 don't send it" CR));
       }
-      if (BH1750data.size() > 0)
-        pub(subjectBH1750toMQTT, BH1750data);
+      BH1750data["origin"] = subjectBH1750toMQTT;
+      enqueueJsonObject(BH1750data);
     }
     persistedll = Lux;
     persistedlf = ftcd;

--- a/main/ZsensorBME280.ino
+++ b/main/ZsensorBME280.ino
@@ -147,8 +147,8 @@ void MeasureTempHumAndPressure() {
       Log.error(F("Failed to read from BME280/BMP280!" CR));
     } else {
       Log.trace(F("Creating BME280/BMP280 buffer" CR));
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject BME280data = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> BME280dataBuffer;
+      JsonObject BME280data = BME280dataBuffer.to<JsonObject>();
       // Generate Temperature in degrees C
       if (BmeTempC != persisted_bme_tempc || bme280_always) {
         BME280data["tempc"] = (float)BmeTempC;
@@ -191,9 +191,8 @@ void MeasureTempHumAndPressure() {
       } else {
         Log.trace(F("Same Altitude Feet don't send it" CR));
       }
-      if (BME280data.size() > 0) {
-        pub(BMETOPIC, BME280data);
-      }
+      BME280data["origin"] = BMETOPIC;
+      enqueueJsonObject(BME280data);
     }
 
     persisted_bme_tempc = BmeTempC;

--- a/main/ZsensorC37_YL83_HMRD.ino
+++ b/main/ZsensorC37_YL83_HMRD.ino
@@ -53,8 +53,8 @@ void MeasureC37_YL83_HMRDWater() {
     int sensorAnalogValue = analogRead(C37_YL83_HMRD_Analog_GPIO);
 
     Log.trace(F("Creating C37_YL83_HMRD buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject C37_YL83_HMRDdata = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> C37_YL83_HMRDdataBuffer;
+    JsonObject C37_YL83_HMRDdata = C37_YL83_HMRDdataBuffer.to<JsonObject>();
     if (sensorDigitalValue != persisteddigital || C37_YL83_HMRD_ALWAYS) {
       C37_YL83_HMRDdata["detected"] = (sensorDigitalValue == 1 ? "false" : "true");
     } else {
@@ -66,7 +66,8 @@ void MeasureC37_YL83_HMRDWater() {
       Log.trace(F("Same analog don't send it" CR));
     }
     if (C37_YL83_HMRDdata.size() > 0) {
-      pub(C37_YL83_HMRD_TOPIC, C37_YL83_HMRDdata);
+      C37_YL83_HMRDdata["origin"] = C37_YL83_HMRD_TOPIC;
+      enqueueJsonObject(C37_YL83_HMRDdata);
       delay(10);
 #  if defined(DEEP_SLEEP_IN_US) || defined(ESP32_EXT0_WAKE_PIN)
       if (sensorDigitalValue == 1) //No water detected, all good we can sleep

--- a/main/ZsensorDHT.ino
+++ b/main/ZsensorDHT.ino
@@ -55,8 +55,8 @@ void MeasureTempAndHum() {
       Log.error(F("Failed to read from DHT sensor!" CR));
     } else {
       Log.trace(F("Creating DHT buffer" CR));
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject DHTdata = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> DHTdataBuffer;
+      JsonObject DHTdata = DHTdataBuffer.to<JsonObject>();
       if (h != persistedh || dht_always) {
         DHTdata["hum"] = (float)h;
       } else {
@@ -68,8 +68,8 @@ void MeasureTempAndHum() {
       } else {
         Log.trace(F("Same temp don't send it" CR));
       }
-      if (DHTdata.size() > 0)
-        pub(DHTTOPIC, DHTdata);
+      DHTdata["origin"] = DHTTOPIC;
+      enqueueJsonObject(DHTdata);
     }
     persistedh = h;
     persistedt = t;

--- a/main/ZsensorDS1820.ino
+++ b/main/ZsensorDS1820.ino
@@ -140,8 +140,8 @@ void MeasureDS1820Temp() {
       Log.error(F("DS1820: Failed to identify any temperature sensors on 1-wire bus during setup!" CR));
     } else {
       Log.trace(F("DS1820: Reading temperature(s) from %d sensor(s)..." CR), ds1820_count);
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject DS1820data = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> DS1820dataBuffer;
+      JsonObject DS1820data = DS1820dataBuffer.to<JsonObject>();
 
       for (uint8_t i = 0; i < ds1820_count; i++) {
         current_temp[i] = round(ds1820.getTempC(ds1820_devices[i]) * 10) / 10.0;
@@ -156,7 +156,9 @@ void MeasureDS1820Temp() {
             DS1820data["res"] = String(ds1820_resolution[i]) + String("bit");
             DS1820data["addr"] = ds1820_addr[i];
           }
-          pub((char*)(String(OW_TOPIC) + "/" + ds1820_addr[i]).c_str(), DS1820data);
+          String origin = String(OW_TOPIC) + "/" + ds1820_addr[i];
+          DS1820data["origin"] = origin;
+          enqueueJsonObject(DS1820data);
           delay(10);
 #  if defined(DEEP_SLEEP_IN_US) || defined(ESP32_EXT0_WAKE_PIN)
           ready_to_sleep = true;

--- a/main/ZsensorGPIOInput.ino
+++ b/main/ZsensorGPIOInput.ino
@@ -85,16 +85,16 @@ void MeasureGPIOInput() {
     // if the Input state has changed:
     if (reading != InputState) {
       Log.trace(F("Creating GPIOInput buffer" CR));
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject GPIOdata = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> GPIOdataBuffer;
+      JsonObject GPIOdata = GPIOdataBuffer.to<JsonObject>();
       if (InputState == HIGH) {
         GPIOdata["gpio"] = "HIGH";
       }
       if (InputState == LOW) {
         GPIOdata["gpio"] = "LOW";
       }
-      if (GPIOdata.size() > 0)
-        pub(subjectGPIOInputtoMQTT, GPIOdata);
+      GPIOdata["origin"] = subjectGPIOInputtoMQTT;
+      enqueueJsonObject(GPIOdata);
 
 #  if defined(ZactuatorONOFF) && defined(ACTUATOR_TRIGGER)
       //Trigger the actuator if we are not at startup

--- a/main/ZsensorHCSR04.ino
+++ b/main/ZsensorHCSR04.ino
@@ -44,8 +44,8 @@ void MeasureDistance() {
   if (millis() > (timeHCSR04 + TimeBetweenReadingHCSR04)) {
     timeHCSR04 = millis();
     Log.trace(F("Creating HCSR04 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject HCSR04data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> HCSR04dataBuffer;
+    JsonObject HCSR04data = HCSR04dataBuffer.to<JsonObject>();
     digitalWrite(HCSR04_TRI_GPIO, LOW);
     delayMicroseconds(2);
     digitalWrite(HCSR04_TRI_GPIO, HIGH);
@@ -69,8 +69,8 @@ void MeasureDistance() {
         Log.trace(F("HC SR04 Distance hasn't changed" CR));
       }
       distance = d;
-      if (HCSR04data.size() > 0)
-        pub(subjectHCSR04, HCSR04data);
+      HCSR04data["origin"] = subjectHCSR04;
+      enqueueJsonObject(HCSR04data);
     }
   }
 }

--- a/main/ZsensorHCSR501.ino
+++ b/main/ZsensorHCSR501.ino
@@ -41,8 +41,8 @@ void setupHCSR501() {
 
 void MeasureHCSR501() {
   if (millis() > TimeBeforeStartHCSR501) { //let time to init the PIR sensor
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject HCSR501data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> HCSR501dataBuffer;
+    JsonObject HCSR501data = HCSR501dataBuffer.to<JsonObject>();
     static int pirState = LOW;
     int PresenceValue = digitalRead(HCSR501_GPIO);
 #  if defined(ESP8266) || defined(ESP32)
@@ -64,8 +64,8 @@ void MeasureHCSR501() {
 #  ifdef HCSR501_LED_NOTIFY_GPIO
     digitalWrite(HCSR501_LED_NOTIFY_GPIO, pirState == HCSR501_LED_ON);
 #  endif
-    if (HCSR501data.size() > 0)
-      pub(subjectHCSR501toMQTT, HCSR501data);
+    HCSR501data["origin"] = subjectHCSR501toMQTT;
+    enqueueJsonObject(HCSR501data);
   }
 }
 #endif

--- a/main/ZsensorHTU21.ino
+++ b/main/ZsensorHTU21.ino
@@ -83,8 +83,8 @@ void MeasureTempHum() {
       Log.error(F("Failed to read from sensor HTU21!" CR));
     } else {
       Log.notice(F("Creating HTU21 buffer" CR));
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject HTU21data = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> HTU21dataBuffer;
+      JsonObject HTU21data = HTU21dataBuffer.to<JsonObject>();
       // Generate Temperature in degrees C
       if (HtuTempC != persisted_htu_tempc || htu21_always) {
         float HtuTempF = (HtuTempC * 1.8) + 32;
@@ -100,9 +100,8 @@ void MeasureTempHum() {
       } else {
         Log.notice(F("Same Humidity. Don't send it" CR));
       }
-
-      if (HTU21data.size() > 0)
-        pub(HTUTOPIC, HTU21data);
+      HTU21data["origin"] = HTUTOPIC;
+      enqueueJsonObject(HTU21data);
     }
     persisted_htu_tempc = HtuTempC;
     persisted_htu_hum = HtuHum;

--- a/main/ZsensorINA226.ino
+++ b/main/ZsensorINA226.ino
@@ -53,8 +53,8 @@ void MeasureINA226() {
   if (millis() > (timeINA226 + TimeBetweenReadingINA226)) { //retrieving value of temperature and humidity of the box from DHT every xUL
     timeINA226 = millis();
     Log.trace(F("Creating INA226 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject INA226data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> INA226dataBuffer;
+    JsonObject INA226data = INA226dataBuffer.to<JsonObject>();
     // Topic on which we will send data
     Log.trace(F("Retrieving electrical data" CR));
     // Bus Spannung, read-only, 16Bit, 0...40.96V max., LSB 1.25mV
@@ -72,7 +72,8 @@ void MeasureINA226() {
     INA226data["volt"] = volt;
     INA226data["current"] = current;
     INA226data["power"] = power;
-    pub(subjectINA226toMQTT, INA226data);
+    INA226data["origin"] = subjectINA226toMQTT;
+    enqueueJsonObject(INA226data);
   }
 }
 

--- a/main/ZsensorLM75.ino
+++ b/main/ZsensorLM75.ino
@@ -80,14 +80,15 @@ void MeasureTemp() {
       Log.error(F("Failed to read from sensor HLM75!" CR));
     } else {
       Log.notice(F("Creating LM75 buffer" CR));
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject LM75data = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> LM75dataBuffer;
+      JsonObject LM75data = LM75dataBuffer.to<JsonObject>();
       // Generate Temperature in degrees C
       if (lm75TempC != persisted_lm75_tempc || lm75_always) {
         float lm75TempF = (lm75TempC * 1.8) + 32;
         LM75data["tempc"] = (float)lm75TempC;
         LM75data["tempf"] = (float)lm75TempF;
-        pub(LM75TOPIC, LM75data);
+        LM75data["origin"] = LM75TOPIC;
+        enqueueJsonObject(LM75data);
       } else {
         Log.notice(F("Same Temp. Don't send it" CR));
       }

--- a/main/ZsensorMQ2.ino
+++ b/main/ZsensorMQ2.ino
@@ -61,13 +61,13 @@ void MeasureGasMQ2() {
     timemq2 = millis();
 
     Log.trace(F("Creating MQ2 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject MQ2data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> MQ2dataBuffer;
+    JsonObject MQ2data = MQ2dataBuffer.to<JsonObject>();
 
     MQ2data["gas"] = analogRead(MQ2SENSORADCPIN);
     MQ2data["detected"] = digitalRead(MQ2SENSORDETECTPIN) == HIGH ? "false" : "true";
-
-    pub(subjectMQ2toMQTT, MQ2data);
+    MQ2data["origin"] = subjectMQ2toMQTT;
+    enqueueJsonObject(MQ2data);
   }
 }
 #endif

--- a/main/ZsensorSHTC3.ino
+++ b/main/ZsensorSHTC3.ino
@@ -47,8 +47,8 @@ void MeasureTempAndHum() {
         Log.error(F("Failed to read from SHTC3 sensor!" CR));
       } else {
         Log.trace(F("Creating SHTC3 buffer" CR));
-        StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-        JsonObject SHTC3data = jsonBuffer.to<JsonObject>();
+        StaticJsonDocument<JSON_MSG_BUFFER> SHTC3dataBuffer;
+        JsonObject SHTC3data = SHTC3dataBuffer.to<JsonObject>();
         if (h != persistedh || shtc3_always) {
           SHTC3data["hum"] = (float)h;
         } else {
@@ -60,8 +60,8 @@ void MeasureTempAndHum() {
         } else {
           Log.trace(F("Same temp don't send it" CR));
         }
-        if (SHTC3data.size() > 0)
-          pub(SHTC3TOPIC, SHTC3data);
+        SHTC3data["origin"] = SHTC3TOPIC;
+        enqueueJsonObject(SHTC3data);
       }
       persistedh = h;
       persistedt = t;

--- a/main/ZsensorTEMT6000.ino
+++ b/main/ZsensorTEMT6000.ino
@@ -53,8 +53,8 @@ void MeasureLightIntensityTEMT6000() {
     timetemt6000 = millis();
 
     Log.trace(F("Creating TEMT6000 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject TEMT6000data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> TEMT6000dataBuffer;
+    JsonObject TEMT6000data = TEMT6000dataBuffer.to<JsonObject>();
 
     float volts = analogRead(TEMT6000LIGHTSENSORPIN) * 5.0 / 1024.0;
     float amps = volts / 10000.0; // across 10,000 Ohms
@@ -67,8 +67,8 @@ void MeasureLightIntensityTEMT6000() {
       TEMT6000data["lux"] = (float)lux;
       TEMT6000data["ftcd"] = (float)(lux) / 10.764;
       TEMT6000data["wattsm2"] = (float)(lux) / 683.0;
-
-      pub(subjectTEMT6000toMQTT, TEMT6000data);
+      TEMT6000data["origin"] = subjectTEMT6000toMQTT;
+      enqueueJsonObject(TEMT6000data);
     } else {
       Log.trace(F("Same lux value, do not send" CR));
     }

--- a/main/ZsensorTSL2561.ino
+++ b/main/ZsensorTSL2561.ino
@@ -90,8 +90,8 @@ void MeasureLightIntensityTSL2561() {
     timetsl2561 = millis();
 
     Log.trace(F("Creating TSL2561 buffer" CR));
-    StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-    JsonObject TSL2561data = jsonBuffer.to<JsonObject>();
+    StaticJsonDocument<JSON_MSG_BUFFER> TSL2561dataBuffer;
+    JsonObject TSL2561data = TSL2561dataBuffer.to<JsonObject>();
 
     sensors_event_t event;
     tsl.getEvent(&event);
@@ -104,8 +104,8 @@ void MeasureLightIntensityTSL2561() {
         TSL2561data["lux"] = (float)event.light;
         TSL2561data["ftcd"] = (float)(event.light) / 10.764;
         TSL2561data["wattsm2"] = (float)(event.light) / 683.0;
-
-        pub(subjectTSL12561toMQTT, TSL2561data);
+        TSL2561data["origin"] = subjectTSL12561toMQTT;
+        enqueueJsonObject(TSL2561data);
       } else {
         Log.trace(F("Same lux value, do not send" CR));
       }

--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -624,8 +624,8 @@ void handleWI() {
       return;
 
     } else if (server.hasArg("save")) {
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject WEBtoSYS = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> WEBtoSYSBuffer;
+      JsonObject WEBtoSYS = WEBtoSYSBuffer.to<JsonObject>();
       bool update = false;
       if (server.hasArg("s1")) {
         WEBtoSYS["wifi_ssid"] = server.arg("s1");
@@ -705,8 +705,8 @@ void handleMQ() {
       WEBUI_TRACE_LOG(F("handleMQ Arg: %d, %s=%s" CR), i, server.argName(i).c_str(), server.arg(i).c_str());
     }
     if (server.hasArg("save")) {
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject WEBtoSYS = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> WEBtoSYSBuffer;
+      JsonObject WEBtoSYS = WEBtoSYSBuffer.to<JsonObject>();
       bool update = false;
 
       if (server.hasArg("mh")) {
@@ -1567,7 +1567,6 @@ void MQTTtoWebUI(char* topicOri, JsonObject& WebUIdata) { // json object decodin
     if (success) {
       stateWebUIStatus();
     } else {
-      // pub(subjectWebUItoMQTT, "{\"Status\": \"Error\"}"); // Fail feedback
       Log.error(F("[ WebUI ] MQTTtoWebUI Fail json" CR), WebUIdata);
     }
   }
@@ -1575,8 +1574,8 @@ void MQTTtoWebUI(char* topicOri, JsonObject& WebUIdata) { // json object decodin
 
 String stateWebUIStatus() {
   //Publish display state
-  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-  JsonObject WebUIdata = jsonBuffer.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> WebUIdataBuffer;
+  JsonObject WebUIdata = WebUIdataBuffer.to<JsonObject>();
   WebUIdata["displayMetric"] = (bool)displayMetric;
   WebUIdata["webUISecure"] = (bool)webUISecure;
   WebUIdata["displayQueue"] = uxQueueMessagesWaiting(webUIQueue);
@@ -1585,7 +1584,8 @@ String stateWebUIStatus() {
   serializeJson(WebUIdata, output);
 
   // WebUIdata["currentMessage"] = currentWebUIMessage;
-  pub(subjectWebUItoMQTT, WebUIdata);
+  WebUIdata["origin"] = subjectWebUItoMQTT;
+  enqueueJsonObject(WebUIdata);
   return output;
 }
 

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -29,16 +29,13 @@
 extern void setupBT();
 extern bool BTtoMQTT();
 extern void MQTTtoBT(char* topicOri, JsonObject& RFdata);
-extern void emptyBTQueue();
+extern void pubMainCore(JsonObject& data);
 extern void launchBTDiscovery(bool overrideDiscovery);
 extern void stopProcessing();
 extern void lowPowerESP32();
 extern String stateBTMeasures(bool);
 
 #ifdef ESP32
-extern int btQueueBlocked;
-extern int btQueueLengthSum;
-extern int btQueueLengthCount;
 #  include "NimBLEDevice.h"
 #endif
 
@@ -117,10 +114,6 @@ extern int btQueueLengthCount;
 
 #ifndef HassPresence
 #  define HassPresence false //false if we publish into Home Assistant presence topic
-#endif
-
-#ifndef BTQueueSize
-#  define BTQueueSize 4 // lockless queue size for multi core cases (ESP32 currently)
 #endif
 
 #define HMSerialSpeed 9600 // Communication speed with the HM module, softwareserial doesn't support 115200
@@ -235,7 +228,5 @@ public:
     MAX,
   };
 };
-
-JsonObject& getBTJsonObject(const char* json = NULL, bool haPresenceEnabled = true);
 
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -60,6 +60,12 @@ unsigned long timer_sys_checks = 0;
 
 #  define ARDUINOJSON_USE_LONG_LONG     1
 #  define ARDUINOJSON_ENABLE_STD_STRING 1
+
+#  include <queue>
+#  ifndef QueueSize
+#    define QueueSize 32
+#  endif
+
 #endif
 
 /**
@@ -75,6 +81,15 @@ bool ready_to_sleep = false;
 #include <PubSubClient.h>
 
 #include <string>
+
+#if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
+struct JsonBundle {
+  StaticJsonDocument<JSON_MSG_BUFFER> doc;
+};
+
+std::queue<JsonBundle> jsonQueue;
+int queueLengthSum = 0;
+#endif
 
 StaticJsonDocument<JSON_MSG_BUFFER> modulesBuffer;
 JsonArray modules = modulesBuffer.to<JsonArray>();
@@ -389,6 +404,67 @@ bool to_bool(String const& s) { // thanks Chris Jester-Young from stackoverflow
   return s != "0";
 }
 
+/*
+ * Publish a message depending on its origin
+ *
+*/
+void pubMainCore(JsonObject& data) {
+  if (data.containsKey("origin")) {
+    if (data.containsKey("distance")) {
+#ifdef ZgatewayBT
+      String topic = String(mqtt_topic) + BTConfig.presenceTopic + String(gateway_name);
+      Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
+      pub_custom_topic((char*)topic.c_str(), data, false);
+#endif
+    } else {
+      pub((char*)data["origin"].as<const char*>(), data);
+    }
+  } else {
+    Log.trace(F("No origin in JSON filtered" CR));
+  }
+}
+
+// Add a document to the queue
+void enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc) {
+  if (jsonDoc.size() == 0) {
+    Log.error(F("Empty JSON, not enqueued" CR));
+    return;
+  }
+  Log.trace(F("Enqueue JSON" CR));
+#if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
+  JsonBundle bundle;
+  bundle.doc = jsonDoc;
+  jsonQueue.push(bundle);
+  Log.trace(F("Queue length: %d" CR), jsonQueue.size());
+#else
+  // Pub to main core
+  JsonObject jsonObj = jsonDoc.to<JsonObject>();
+  pubMainCore(jsonObj); // Arduino UNO or other boards with small memory, we don't store and directly publish
+#endif
+}
+
+#if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
+// Empty the documents queue
+void emptyQueue() {
+  while (true) {
+    JsonBundle bundle;
+
+    if (jsonQueue.empty()) {
+      break;
+    }
+    Log.trace(F("Dequeue JSON" CR));
+    bundle = jsonQueue.front();
+    jsonQueue.pop();
+
+    JsonObject obj = bundle.doc.as<JsonObject>();
+    pubMainCore(obj);
+    queueLengthSum++;
+  }
+}
+#else
+void emptyQueue() {}
+#endif
+
 /**
  * @brief Publish the payload on default MQTT topic.
  *
@@ -418,7 +494,13 @@ void pub(const char* topicori, JsonObject& data) {
   data["unixtime"] = unixtimestamp();
 #  endif
 #endif
-
+  if (data.containsKey("origin")) { // temporary, in the future use this instead of topicori
+    data.remove("origin");
+  }
+  if (data.size() == 0) {
+    Log.error(F("Empty JSON, not published" CR));
+    return;
+  }
   serializeJson(data, dataAsString);
   Log.notice(F("Send on %s msg %s" CR), topicori, dataAsString.c_str());
   String topic = String(mqtt_topic) + String(gateway_name) + String(topicori);
@@ -626,7 +708,7 @@ void delayWithOTA(long waitMillis) {
     WebUILoop();
 #  endif
 #  ifdef ESP32
-    esp_task_wdt_reset();
+    //esp_task_wdt_reset();
 #  endif
     delay(waitStep);
   }
@@ -686,8 +768,8 @@ void connectMQTT() {
 
   Log.warning(F("MQTT connection..." CR));
 #ifdef ESP32
-  esp_task_wdt_add(NULL);
-  esp_task_wdt_reset();
+  //esp_task_wdt_add(NULL);
+  //esp_task_wdt_reset();
 #endif
   char topic[mqtt_topic_max_size];
   strcpy(topic, mqtt_topic);
@@ -933,7 +1015,7 @@ void setup() {
   }
 #  endif
 #  ifdef ESP32
-  esp_task_wdt_init(GeneralTimeOut, true); //enable panic so ESP32 restarts
+  //esp_task_wdt_init(GeneralTimeOut, true); //enable panic so ESP32 restarts
 #  endif
 /*
  The 2 modules below are not connection dependent so start them before the connectivity functions
@@ -1245,7 +1327,7 @@ void setOTA() {
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
     Log.trace(F("Progress: %u%%\r" CR), (progress / (total / 100)));
 #  ifdef ESP32
-    esp_task_wdt_reset();
+    //esp_task_wdt_reset();
 #  endif
     last_ota_activity_millis = millis();
   });
@@ -1433,7 +1515,7 @@ void blockingWaitForReset() {
         }
 #    endif
 #    ifdef ESP32
-        esp_task_wdt_delete(NULL);
+        //esp_task_wdt_delete(NULL);
 #    endif
         InfoIndicatorOFF();
         SendReceiveIndicatorOFF();
@@ -1841,7 +1923,7 @@ void loop() {
 #endif
 
 #ifdef ESP32
-  esp_task_wdt_reset();
+  //esp_task_wdt_reset();
 #endif
 
   unsigned long now = millis();
@@ -1917,6 +1999,7 @@ void loop() {
         timer_sys_checks = millis();
       }
 #endif
+      emptyQueue();
 #ifdef ZsensorBME280
       MeasureTempHumAndPressure(); //Addon to measure Temperature, Humidity, Pressure and Altitude with a Bosch BME280/BMP280
 #endif
@@ -2001,7 +2084,6 @@ void loop() {
       if (SYSConfig.discovery)
         launchBTDiscovery(publishDiscovery);
 #  endif
-      emptyBTQueue();
 #endif
 #ifdef ZgatewaySRFB
       SRFBtoMQTT();
@@ -2041,14 +2123,14 @@ void loop() {
     }
   } else { // disconnected from network
 #ifdef ESP32
-    esp_task_wdt_reset();
+    //esp_task_wdt_reset();
 #endif
     connected = false;
     Log.warning(F("Network disconnected" CR));
     ErrorIndicatorON();
     delay(2000); // add a delay to avoid ESP32 crash and reset
 #ifdef ESP32
-    esp_task_wdt_reset();
+    //esp_task_wdt_reset();
 #endif
     ErrorIndicatorOFF();
     delay(2000);
@@ -2163,7 +2245,7 @@ void eraseAndRestart() {
   delay(5000);
   ESP.reset();
 #  else
-  esp_task_wdt_delete(NULL);
+  //esp_task_wdt_delete(NULL);
   nvs_flash_erase();
   ESP.restart();
 #  endif
@@ -2173,8 +2255,8 @@ void eraseAndRestart() {
 
 #if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
 String stateMeasures() {
-  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-  JsonObject SYSdata = jsonBuffer.to<JsonObject>();
+  StaticJsonDocument<JSON_MSG_BUFFER> SYSdata;
+
   SYSdata["uptime"] = uptime();
 
   SYSdata["version"] = OMG_VERSION;
@@ -2190,6 +2272,8 @@ String stateMeasures() {
   SYSdata["freemem"] = freeMem;
   SYSdata["mqttport"] = mqtt_port;
   SYSdata["mqttsecure"] = mqtt_secure;
+  SYSdata["msgproc"] = queueLengthSum;
+  SYSdata["msgspeed"] = round2((float)queueLengthSum / uptime());
 #    ifdef ESP32
   minFreeMem = ESP.getMinFreeHeap();
   SYSdata["minfreemem"] = minFreeMem;
@@ -2262,7 +2346,8 @@ String stateMeasures() {
 #  endif
   SYSdata["modules"] = modules;
 
-  pub(subjectSYStoMQTT, SYSdata);
+  SYSdata["origin"] = subjectSYStoMQTT;
+  enqueueJsonObject(SYSdata);
   pubOled(subjectSYStoMQTT, SYSdata);
 
   char jsonChar[100];
@@ -2415,7 +2500,7 @@ void receivingMQTT(char* topicOri, char* datacallback) {
 #  ifdef MQTT_HTTPS_FW_UPDATE
     MQTTHttpsFWUpdate(topicOri, jsondata);
 #  endif
-#  ifdef ZwebUI
+#  if defined(ZwebUI) && defined(ESP32)
     MQTTtoWebUI(topicOri, jsondata);
 #  endif
 #endif
@@ -2496,7 +2581,8 @@ bool checkForUpdates() {
     if (!jsondata.containsKey("release_summary"))
       jsondata["release_summary"] = "";
     latestVersion = jsondata["latest_version"].as<String>();
-    pub(subjectRLStoMQTT, jsondata);
+    jsondata["origin"] = subjectRLStoMQTT;
+    enqueueJsonObject(jsondata);
     Log.trace(F("Update file found on server" CR));
     return true;
   } else {
@@ -2558,16 +2644,16 @@ void MQTTHttpsFWUpdate(char* topicOri, JsonObject& HttpsFwUpdateData) {
       stopProcessing();
 #  endif
 #  ifdef ESP32
-      esp_task_wdt_delete(NULL); // Stop task watchdog during update
+      //esp_task_wdt_delete(NULL); // Stop task watchdog during update
 #  endif
       Log.warning(F("Starting firmware update" CR));
 
       SendReceiveIndicatorON();
       ErrorIndicatorON();
-      StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-      JsonObject jsondata = jsonBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_MSG_BUFFER> jsondata;
       jsondata["release_summary"] = "Update in progress ...";
-      pub(subjectRLStoMQTT, jsondata);
+      jsondata["origin"] = subjectRLStoMQTT;
+      enqueueJsonObject(jsondata);
 
       const char* ota_cert = HttpsFwUpdateData["server_cert"];
       if (!ota_cert && !strstr(url, "http:")) {
@@ -2634,7 +2720,8 @@ void MQTTHttpsFWUpdate(char* topicOri, JsonObject& HttpsFwUpdateData) {
           Log.notice(F("HTTP_UPDATE_OK" CR));
           jsondata["release_summary"] = "Update success !";
           jsondata["installed_version"] = latestVersion;
-          pub(subjectRLStoMQTT, jsondata);
+          jsondata["origin"] = subjectRLStoMQTT;
+          enqueueJsonObject(jsondata);
           ota_server_cert = ota_cert;
 #  ifndef ESPWifiManualSetup
           saveConfig();

--- a/main/main.ino
+++ b/main/main.ino
@@ -405,44 +405,6 @@ bool to_bool(String const& s) { // thanks Chris Jester-Young from stackoverflow
 }
 
 /*
- * Add the jsonObject id as a topic to the jsonObject origin
- *
-*/
-void buildTopicFromId(JsonObject& Jsondata, const char* origin) {
-  if (!Jsondata.containsKey("id")) {
-    Log.error(F("No id in Jsondata" CR));
-    return;
-  }
-
-  std::string topic = Jsondata["id"].as<std::string>();
-
-  // Replace ":" in topic
-  size_t pos = topic.find(":");
-  while (pos != std::string::npos) {
-    topic.erase(pos, 1);
-    pos = topic.find(":", pos);
-  }
-#ifdef ZgatewayBT
-  if (BTConfig.pubBeaconUuidForTopic && !BTConfig.extDecoderEnable && Jsondata.containsKey("model_id") && Jsondata["model_id"].as<std::string>() == "IBEACON") {
-    if (Jsondata.containsKey("uuid")) {
-      topic = Jsondata["uuid"].as<std::string>();
-    } else {
-      Log.error(F("No uuid in Jsondata" CR));
-    }
-  }
-
-  if (BTConfig.extDecoderEnable && !Jsondata.containsKey("model"))
-    topic = BTConfig.extDecoderTopic.c_str();
-#endif
-  std::string subjectStr(origin);
-  topic = subjectStr + "/" + topic;
-
-  Jsondata["origin"] = topic;
-
-  Log.trace(F("Origin: %s" CR), Jsondata["origin"].as<const char*>());
-}
-
-/*
  * Publish a message depending on its origin
  *
 */
@@ -482,6 +444,45 @@ void enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc) {
 }
 
 #if defined(ESP8266) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
+
+/*
+ * Add the jsonObject id as a topic to the jsonObject origin
+ *
+*/
+void buildTopicFromId(JsonObject& Jsondata, const char* origin) {
+  if (!Jsondata.containsKey("id")) {
+    Log.error(F("No id in Jsondata" CR));
+    return;
+  }
+
+  std::string topic = Jsondata["id"].as<std::string>();
+
+  // Replace ":" in topic
+  size_t pos = topic.find(":");
+  while (pos != std::string::npos) {
+    topic.erase(pos, 1);
+    pos = topic.find(":", pos);
+  }
+#  ifdef ZgatewayBT
+  if (BTConfig.pubBeaconUuidForTopic && !BTConfig.extDecoderEnable && Jsondata.containsKey("model_id") && Jsondata["model_id"].as<std::string>() == "IBEACON") {
+    if (Jsondata.containsKey("uuid")) {
+      topic = Jsondata["uuid"].as<std::string>();
+    } else {
+      Log.error(F("No uuid in Jsondata" CR));
+    }
+  }
+
+  if (BTConfig.extDecoderEnable && !Jsondata.containsKey("model"))
+    topic = BTConfig.extDecoderTopic.c_str();
+#  endif
+  std::string subjectStr(origin);
+  topic = subjectStr + "/" + topic;
+
+  Jsondata["origin"] = topic;
+
+  Log.trace(F("Origin: %s" CR), Jsondata["origin"].as<const char*>());
+}
+
 // Empty the documents queue
 void emptyQueue() {
   while (true) {

--- a/main/main.ino
+++ b/main/main.ino
@@ -410,17 +410,16 @@ bool to_bool(String const& s) { // thanks Chris Jester-Young from stackoverflow
 */
 void pubMainCore(JsonObject& data) {
   if (data.containsKey("origin")) {
-    if (data.containsKey("distance")) {
+    pub((char*)data["origin"].as<const char*>(), data);
 #ifdef ZgatewayBT
+    if (data.containsKey("distance")) {
       String topic = String(mqtt_topic) + BTConfig.presenceTopic + String(gateway_name);
       Log.trace(F("Pub HA Presence %s" CR), topic.c_str());
       pub_custom_topic((char*)topic.c_str(), data, false);
-#endif
-    } else {
-      pub((char*)data["origin"].as<const char*>(), data);
     }
+#endif
   } else {
-    Log.trace(F("No origin in JSON filtered" CR));
+    Log.error(F("No origin in JSON filtered" CR));
   }
 }
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -2593,6 +2593,9 @@ String latestVersion;
  */
 bool checkForUpdates() {
   Log.notice(F("Update check, free heap: %d"), ESP.getFreeHeap());
+#      ifdef ZGatewayBT
+  ProcessLock = true;
+#      endif
   HTTPClient http;
   http.setTimeout((GeneralTimeOut - 1) * 1000); // -1 to avoid WDT
   http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
@@ -2627,6 +2630,9 @@ bool checkForUpdates() {
     Log.trace(F("No update file found on server" CR));
     return false;
   }
+#      ifdef ZGatewayBT
+  ProcessLock = false;
+#      endif
   Log.notice(F("Update check done, free heap: %d"), ESP.getFreeHeap());
 }
 


### PR DESCRIPTION
## Description:
To avoid concurrency issues when modules or/and gateways are publishing data. A queue system was previously in place for the BT gateway. With this PR it is now used by all the modules.
Previously having different modules potentially assigned to different cores was generating MQTT disconnections.

- Simplify signature
- BuildBTtopic outside of main
- Cherry pick 1736
- Improve queue size
- Simplify Hapresence
- Allocate json buffer in the heap to avoid overloading the callback

Why not use the FreeRTOS queue management function? I gave it a try but was not satisfied with the stability and got better stability with the stl

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
