### PR TITLE
Generic SSD1306 display support for ESP32 added

### DIFF
--- a/docs/use/displays.md
+++ b/docs/use/displays.md
@@ -1,6 +1,6 @@
 # Displays
 
-## SSD1306 Display (Heltec SX127X and LILYGO® LoRa32 boards)
+## SSD1306 Display (Heltec SX127X, LILYGO® LoRa32 boards, generic SSD1306 displays)
 Several options are available for the display of information on the SSD1306 display. Some options are exclusive to each other, and when a different option is enabled, the current option is disabled.
 
 The current SSD1306 display states are being published to the `SSD1306toMQTT` topic, e.g.
@@ -69,7 +69,7 @@ you can also revert it back with
 
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m '{"log-oled":false}'`
 
-The log level of the messages displayed is Errors and Warnings, and this can only be changed via the compiler directive `-DLOG_LEVEL_OLED=LOG_LEVEL_NOTICE`.  
+The log level of the messages displayed is Errors and Warnings, and this can only be changed via the compiler directive `-DLOG_LEVEL_OLED=LOG_LEVEL_NOTICE`.
 
 ### Displaying Module json messages (default)
 
@@ -97,12 +97,48 @@ At any time, you can reload the stored configuration with the command:
 
 If you want to erase the stored configuration, use the command:
 
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m '{"erase":true}'` 
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m '{"erase":true}'`
 
 Note that this will not change the running configuration, it only ensures that the default configuration is used at next startup.
 
 If you want to load the default configuration use the command:
 
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m '{"init":true}'` 
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoSSD1306/config -m '{"init":true}'`
 
 Note that this will not change the stored configuration, `erase` or `save` is still needed to overwrite the saved configuration.
+
+### Connecting a generic SSD1306 display to ESP32
+It is possible to connect a generic SSD1306 display with resolution 128*64 to the hardware setups.
+This example describes how to do it with the ESP32 board.
+- Connect the display to the ESP32 (display &rarr; ESP32):
+  - VCC &rarr; 5V (or 3.3V, check your display documentation)
+  - GND &rarr; GND
+  - SCL &rarr; pin 22
+  - SDA &rarr; pin 21
+- Modify the environment definition in `environments.ini`.
+  - Add the display library:
+    ```
+    lib_deps =
+      ${com-esp32.lib_deps}
+      ...
+      ${libraries.ssd1306}
+    ```
+  - Add relevant build flags:
+    ```
+    build_flags =
+      ${com-esp32.build_flags}
+      ...
+    ; *** Generic SSD1306 OLED Options **
+      '-DZdisplaySSD1306="GenericSSD1306"'
+      '-DOLED_SDA=21'               ; SSD1306 pin SDA
+      '-DOLED_SCL=22'               ; SSD1306 pin SCL
+      '-DGenericSSD1306=true'
+      '-DJSON_TO_OLED=true'
+      '-DDISPLAY_PAGE_INTERVAL=30'
+    ;  '-DLOG_TO_OLED=true'         ; Enable log to OLED
+    ;  '-DLOG_LEVEL_OLED=LOG_LEVEL_NOTICE'
+    ;  '-DDISPLAY_IDLE_LOGO=false'
+    ;  '-DDISPLAY_BRIGHTNESS=80'
+    ;  '-DDISPLAY_METRIC=false'
+    ;  '-DDISPLAY_FLIP=false'
+    ```

--- a/environments.ini
+++ b/environments.ini
@@ -761,6 +761,60 @@ build_flags =
 ;  '-DRADIOLIB_VERBOSE=true'
 custom_description = Gateway using RTL_433_ESP library, need CC1101
 
+[env:esp32dev-rtl_433-oled]
+platform = ${com.esp32_platform}
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp32.lib_deps}
+  ${libraries.rtl_433_ESP}
+  ${libraries.smartrc-cc1101-driver-lib}
+  ${libraries.ssd1306}
+build_flags =
+  ${com-esp32.build_flags}
+; *** OpenMQTTGateway Config ***
+  ;'-UZmqttDiscovery'          ; disables MQTT Discovery
+  '-DvalueAsATopic=true'       ; MQTT topic includes model and device
+  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
+  '-DGateway_Name="OMG_rtl_433_ESP"'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433="rtl_433"'
+  '-DZradioCC1101="CC1101"'
+; *** rtl_433_ESP Options ***
+;  '-DRTL_DEBUG=4'             ; rtl_433 verbose mode
+;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
+;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
+;  '-DMEMORY_DEBUG=true'       ; display memory usage information
+  '-DDEMOD_DEBUG=false'         ; display signal debug info
+;  '-DMY_DEVICES=true'         ; subset of devices
+  '-DPUBLISH_UNPARSED=false'    ; publish unparsed signal details
+;  '-DRSSI_THRESHOLD=12'       ; Apply a delta of 12 to average RSSI level
+;  '-DAVERAGE_RSSI=5000'       ; Display RSSI floor ( Average of 5000 samples )
+  '-DSIGNAL_RSSI=true'         ; Display during signal receive
+  '-DNO_DEAF_WORKAROUND=true'
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'       ; CC1101 Transceiver Module
+;  '-DRF_MODULE_CS=5'          ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=12'        ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=27'        ; CC1101 pin GDO2
+; *** RadioLib Options ***
+;  '-DRADIOLIB_DEBUG=true'
+;  '-DRADIOLIB_VERBOSE=true'
+; *** Generic SSD1306 OLED Options **
+  '-DZdisplaySSD1306="Generic_SSD1306"'
+  '-DOLED_SDA=21'               ; SSD1306 pin SDA
+  '-DOLED_SCL=22'               ; SSD1306 pin SCL
+  '-DGenericSSD1306=true'
+  '-DJSON_TO_OLED=true'
+;  '-DLOG_TO_OLED=true'         ; Enable log to OLED
+;  '-DLOG_LEVEL_OLED=LOG_LEVEL_NOTICE'
+;  '-DDISPLAY_IDLE_LOGO=false'
+;  '-DDISPLAY_BRIGHTNESS=80'
+;  '-DDISPLAY_METRIC=false'
+;  '-DDISPLAY_FLIP=false'
+  '-DDISPLAY_PAGE_INTERVAL=30'
+custom_description = Gateway using RTL_433_ESP library, need CC1101. With OLED.
+
 [env:heltec-rtl_433]
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32_V2

--- a/environments.ini
+++ b/environments.ini
@@ -761,60 +761,6 @@ build_flags =
 ;  '-DRADIOLIB_VERBOSE=true'
 custom_description = Gateway using RTL_433_ESP library, need CC1101
 
-[env:esp32dev-rtl_433-oled]
-platform = ${com.esp32_platform}
-board = esp32dev
-board_build.partitions = min_spiffs.csv
-lib_deps =
-  ${com-esp32.lib_deps}
-  ${libraries.rtl_433_ESP}
-  ${libraries.smartrc-cc1101-driver-lib}
-  ${libraries.ssd1306}
-build_flags =
-  ${com-esp32.build_flags}
-; *** OpenMQTTGateway Config ***
-  ;'-UZmqttDiscovery'          ; disables MQTT Discovery
-  '-DvalueAsATopic=true'       ; MQTT topic includes model and device
-  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
-  '-DGateway_Name="OMG_rtl_433_ESP"'
-; *** OpenMQTTGateway Modules ***
-  '-DZgatewayRTL_433="rtl_433"'
-  '-DZradioCC1101="CC1101"'
-; *** rtl_433_ESP Options ***
-;  '-DRTL_DEBUG=4'             ; rtl_433 verbose mode
-;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
-;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
-;  '-DMEMORY_DEBUG=true'       ; display memory usage information
-  '-DDEMOD_DEBUG=false'         ; display signal debug info
-;  '-DMY_DEVICES=true'         ; subset of devices
-  '-DPUBLISH_UNPARSED=false'    ; publish unparsed signal details
-;  '-DRSSI_THRESHOLD=12'       ; Apply a delta of 12 to average RSSI level
-;  '-DAVERAGE_RSSI=5000'       ; Display RSSI floor ( Average of 5000 samples )
-  '-DSIGNAL_RSSI=true'         ; Display during signal receive
-  '-DNO_DEAF_WORKAROUND=true'
-; *** RF Module Options ***
-  '-DRF_CC1101="CC1101"'       ; CC1101 Transceiver Module
-;  '-DRF_MODULE_CS=5'          ; pin to be used as chip select
-  '-DRF_MODULE_GDO0=12'        ; CC1101 pin GDO0
-  '-DRF_MODULE_GDO2=27'        ; CC1101 pin GDO2
-; *** RadioLib Options ***
-;  '-DRADIOLIB_DEBUG=true'
-;  '-DRADIOLIB_VERBOSE=true'
-; *** Generic SSD1306 OLED Options **
-  '-DZdisplaySSD1306="Generic_SSD1306"'
-  '-DOLED_SDA=21'               ; SSD1306 pin SDA
-  '-DOLED_SCL=22'               ; SSD1306 pin SCL
-  '-DGenericSSD1306=true'
-  '-DJSON_TO_OLED=true'
-;  '-DLOG_TO_OLED=true'         ; Enable log to OLED
-;  '-DLOG_LEVEL_OLED=LOG_LEVEL_NOTICE'
-;  '-DDISPLAY_IDLE_LOGO=false'
-;  '-DDISPLAY_BRIGHTNESS=80'
-;  '-DDISPLAY_METRIC=false'
-;  '-DDISPLAY_FLIP=false'
-  '-DDISPLAY_PAGE_INTERVAL=30'
-custom_description = Gateway using RTL_433_ESP library, need CC1101. With OLED.
-
 [env:heltec-rtl_433]
 platform = ${com.esp32_platform}
 board = heltec_wifi_lora_32_V2

--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -302,6 +302,8 @@ OledSerial::OledSerial(int x) {
   // delay(50);
   // digitalWrite(OLED_RST, HIGH);
   display = new SSD1306Wire(0x3c, OLED_SDA, OLED_SCL, GEOMETRY_128_64);
+#  elif defined(GenericSSD1306)
+  display = new SSD1306Wire(0x3c, OLED_SDA, OLED_SCL, GEOMETRY_128_64);
 #  endif
 }
 
@@ -357,7 +359,7 @@ void OledSerial::flush(void) {
 }
 
 /*
-Erase display and paint it with the color.  Used to 
+Erase display and paint it with the color.  Used to
 */
 void OledSerial::fillScreen(OLEDDISPLAY_COLOR color) {
   if (xSemaphoreTake(semaphoreOLEDOperation, pdMS_TO_TICKS(30000)) == pdTRUE) {

--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -302,7 +302,7 @@ OledSerial::OledSerial(int x) {
   // delay(50);
   // digitalWrite(OLED_RST, HIGH);
   display = new SSD1306Wire(0x3c, OLED_SDA, OLED_SCL, GEOMETRY_128_64);
-#  elif defined(GenericSSD1306)
+#  elif defined(GenericSSD1306) // a generic ssd1306 oled with of size 128*64
   display = new SSD1306Wire(0x3c, OLED_SDA, OLED_SCL, GEOMETRY_128_64);
 #  endif
 }


### PR DESCRIPTION
## Description:
Add support for a generic SSD1306 display for ESP32 boards. The only code change includes the generic display module init. Other changes are in the documentation describing how to connect the display to ESP32 and the needed changes to build environments if the display should be used.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
