### PR TITLE
[RF] Fix crash on transmit with CC1101/ESP32

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -263,7 +263,7 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       Log.notice(F("Bits nb: %d" CR), valueBITS);
 #    ifdef ZradioCC1101 // set Receive off and Transmitt on
       disableActiveReceiver();
-      
+
       int txPower = RFdata["txpower"] | RF_CC1101_TXPOWER;
       ELECHOUSE_cc1101.setPA((int)txPower);
       Log.notice(F("CC1101 TX Power: %d" CR), txPower);

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -262,13 +262,14 @@ void MQTTtoRF(char* topicOri, JsonObject& RFdata) { // json object decoding
       Log.notice(F("RF Pulse Lgth: %d" CR), valuePLSL);
       Log.notice(F("Bits nb: %d" CR), valueBITS);
 #    ifdef ZradioCC1101 // set Receive off and Transmitt on
+      disableActiveReceiver();
+      
       int txPower = RFdata["txpower"] | RF_CC1101_TXPOWER;
       ELECHOUSE_cc1101.setPA((int)txPower);
       Log.notice(F("CC1101 TX Power: %d" CR), txPower);
 
       float trMhz = RFdata["mhz"] | CC1101_FREQUENCY;
       if (validFrequency((int)trMhz)) {
-        disableActiveReceiver();
         ELECHOUSE_cc1101.SetTx(trMhz);
         Log.notice(F("Transmit mhz: %F" CR), trMhz);
       }


### PR DESCRIPTION
## Description:

Fix Issue #1800 , disable receiver before setting TX power on CC1101.

## Checklist:
  - [ x ] The pull request is done against the latest development branch
  - [ x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
