### PR TITLE
[SYS] Avoid logging sensitive information

### DIFF
--- a/docs/upload/builds.md
+++ b/docs/upload/builds.md
@@ -42,7 +42,6 @@ build_flags =
   ${env.build_flags}        ; Inherit all the build flags from [env]
   '-DsimpleReceiving=true'  ; Add some of our own build flags
   '-DZmqttDiscovery="HADiscovery"'
-  '-DTRACE=1'
   ;'-DCORE_DEBUG_LEVEL=4'
 ```
 Here, build flags starting with "-D" let us set configuration values you would normally find in `User_config.h` and `config_xx.h` files by specifying them here, overriding the default values set in those files. To include special characters, you can triple escape them with a backslash like so:

--- a/environments.ini
+++ b/environments.ini
@@ -1712,7 +1712,7 @@ extends = env:esp32c3-dev-c2-ble
 build_flags =
   ${env:esp32c3-dev-c2-ble.build_flags}
   '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; ommit logging for increased stability
-  '-DWM_DEBUG_LEVEL=0'
+  '-DWM_DEBUG=0'
 custom_description = BLE gateway on Espressiv ESP32-C3-DevKitC-02 without logging
 
 ; Wemos Lolin C3 mini v2.1.0
@@ -1742,7 +1742,7 @@ build_flags =
 ; As a default we disable serial output. Use the _with_serial environment if you
 ; need serial output for debugging purposes.
   '-DLOG_LEVEL=LOG_LEVEL_SILENT'  ; disable serial logging.
-  '-DWM_DEBUG_LEVEL=0'  ; disable serial logging.
+  '-DWM_DEBUG=0'  ; disable serial logging.
 custom_description = BLE gateway on ESP32C3
 custom_hardware = Wemos Lolin C3 mini v2.1.0
 
@@ -1751,7 +1751,6 @@ extends = env:esp32c3_lolin_mini
 build_flags =
   ${env:esp32c3_lolin_mini.build_flags}
   '-DLOG_LEVEL=LOG_LEVEL_NOTICE' ;default
-  '-DWM_DEBUG_LEVEL=1' ;DEBUG_NOTIFY=1, default value
 ; Serial output via USB
   '-DCONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=true'
   '-DCONFIG_ESP_CONSOLE_UART=ESP_CONSOLE_USB_SERIAL_JTAG'

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -130,8 +130,8 @@ const byte mac[] = {0xDE, 0xED, 0xBA, 0xFE, 0x54, 0x95}; //W5100 ethernet shield
 #ifndef WiFi_TimeOut
 #  define WiFi_TimeOut 30
 #endif
-#ifndef WM_DEBUG_LEVEL
-#  define WM_DEBUG_LEVEL 1 // valid values are: DEBUG_ERROR = 0, DEBUG_NOTIFY = 1, DEBUG_VERBOSE = 2, DEBUG_DEV = 3, DEBUG_MAX = 4
+#ifndef WM_DEBUG // WiFi Manager debug
+#  define WM_DEBUG 1
 #endif
 //#define WIFIMNG_HIDE_MQTT_CONFIG //Uncomment so as to hide MQTT setting from Wifi manager page
 

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -443,7 +443,7 @@ void updateDevicesStatus() {
 }
 
 void dumpDevices() {
-#  if LOG_LEVEL > 4 // > NOTICE LOG LEVEL
+#  if LOG_LEVEL > LOG_LEVEL_NOTICE
   for (vector<BLEdevice*>::iterator it = devices.begin(); it != devices.end(); ++it) {
     BLEdevice* p = *it;
     Log.trace(F("macAdr %s" CR), p->macAdr);

--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -641,9 +641,6 @@ void handleWI() {
       }
       if (update) {
         String topic = String(mqtt_topic) + String(gateway_name) + String(subjectMQTTtoSYSset);
-        String output;
-        serializeJson(WEBtoSYS, output);
-        Log.notice(F("[WebUI] MQTTtoSYS %s" CR), output.c_str());
         Log.warning(F("[WebUI] Save WiFi and Restart" CR));
         char jsonChar[100];
         serializeJson(modules, jsonChar, measureJson(modules) + 1);
@@ -785,9 +782,6 @@ void handleMQ() {
 
         delay(2000); // Wait for web page to be sent before
         String topic = String(mqtt_topic) + String(gateway_name) + String(subjectMQTTtoSYSset);
-        String output;
-        serializeJson(WEBtoSYS, output);
-        Log.notice(F("[WebUI] MQTTtoSYS %s" CR), output.c_str());
         MQTTtoSYS((char*)topic.c_str(), WEBtoSYS);
         return;
       } else {
@@ -860,9 +854,6 @@ void handleCG() {
 
     delay(2000); // Wait for web page to be sent before
     String topic = String(mqtt_topic) + String(gateway_name) + String(subjectMQTTtoSYSset);
-    String output;
-    serializeJson(WEBtoSYS, output);
-    Log.notice(F("[WebUI] MQTTtoSYS %s" CR), output.c_str());
     MQTTtoSYS((char*)topic.c_str(), WEBtoSYS);
   } else {
     Log.warning(F("[WebUI] No changes" CR));

--- a/main/main.ino
+++ b/main/main.ino
@@ -1683,7 +1683,6 @@ void saveConfig() {
     Log.error(F("failed to open config file for writing" CR));
   }
 
-  serializeJsonPretty(json, Serial);
   serializeJson(json, configFile);
   configFile.close();
 }
@@ -1711,7 +1710,6 @@ bool loadConfigFromFlash() {
       if (error) {
         Log.error(F("deserialize config failed: %s, buffer capacity: %u" CR), error.c_str(), json.capacity());
       }
-      serializeJsonPretty(json, Serial);
       if (!json.isNull()) {
         Log.trace(F("\nparsed json, size: %u" CR), json.memoryUsage());
         if (json.containsKey("mqtt_server"))
@@ -1782,7 +1780,7 @@ void setup_wifimanager(bool reset_settings) {
   Log.notice(F("OTA Hostname: %s.local" CR), ota_hostname);
 #  endif
 
-  wifiManager.setDebugOutput(WM_DEBUG_LEVEL);
+  wifiManager.setDebugOutput(WM_DEBUG);
 
   // The extra parameters to be configured (can be either global or just in the setup)
   // After connecting, parameter.getValue() will get you the configured value

--- a/platformio.ini
+++ b/platformio.ini
@@ -166,6 +166,7 @@ lib_deps =
   ${libraries.arduinojson}
   ${libraries.arduinolog}
 build_flags =
+  '-DWM_DEBUG_LEVEL=1' ;WiFi Manager log level, valid values are: DEBUG_ERROR = 0, DEBUG_NOTIFY = 1, DEBUG_VERBOSE = 2, DEBUG_DEV = 3, DEBUG_MAX = 4
   -w ; supress all warnings
 ;  -E ; generate precompiled source file (.pio/build/*/src/main.ino.cpp.o), use for precompilator debuging only (prevent compilation to succeed)
 ;  '-DLOG_LEVEL=LOG_LEVEL_TRACE'  ; Enable trace level logging
@@ -184,7 +185,6 @@ build_flags =
   ${env.build_flags}
   '-DENV_NAME="$PIOENV"'
   '-DZmqttDiscovery="HADiscovery"'
-  '-DTRACE=1'
   '-DMQTTsetMQTT'
   '-DMQTT_HTTPS_FW_UPDATE'
   ;'-DCORE_DEBUG_LEVEL=4'
@@ -198,7 +198,6 @@ build_flags =
   ${env.build_flags}
   '-DENV_NAME="$PIOENV"'
   '-DZmqttDiscovery="HADiscovery"'
-  '-DTRACE=1'
   '-DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL_DISABLED'
   '-DCONFIG_BT_NIMBLE_ROLE_BROADCASTER_DISABLED'
   '-DMQTTsetMQTT'
@@ -214,7 +213,6 @@ lib_deps =
 build_flags =
   ${env.build_flags}
   '-DZmqttDiscovery="HADiscovery"'
-  '-DTRACE=1'
 
 [com-arduino-low-memory]
 lib_deps =


### PR DESCRIPTION
## Description:
Remove the export of the MQTT information to the serial console
Change the WiFi manager log level to notify

The goal is to avoid capturing sensitive information from a serial console access.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
