### PR TITLE
[BT] Off timer add for binary sensors

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -79,7 +79,7 @@ Note that you can find apps to simulate beacons and do some tests like [Beacon s
 iOS version >=10 devices advertise without an extra app MAC address, nevertheless this address [changes randomly](https://github.com/1technophile/OpenMQTTGateway/issues/71) and cannot be used for presence detection. You must install an app to advertise a fixed MAC address.
 
 ::: info
-The `presenceawaytimer` is also used to reset the state of the PIR/motion sensors to `off` when using HA MQTT discovery convention. If the Sensor does not detect a motion, its state will be automatically set to `off` after the `presenceawaytimer`.
+The `presenceawaytimer` is also used to reset the state of the binary sensors, PIR/motion sensors to `off` when using HA MQTT discovery convention. If the Sensor does not detect a motion, its state will be automatically set to `off` after the `presenceawaytimer`.
 :::
 
 ## Receiving signals from BLE devices with accelerometers for movement detection

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1054,7 +1054,7 @@ void launchBTDiscovery(bool overrideDiscovery) {
                                 discovery_topic.c_str(), entity_name.c_str(), unique_id.c_str(),
                                 will_Topic, prop.value()["name"], value_template.c_str(),
                                 "True", "False", "",
-                                0, "", "", false, "",
+                                BTConfig.presenceAwayTimer, "", "", false, "",
                                 model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
                                 stateClassNone);
               } else if (strcmp(prop.key().c_str(), "device") != 0 && strcmp(prop.key().c_str(), "mac") != 0) { // Exception on device and mac as these ones are not sensors


### PR DESCRIPTION
## Description:
Some devices are not publishing a false status payload when not anymore detecting an event, this PR enables to reset the state to false after `presenceawaytimer`
This is applicable to all the entities with the type `binary_sensor`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
