### PR TITLE
[SYS] Log Theengs props deserilization failures

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1020,7 +1020,18 @@ void launchBTDiscovery(bool overrideDiscovery) {
           }
           if (!properties.empty()) {
             StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
-            deserializeJson(jsonBuffer, properties);
+            auto error = deserializeJson(jsonBuffer, properties);
+            if (error) {
+              if (jsonBuffer.overflowed()) {
+                // This should not happen if JSON_MSG_BUFFER is large enough for
+                // the Theengs json properties
+                Log.error(F("JSON deserialization of Theengs properties overflowed (error %s), buffer capacity: %u. Program might crash. Properties json: %s" CR),
+                          error.c_str(), jsonBuffer.capacity(), properties.c_str());
+              } else {
+                Log.error(F("JSON deserialization of Theengs properties errored: %" CR), 
+                          error.c_str());
+              }
+            }
             for (JsonPair prop : jsonBuffer["properties"].as<JsonObject>()) {
               Log.trace(F("Key: %s"), prop.key().c_str());
               Log.trace(F("Unit: %s"), prop.value()["unit"].as<const char*>());

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1028,7 +1028,7 @@ void launchBTDiscovery(bool overrideDiscovery) {
                 Log.error(F("JSON deserialization of Theengs properties overflowed (error %s), buffer capacity: %u. Program might crash. Properties json: %s" CR),
                           error.c_str(), jsonBuffer.capacity(), properties.c_str());
               } else {
-                Log.error(F("JSON deserialization of Theengs properties errored: %" CR), 
+                Log.error(F("JSON deserialization of Theengs properties errored: %" CR),
                           error.c_str());
               }
             }


### PR DESCRIPTION
Now we log failing theengs json props deserialization failures. 

**Note:** the rest of the function implementation is kept as is, with no null/data-validity checks, and NoMemory-erroring deserialization is likely to follow with a crash later in the strcmp conditionals like in #1905.

The code could be implemented more defensivly, in such a way that approriate null checks are in place before strcmp...then the code would work with "best-effort" basis in limited-memory (non-ESP32) environments. However, as pointed by the main author 1technophile in #1905, support for other boards is likely dropped in the future.

Related to #1905

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
