### PR TITLE
[DISC] Add the capability to use the device BLE name

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -393,9 +393,9 @@ void createDiscovery(const char* sensor_type,
       device["mdl"] = device_model;
     }
 
-    // generate unique device name by adding the second half of the device_id only if device_name and device_id are different
+    // generate unique device name by adding the second half of the device_id only if device_name and device_id are different and we don't want to use the BLE name
     if (device_name[0]) {
-      if (strcmp(device_id, device_name) != 0 && device_id[0]) {
+      if (strcmp(device_id, device_name) != 0 && device_id[0] && !ForceDeviceName) {
         device["name"] = device_name + String("-") + String(device_id + 6);
       } else {
         device["name"] = device_name;

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -116,15 +116,9 @@ extern String stateBTMeasures(bool);
 #  define HassPresence false //true if we publish into Home Assistant presence topic
 #endif
 
-#define HMSerialSpeed 9600 // Communication speed with the HM module, softwareserial doesn't support 115200
-//#define HM_BLUE_LED_STOP true //uncomment to stop the blue led light of HM1X
-
-#define BLEdelimiter       "4f4b2b444953413a" // OK+DISA:
-#define BLEEndOfDiscovery  "4f4b2b4449534345" // OK+DISCE
-#define BLEdelimiterLength 16
-#define CRLR               "0d0a"
-#define CRLR_Length        4
-#define BLE_CNCT_TIMEOUT   3000
+#ifndef BLE_CNCT_TIMEOUT
+#  define BLE_CNCT_TIMEOUT 3000
+#endif
 
 unsigned long scanCount = 0;
 
@@ -210,6 +204,7 @@ struct BLEAction {
 
 struct BLEdevice {
   char macAdr[18];
+  char name[20];
   int macType;
   bool isDisc;
   bool isWhtL;

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -129,6 +129,10 @@ void announceDeviceTrigger(bool use_gateway_info,
 #  define GATEWAY_MANUFACTURER "OMG_community"
 #endif
 
+#ifndef ForceDeviceName
+#  define ForceDeviceName false // Set to true to force the device name to be from the name of the device and not the model
+#endif
+
 /*-------------- Auto discovery macros-----------------*/
 // Set the line below to true so as to have autodiscovery working with OpenHAB
 #ifndef OpenHABDiscovery


### PR DESCRIPTION
## Description:
Enabling the capability to use the device name for discovery instead of the concatenation of the model + 6 last digits of the mac 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
