### PR TITLE
[SYS] Change OTAPASSWORD for devices using a part of the MAC as the password

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -1732,8 +1732,18 @@ bool loadConfigFromFlash() {
           mqtt_ss_index = json["mqtt_ss_index"].as<uint8_t>();
         if (json.containsKey("gateway_name"))
           strcpy(gateway_name, json["gateway_name"]);
-        if (json.containsKey("ota_pass"))
+        if (json.containsKey("ota_pass")) {
           strcpy(ota_pass, json["ota_pass"]);
+#  ifdef WM_PWD_FROM_MAC // From ESP Mac Address, last 8 digits as the password
+          // Compare the existing ota_pass if ota_pass = OTAPASSWORD then replace with the last 8 digits of the mac address
+          // This enable user migrating from previous version to have the same WiFi portal password as previously unless they changed it
+          if (strcmp(ota_pass, "OTAPASSWORD") == 0) {
+            String s = WiFi.macAddress();
+            sprintf(ota_pass, "%.2s%.2s%.2s%.2s",
+                    s.c_str() + 6, s.c_str() + 9, s.c_str() + 12, s.c_str() + 15);
+          }
+#  endif
+        }
         if (json.containsKey("ota_server_cert"))
           ota_server_cert = json["ota_server_cert"].as<const char*>();
         result = true;


### PR DESCRIPTION
## Description:
To keep the same password as previously (8 last digits of the MAC) rather than replacing it by OTAPASSWORD

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
