### PR TITLE
[SYS] Change log level when publication is canceled

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -651,7 +651,7 @@ void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
       Log.warning(F("Client not connected, aborting the publication" CR));
     }
   } else {
-    Log.trace(F("[ OMG->MQTT CANCELED] topic: %s msg: %s " CR), topic, payload);
+    Log.notice(F("[ OMG->MQTT CANCELED] topic: %s msg: %s " CR), topic, payload);
   }
 }
 


### PR DESCRIPTION
## Description:
Enable to identify in the Serial console when the MQTT publication is canceled for a message with the default log level.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
