### PR TITLE
[SOMFY] fix frequency in documentation

### DIFF
--- a/docs/use/actuators.md
+++ b/docs/use/actuators.md
@@ -141,8 +141,8 @@ The frequency key is optional, if not set the gateway will use the default frequ
 
 Send PROG command with remote 0:
 
-`mosquitto_pub -t home/OpenMQTTGateway_Somfy/commands/MQTTtoSomfy -m '{"remote":0,"command":"Prog","frequency":433.92}'`
+`mosquitto_pub -t home/OpenMQTTGateway_Somfy/commands/MQTTtoSomfy -m '{"remote":0,"command":"Prog","frequency":433.42}'`
 
 Send Up command with remote 1:
 
-`mosquitto_pub -t home/OpenMQTTGateway_Somfy/commands/MQTTtoSomfy -m '{"remote":1,"command":"Up","frequency":433.92}'`
+`mosquitto_pub -t home/OpenMQTTGateway_Somfy/commands/MQTTtoSomfy -m '{"remote":1,"command":"Up","frequency":433.42}'`


### PR DESCRIPTION
## Description:
It seems that #1822 added the wrong frequency to the documentation. The correct frequency is 433.42 Mhz.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
