### PR TITLE
[HA Discovery] Do not deactive autodiscovery when discovery_republish_on_reconnect is enabled

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -2003,8 +2003,9 @@ void loop() {
       // We have just re-connected if connected was previously false
       bool justReconnected = !connected;
 #ifdef ZmqttDiscovery
-      // Deactivate autodiscovery after DiscoveryAutoOffTimer
-      if (SYSConfig.discovery && (now > lastDiscovery + DiscoveryAutoOffTimer))
+      // Deactivate autodiscovery after DiscoveryAutoOffTimer.
+      // Exception: when discovery_republish_on_reconnect is enabled, we never never automatically disable discovery
+      if (!discovery_republish_on_reconnect && SYSConfig.discovery && (now > lastDiscovery + DiscoveryAutoOffTimer))
         SYSConfig.discovery = false;
       // at first connection we publish the discovery payloads
       // or, when we have just re-connected (only when discovery_republish_on_reconnect is enabled)


### PR DESCRIPTION
Do not deactive autodiscovery in certain cases when `discovery_republish_on_reconnect` (see https://github.com/1technophile/OpenMQTTGateway/pull/1274 and https://github.com/1technophile/OpenMQTTGateway/pull/1290 ) is enabled

The introduction of `DiscoveryAutoOffTimer` in https://github.com/1technophile/OpenMQTTGateway/commit/3f92e14ba6d22173bba0b5b7d43743663a5eac1a / https://github.com/1technophile/OpenMQTTGateway/pull/1541 introduced a regression for the re-publishing of discovery topics (`discovery_republish_on_reconnect`) as first introduced in https://github.com/1technophile/OpenMQTTGateway/pull/1290 - after `DiscoveryAutoOffTimer` has elapsed, the system does not republish the topics even when MQTT connection is re-established.

This PR disables the effect of `DiscoveryAutoOffTimer` when `discovery_republish_on_reconnect` is enabled

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
