### PR TITLE
[CI] Keep existing gh-pages file when doing dev deployments

### DIFF
--- a/.github/workflows/build_and_docs_to_dev.yml
+++ b/.github/workflows/build_and_docs_to_dev.yml
@@ -52,3 +52,4 @@ jobs:
           destination_dir: dev
           cname: docs.openmqttgateway.com
           force_orphan: true
+          keep_files: true


### PR DESCRIPTION
## Description:
This should avoid removing the production portal available in the root directory

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
