### PR TITLE
[BT] Fix HA discovery for motion and door sensor

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -68,6 +68,10 @@ Note that you can find apps to simulate beacons and do some tests like [Beacon s
 
 iOS version >=10 devices advertise without an extra app MAC address, nevertheless this address [changes randomly](https://github.com/1technophile/OpenMQTTGateway/issues/71) and cannot be used for presence detection. You must install an app to advertise a fixed MAC address.
 
+::: info
+The `presenceawaytimer` is also used to reset the state of the PIR/motion sensors to `off` when using HA MQTT discovery convention. If the Sensor does not detect a motion, its state will be automatically set to `off` after the `presenceawaytimer`.
+:::
+
 ## Receiving signals from BLE devices with accelerometers for movement detection
 The gateway is designed to detect BLE trackers from BlueCharm and automatically create a binary sensor entity in accordance with the Home Assistant discovery convention, provided that auto discovery is enabled.
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1030,6 +1030,14 @@ void launchBTDiscovery(bool overrideDiscovery) {
                                 0, "", "", false, "",
                                 model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
                                 stateClassMeasurement, nullptr, nullptr, "[\"lb\",\"kg\",\"jin\"]");
+              } else if (strcmp(prop.key().c_str(), "pres") == 0) {
+                createDiscovery("binary_sensor",
+                                discovery_topic.c_str(), entity_name.c_str(), unique_id.c_str(),
+                                will_Topic, "motion", value_template.c_str(), // Idealy we should have the decoder give the name here as "motion" but for now it gives "presence"
+                                "True", "False", "",
+                                BTConfig.presenceAwayTimer, "", "", false, "",
+                                model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
+                                stateClassNone);
               } else if (strcmp(prop.key().c_str(), "device") != 0 && strcmp(prop.key().c_str(), "mac") != 0) { // Exception on device and mac as these ones are not sensors
                 createDiscovery("sensor",
                                 discovery_topic.c_str(), entity_name.c_str(), unique_id.c_str(),

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1030,12 +1030,28 @@ void launchBTDiscovery(bool overrideDiscovery) {
                                 0, "", "", false, "",
                                 model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
                                 stateClassMeasurement, nullptr, nullptr, "[\"lb\",\"kg\",\"jin\"]");
-              } else if (strcmp(prop.key().c_str(), "pres") == 0) {
+              } else if (strcmp(prop.key().c_str(), "pres") == 0 || strcmp(prop.key().c_str(), "movement") == 0) {
                 createDiscovery("binary_sensor",
                                 discovery_topic.c_str(), entity_name.c_str(), unique_id.c_str(),
                                 will_Topic, "motion", value_template.c_str(), // Idealy we should have the decoder give the name here as "motion" but for now it gives "presence"
                                 "True", "False", "",
                                 BTConfig.presenceAwayTimer, "", "", false, "",
+                                model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
+                                stateClassNone);
+              } else if (strcmp(prop.value()["unit"], "string") == 0 && strcmp(prop.key().c_str(), "mac") != 0) {
+                createDiscovery("sensor",
+                                discovery_topic.c_str(), entity_name.c_str(), unique_id.c_str(),
+                                will_Topic, prop.value()["name"], value_template.c_str(),
+                                "", "", "",
+                                0, "", "", false, "",
+                                model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
+                                stateClassNone);
+              } else if (strcmp(prop.value()["unit"], "status") == 0) {
+                createDiscovery("binary_sensor",
+                                discovery_topic.c_str(), entity_name.c_str(), unique_id.c_str(),
+                                will_Topic, prop.value()["name"], value_template.c_str(),
+                                "True", "False", "",
+                                0, "", "", false, "",
                                 model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
                                 stateClassNone);
               } else if (strcmp(prop.key().c_str(), "device") != 0 && strcmp(prop.key().c_str(), "mac") != 0) { // Exception on device and mac as these ones are not sensors

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -163,7 +163,7 @@ struct BTConfig_s {
   bool pubAdvData; // Publish advertisement data
   bool pubBeaconUuidForTopic; // Use iBeacon UUID as topic, instead of sender (random) MAC address
   bool ignoreWBlist; // Disable Whitelist & Blacklist
-  unsigned long presenceAwayTimer; //Timer that trigger a tracker state as offline if not seen
+  unsigned long presenceAwayTimer; //Timer that trigger a tracker/PIR state as offline/off if not seen
   unsigned long movingTimer; //Timer that trigger a moving sensor state as offline if not seen
 };
 

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -184,6 +184,8 @@ void announceDeviceTrigger(bool use_gateway_info,
 const char* availableHASSClasses[] = {"battery",
                                       "carbon_monoxide",
                                       "carbon_dioxide",
+                                      "door",
+                                      "enum",
                                       "pm10",
                                       "pm25",
                                       "humidity",
@@ -197,7 +199,7 @@ const char* availableHASSClasses[] = {"battery",
                                       "energy",
                                       "power_factor",
                                       "voltage",
-                                      "enum"};
+                                      "window"};
 
 // From https://github.com/home-assistant/core/blob/d7ac4bd65379e11461c7ce0893d3533d8d8b8cbf/homeassistant/const.py#L379
 // List of units available in Home Assistant


### PR DESCRIPTION
## Description:
Was defined previously as a sensor instead of a binary_sensor.
Also, use the `presenceawaytimer` as an `off_delay` in case the `"pres":false` attribute is not published for motion sensors

Use the sensors that publishe strings as a `sensor`.

Use the sensors that publishe status as a `binary_sensor` without `off_delay`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
