### PR TITLE
[DISC] Do not retain autodiscovery on/off commands.

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -502,7 +502,7 @@ void pubMqttDiscovery() {
                   "{\"discovery\":true,\"save\":true}", "{\"discovery\":false,\"save\":true}", "", //set,payload_on,payload_off,unit_of_meas,
                   0, //set  off_delay
                   Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoSYSset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
-                  "", "", "", "", true, // device name, device manufacturer, device model, device MAC, retain,
+                  "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain,
                   stateClassNone, //State Class
                   "false", "true" //state_off, state_on
   );
@@ -512,7 +512,7 @@ void pubMqttDiscovery() {
                   "{\"ohdiscovery\":true,\"save\":true}", "{\"ohdiscovery\":false,\"save\":true}", "", //set,payload_on,payload_off,unit_of_meas,
                   0, //set  off_delay
                   Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoSYSset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
-                  "", "", "", "", true, // device name, device manufacturer, device model, device MAC, retain,
+                  "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain,
                   stateClassNone, //State Class
                   "false", "true" //state_off, state_on
   );


### PR DESCRIPTION
Set "retain":false within autodiscovery messages for Home Assistant and OpenHAB discovery switch.

## Description:

[Community thread](https://community.openmqttgateway.com/t/interaction-between-discovery-auto-off-timer-and-retain-flag/2860)

As discovery state is stored in flash memory and there is an auto off timer, we don't want discovery turned back on by a retained MQTT message when device reboots.

## Checklist:
  - [ x ] The pull request is done against the latest development branch
  - [ x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
