### PR TITLE
Differentiation between OOK and FSK modulation in default environments' names

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -794,7 +794,7 @@ build_flags =
 ; *** OpenMQTTGateway Config ***
   ;'-UZmqttDiscovery'          ; disables MQTT Discovery
   '-DvalueAsATopic=true'       ; MQTT topic includes model and device
-  '-DGateway_Name="OMG_heltec_rtl_433_ESP"'
+  '-DGateway_Name="OMG_heltec_rtl_433_ESP_OOK"'
 ; *** OpenMQTTGateway Modules ***
   '-DZgatewayRTL_433="rtl_433"'
   '-DZradioSX127x="SX127x"'
@@ -823,7 +823,7 @@ build_flags =
 ; *** OpenMQTTGateway Config ***
   ;'-UZmqttDiscovery'          ; disables MQTT Discovery
   '-DvalueAsATopic=true'       ; MQTT topic includes model and device
-  '-DGateway_Name="OMG_heltec_rtl_433_ESP"'
+  '-DGateway_Name="OMG_heltec_rtl_433_ESP_FSK"'
   '-DOOK_MODULATION=false' ; FSK modulation activated
   '-DRF_FREQUENCY=915'
   ;-DRF_FREQUENCY=868.300'
@@ -881,7 +881,7 @@ build_flags =
 ; *** OpenMQTTGateway Config ***
   ;'-UZmqttDiscovery'          ; disables MQTT Discovery
   '-DvalueAsATopic=true'    ; MQTT topic includes model and device
-  '-DGateway_Name="OMG_lilygo_rtl_433_ESP"'
+  '-DGateway_Name="OMG_lilygo_rtl_433_ESP_OOK"'
 ; *** OpenMQTTGateway Modules ***
   '-DZgatewayRTL_433="rtl_433"'
   '-DZradioSX127x="SX127x"'
@@ -910,7 +910,7 @@ build_flags =
 ; *** OpenMQTTGateway Config ***
   ;'-UZmqttDiscovery'          ; disables MQTT Discovery
   '-DvalueAsATopic=true'    ; MQTT topic includes model and device
-  '-DGateway_Name="OMG_lilygo_rtl_433_ESP"'
+  '-DGateway_Name="OMG_lilygo_rtl_433_ESP_FSK"'
   '-DOOK_MODULATION=false' ; FSK modulation activated
   '-DRF_FREQUENCY=915'
   ;-DRF_FREQUENCY=868.300'


### PR DESCRIPTION
Differentiation between OOK and FSK modulation in default environments' gateway names to avoid possible duplicate/conflicting discoveries

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
