### PR TITLE
[BT] Prevent intervalacts from being lower than interval

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -222,6 +222,10 @@ If you want to change the time between active scans you can change it by MQTT. F
 
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"intervalacts":300000}'`
 
+::: warning Note
+The active scan interval `intervalacts` can only bet set equal to or higher than the passive scan interval `interval`, as any lower value would not make any sense.
+:::
+
 ## Setting the duration of a scan (available with HA discovery)
 
 If you want to change the default duration of each scan cycle to 5 seconds

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -195,11 +195,20 @@ void BTConfig_fromJson(JsonObject& BTdata, bool startup = false) {
   btPresenceParametersDiscovery();
 #  endif
   // Time before before active scan
-  // Scan interval set
-  if (BTdata.containsKey("interval") && BTdata["interval"] != 0)
+  // Scan interval set - and avoid intervalacts to be lower than interval
+  if (BTdata.containsKey("interval") && BTdata["interval"] != 0) {
     Config_update(BTdata, "interval", BTConfig.BLEinterval);
-  // Define if the scan is adaptive or not
-  Config_update(BTdata, "intervalacts", BTConfig.intervalActiveScan);
+    if (BTConfig.intervalActiveScan < BTConfig.BLEinterval) {
+      Config_update(BTdata, "interval", BTConfig.intervalActiveScan);
+    }
+  }
+  // Define if the scan is adaptive or not - and avoid intervalacts to be lower than interval
+  if (BTdata.containsKey("intervalacts") && BTdata["intervalacts"] < BTConfig.BLEinterval) {
+    // Config_update(BTdata, "interval", BTConfig.intervalActiveScan);
+    BTConfig.intervalActiveScan = BTConfig.BLEinterval;
+  } else {
+    Config_update(BTdata, "intervalacts", BTConfig.intervalActiveScan);
+  }
   // Time before a connect set
   Config_update(BTdata, "intervalcnct", BTConfig.intervalConnect);
   // publish all BLE devices discovered or  only the identified sensors (like temperature sensors)


### PR DESCRIPTION
Prevent intervalacts from being lower than interval to avoid untrue non-sensical intervalacts values.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
