### PR TITLE
[BOARD] Olimex Gateway Use LED and button

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -350,11 +350,12 @@ lib_deps =
 build_flags =
   ${com-esp32.build_flags}
   '-DZgatewayBT="BT"'
-  '-DLED_INFO=33'
-  '-DLED_INFO_ON=1'
+  '-DLED_SEND_RECEIVE=33'
+  '-DLED_SEND_RECEIVE_ON=1'
+  '-DTRIGGER_GPIO=34'
   '-DESP32_ETHERNET=true'
   '-DGateway_Name="OMG_ESP32_OLM_GTWE"'
-custom_description = BLE gateway using ethernet, need to be configured through PIO
+custom_description = BLE gateway using ethernet or wifi
 custom_hardware = OLIMEX ESP32 Gateway
 
 [env:esp32-olimex-gtw-ble-poe]


### PR DESCRIPTION
## Description:
Use the available LED as an indicator and button1 of the board to erase the configuration possibly.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
