### PR TITLE
[IR] Fix hex and protocol_name

### DIFF
--- a/main/ZgatewayIR.ino
+++ b/main/ZgatewayIR.ino
@@ -126,10 +126,8 @@ void IRtoMQTT() {
     IRdata["protocol"] = (int)(results.decode_type);
     IRdata["bits"] = (int)(results.bits);
 #  if defined(ESP8266) || defined(ESP32) //resultToHexidecimal is only available with IRremoteESP8266
-    String hex = resultToHexidecimal(&results);
-    IRdata["hex"] = (const char*)hex.c_str();
-    String protocol = typeToString(results.decode_type, false);
-    IRdata["protocol_name"] = (const char*)protocol.c_str();
+    IRdata["hex"] = resultToHexidecimal(&results);
+    IRdata["protocol_name"] = typeToString(results.decode_type, false);
 #  endif
     String rawCode = "";
     // Dump data


### PR DESCRIPTION
## Description:
Fix hex and protocol name field value persistence during the json object lifecycle

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
