### PR TITLE
[BOARD] Differentiate Pilight from multi receiver environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           - "lilygo-rtl_433"
           - "lilygo-ble"
           - "esp32dev-multi_receiver"
+          - "esp32dev-multi_receiver-pilight"
           - "tinypico-ble"
           - "ttgo-lora32-v1"
           - "ttgo-lora32-v21"

--- a/environments.ini
+++ b/environments.ini
@@ -840,6 +840,33 @@ build_flags =
   '-DZgatewayRF="RF"'
   '-DZgatewayRF2="RF2"'
   '-DZgatewayRTL_433="RTL_433"'
+  '-DZradioCC1101="CC1101"'
+  '-DGateway_Name="OMG_multi_receiver"'
+  '-DvalueAsATopic=true'  ; MQTT topic includes model and device (rtl_433) or protocol and id (RF and PiLight)
+;  '-DDEFAULT_RECEIVER=1'  ; Default receiver to enable on startup
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+  '-DRF_MODULE_CS=5'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
+;  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
+custom_description = Multi RF library with the possibility to switch between RTL_433_ESP, NewRemoteSwitch and RCSwitch, need CC1101
+
+[env:esp32dev-multi_receiver-pilight]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp32.lib_deps}
+  ${libraries.rc-switch}
+  ${libraries.smartrc-cc1101-driver-lib}
+  ${libraries.rtl_433_ESP}
+  ${libraries.esppilight}
+  ${libraries.newremoteswitch}
+build_flags =
+  ${com-esp32.build_flags}
+  '-DZgatewayRF="RF"'
+  '-DZgatewayRF2="RF2"'
   '-DZgatewayPilight="Pilight"'
   '-DZradioCC1101="CC1101"'
   '-DGateway_Name="OMG_multi_receiver"'
@@ -851,7 +878,8 @@ build_flags =
   '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
   '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
 ;  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
-custom_description = Multi RF library with the possibility to switch between ESPilight, RTL_433_ESP, NewRemoteSwitch and RCSwitch, need CC1101
+custom_description = Multi RF library with the possibility to switch between ESPilight, NewRemoteSwitch and RCSwitch, need CC1101
+
 
 [env:tinypico-ble]
 platform = ${com.esp32_platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,6 +65,7 @@ extra_configs =
 ;default_envs = lilygo-rtl_433
 ;default_envs = lilygo-ble
 ;default_envs = esp32dev-multi_receiver
+;default_envs = esp32dev-multi_receiver-pilight
 ;default_envs = tinypico-ble
 ;default_envs = ttgo-lora32-v1
 ;default_envs = ttgo-lora32-v21


### PR DESCRIPTION
## Description:
Bypass to #1780 #1741 

There is a conflict between RTL_433 and ESPPiLight regarding nexus protocol. As a bypass differentiating the environments into 2

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
