### PR TITLE
[ONBOARD] Use Gateway short name macro

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -57,7 +57,7 @@
 #  define Gateway_Name "OpenMQTTGateway"
 #endif
 #ifndef Gateway_Short_Name
-#  define Gateway_Short_Name "OMG"
+#  define Gateway_Short_Name "OMG" // 3 characters maximum
 #endif
 
 #ifndef Base_Topic

--- a/main/Zblufi.ino
+++ b/main/Zblufi.ino
@@ -254,8 +254,13 @@ bool startBlufi() {
   esp_blufi_btc_init();
   uint8_t mac[6];
   esp_read_mac(mac, ESP_MAC_WIFI_STA);
-  char advName[20] = {0};
-  snprintf(advName, sizeof(advName), "OMGBFI_%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  char advName[17] = {0};
+  // Check length of Gateway_Short_Name
+  if (strlen(Gateway_Short_Name) > 3) {
+    Log.error(F("Gateway_Short_Name is too long, max 3 characters" CR));
+    return false;
+  }
+  snprintf(advName, sizeof(advName), Gateway_Short_Name "_%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
   NimBLEDevice::init(advName);
   esp_blufi_gatt_svr_init();
   ble_gatts_start();


### PR DESCRIPTION
## Description:
Use Gateway short name macro for BLE discovery

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
