### PR TITLE
[SYS] ESP32 JSON buffer size fixed for RuuviTag_RAWV2

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -674,7 +674,7 @@ Adafruit_NeoPixel leds2(ANEOPIX_IND_NUM_LEDS, ANEOPIX_IND_DATA_GPIO2, ANEOPIX_IN
 #endif
 
 #if defined(ESP32)
-#  define JSON_MSG_BUFFER    768
+#  define JSON_MSG_BUFFER    816 // adjusted to minimum size covering largest Theengs device JSON properties (RuuviTag_RAWv2)
 #  define SIGNAL_SIZE_UL_ULL uint64_t
 #  define STRTO_UL_ULL       strtoull
 #elif defined(ESP8266)


### PR DESCRIPTION
816 bytes is just enough for parsing RuuviTag_RAWV2 json properties.

Resolves #1905

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
