### PR TITLE
[SYS] Add connection fallback capability

### DIFF
--- a/docs/use/gateway.md
+++ b/docs/use/gateway.md
@@ -140,6 +140,10 @@ mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m
  }'
  ```
 
+::: tip
+If the client can't connect to the MQTT broker corresponding to the current `cnt_index`, it will increment the index to the next valid connection set and restart with it.
+:::
+
 ## Saving/Loading connection parameters/certificates at runtime
 This chapter details the process for managing certificates/connections parameters used for secure MQTT communication with OpenMQTTGateway
 

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -284,8 +284,9 @@ struct ss_cnt_parameters {
 // Index 0 is used for connection parameters provided in the build that can be overloaded by WiFi Manager/Onboarding/WebUI,MQTT
 #define CNT_DEFAULT_INDEX 0
 // Index 1 and more are used for connection parameters provided at runtime by MQTT
+#define cnt_parameters_array_size 3
 
-ss_cnt_parameters cnt_parameters_array[3] = {
+ss_cnt_parameters cnt_parameters_array[cnt_parameters_array_size] = {
     {ss_server_cert, ss_client_cert, ss_client_key, OTAserver_cert, MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, true},
     {"", "", "", "", MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false},
     {"", "", "", "", MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false}};

--- a/main/main.ino
+++ b/main/main.ino
@@ -886,7 +886,26 @@ void connectMQTT() {
     delayWithOTA(5000);
     ErrorIndicatorOFF();
     delayWithOTA(5000);
+
+    // If we have failed to connect to the MQTT broker, we will try to connect to the next set of connection parameters
     if (failure_number_mqtt > maxRetryWatchDog) {
+#ifndef ESPWifiManualSetup
+      // Look for the next valid connection
+      for (int i = 0; i < cnt_parameters_array_size; i++) {
+        cnt_index++;
+        if (cnt_index >= cnt_parameters_array_size) {
+          cnt_index = 0;
+        }
+        if (cnt_parameters_array[cnt_index].validConnection) {
+          Log.notice(F("Connection %d valid, switching" CR), cnt_index);
+          saveConfig();
+          break;
+        } else {
+          Log.notice(F("Connection %d not valid" CR), cnt_index);
+        }
+      }
+#endif
+
       unsigned long millis_since_last_ota;
       while (
           // When


### PR DESCRIPTION
## Description:
This feature enables to rotate among the connection parameters index to find a valid one when the current MQTT connection is not working

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
