### PR TITLE
[CI] Publish doc gh-page branch with only the latest commit

### DIFF
--- a/.github/workflows/build_and_docs_to_dev.yml
+++ b/.github/workflows/build_and_docs_to_dev.yml
@@ -51,3 +51,4 @@ jobs:
           publish_dir: ./docs/.vuepress/dist
           destination_dir: dev
           cname: docs.openmqttgateway.com
+          force_orphan: true


### PR DESCRIPTION
## Description:
Goal is to avoid keeping the development binaries in the git history

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
