### PR TITLE
Use configured "packages_dir"

### DIFF
--- a/scripts/replace_lib.py
+++ b/scripts/replace_lib.py
@@ -13,9 +13,8 @@ def calculate_md5(filepath):
 
 def main():
     print(f"Pre build BLE library replacement script")
-    home_path = os.environ.get('HOME') or os.environ.get('USERPROFILE')
     source_file = 'lib/esp32-bt-lib/esp32/libbtdm_app.a'
-    destination_file = os.path.join(home_path, '.platformio', 'packages', 'framework-arduinoespressif32', 'tools', 'sdk', 'esp32', 'ld', 'libbtdm_app.a')
+    destination_file = os.path.join(env.GetProjectConfig().get("platformio", "packages_dir"), 'framework-arduinoespressif32', 'tools', 'sdk', 'esp32', 'ld', 'libbtdm_app.a')
 
     try:
         shutil.copyfile(source_file, destination_file)


### PR DESCRIPTION
* https://docs.platformio.org/en/latest/scripting/examples/platformio_ini_custom_options.html
* https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/packages_dir.html

A user can override `packages_dir` or `core_dir`. So, it is better to use real value instead of static pointed to the HOME.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
