### PR TITLE
[RF] Use exponential backoff delay in initCC1101()

### DIFF
--- a/main/ZcommonRF.ino
+++ b/main/ZcommonRF.ino
@@ -34,6 +34,8 @@
 void initCC1101() {
 #    ifdef ZradioCC1101 //receiving with CC1101
   // Loop on getCC1101() until it returns true and break after 10 attempts
+  int delayMS = 16;
+  int delayMaxMS = 500;
   for (int i = 0; i < 10; i++) {
     if (ELECHOUSE_cc1101.getCC1101()) {
       Log.notice(F("C1101 spi Connection OK" CR));
@@ -42,8 +44,11 @@ void initCC1101() {
       break;
     } else {
       Log.error(F("C1101 spi Connection Error" CR));
-      delay(500);
+      delay(delayMS);
     }
+    // truncated exponential backoff
+    delayMS = delayMS * 2;
+    if (delayMS > delayMaxMS) delayMS = delayMaxMS;
   }
 #    endif
 }


### PR DESCRIPTION
## Description:

In #1812, the function initCC1101() was created to poll getCC1101() until it returns true before using the CC1101 chip. A 500ms delay was put between polls.

In my experience, this delay is too long as the the chip is often ready very shortly after the first check. This change makes the function use exponential backoff to initially check quickly (16ms), then double the wait time until waiting the original 500ms.

A simpler change would be to just use a smaller constant delay, but exponential backoff is a good compromise in case there are instances where a longer delay is needed.

## Checklist:
  - [ x ] The pull request is done against the latest development branch
  - [ x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
