### PR TITLE
[SYS] Use PicoMQTT for MQTT communication

### DIFF
--- a/docs/upload/builds.md
+++ b/docs/upload/builds.md
@@ -18,7 +18,7 @@ PlatformIO config files work on the concept of overriding. At first, a very simp
 [env]
 framework = arduino
 lib_deps =
-  ${libraries.pubsubclient}
+  ${libraries.picomqtt}
   ${libraries.arduinojson}
   ${libraries.arduinolog}
 build_flags =

--- a/docs/upload/troubleshoot.md
+++ b/docs/upload/troubleshoot.md
@@ -38,9 +38,9 @@ instead of
 ## Repetitive MQTT disconnections or/and commands sent to the gateway not taken into account
 Most probably a network issue, don't use a guest network and if going through a firewall check its rules. To put aside gateway issue, try to connect to a local broker on the same network.
 
-## You don't see the messages appearing on your broker but they appears on the serial monitor
-This is due to a too small MQTT packet size, open User_config.h and set:
-`#define mqtt_max_packet_size 1024`
+## OMG ignores messages sent to it via MQTT
+This can happen if the messages are too big and exceed the internal buffer size limit.  To fix this, check the size of the message you're sending (in bytes).  Next, open `User_config.h` and set `mqtt_max_payload_size` to be greater than that size, e.g.:
+`#define mqtt_max_payload_size 1024`
 
 ## ESP Continuous restart or strange behaviour:
 This can be due to corruption of the ESP flash memory, try to erase flash and upload OMG on it again.

--- a/docs/use/ir.md
+++ b/docs/use/ir.md
@@ -107,12 +107,10 @@ In this case the best way is to use hex values instead, but if you can't you may
 In User_config.h replace:
 ```cpp
 # define JSON_MSG_BUFFER 512
-# define mqtt_max_packet_size 1024
 ```
 by
 ```cpp
 # define JSON_MSG_BUFFER 1280
-# define mqtt_max_packet_size 1280
 ```
 
 ## Repeat the IR signal OpenMQTTGateway receive

--- a/environments.ini
+++ b/environments.ini
@@ -26,7 +26,7 @@ custom_description = RF gateway for the Sonoff RF Bridge relying on the internal
 custom_hardware = RFBridge v1
 
 [env:rfbridge-direct]
-platform = espressif8266@^2
+platform = ${com.esp8266_platform}
 board = esp8285
 lib_deps =
   ${com-esp.lib_deps}
@@ -42,6 +42,7 @@ build_flags =
   '-DZsensorGPIOInput="GPIOInput"'
   '-DINPUT_GPIO=0'
   '-DGateway_Name="OMG_SRFB_Direct"'
+  '-fcommon'
 board_build.flash_mode = dout
 board_build.ldscript = eagle.flash.1m64.ld ;this frees more space for firmware uplad via OTA.
 ;extra_scripts = scripts/compressFirmware.py ;uncomment this to compress the firmware. This helps updating e.g. Sonoff RF Bridge via OTA flash by saving space for the uploaded firmware.
@@ -1459,7 +1460,7 @@ board_build.flash_mode = dout
 custom_description = KAKU RF gateway using NewRemoteSwitch library, need CC1101
 
 [env:nodemcuv2-pilight]
-platform = espressif8266@^2
+platform = ${com.esp8266_platform}
 board = nodemcuv2
 lib_deps =
   ${com-esp.lib_deps}
@@ -1470,6 +1471,7 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayPilight="Pilight"'
   '-DGateway_Name="OMG_ESP8266_Pilight"'
+  '-fcommon'
 board_build.flash_mode = dout
 custom_description = Gateway using ESPilight without the need of CC1101
 

--- a/environments.ini
+++ b/environments.ini
@@ -1781,5 +1781,5 @@ build_flags =
   '-DLED_SEND_RECEIVE_ON=0'
   '-DGateway_Name="OMG_ESP32_BLE"'
   '-DUSE_BLUFI=1'
-  '-DARDUINO_LOOP_STACK_SIZE=15000'
+  '-DARDUINO_LOOP_STACK_SIZE=16000'
 custom_description = Regular BLE gateway based on esp-idf with adaptive scanning activated, automatically adapts the scan parameters depending on your devices

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -162,8 +162,8 @@
 #  endif
 #endif
 
-#ifndef mqtt_max_topic_size
-#  define mqtt_max_packet_size JSON_MSG_BUFFER_MAX + mqtt_topic_max_size + 10 // maximum size of the MQTT packet
+#ifndef mqtt_max_payload_size
+#  define mqtt_max_payload_size JSON_MSG_BUFFER_MAX // maximum size of the MQTT payload
 #endif
 
 #ifndef MQTT_USER

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -803,7 +803,7 @@ void coreTask(void* pvParameters) {
   while (true) {
     if (!BTProcessLock) {
       int n = 0;
-      while (client.state() != 0 && n <= InitialMQTTConnectionTimeout && !BTProcessLock) {
+      while (mqtt->connected() && n <= InitialMQTTConnectionTimeout && !BTProcessLock) {
         n++;
         delay(1000);
       }

--- a/platformio.ini
+++ b/platformio.ini
@@ -174,7 +174,7 @@ monitor_speed = 115200
 [com]
 esp8266_platform = espressif8266@4.1.0
 esp32_platform = espressif32@6.1.0
-esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.5/platform-espressif32-v.2.0.5.zip
+esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 atmelavr_platform = atmelavr@3.3.0
 
 [com-esp] ; Used by all ESP8266/ESP8285 based builds

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,7 +113,7 @@ extra_configs =
 [libraries]
 arduinojson = ArduinoJson@6.18.3
 arduinolog = https://github.com/1technophile/Arduino-Log.git#f634509
-pubsubclient = PubSubClient@2.8
+picomqtt = PicoMQTT@1.1.1
 rc-switch = https://github.com/1technophile/rc-switch.git#98537e9
 newremoteswitch = https://github.com/1technophile/NewRemoteSwitch.git#8eb980e
 ble = https://github.com/h2zero/NimBLE-Arduino.git#1.4.1
@@ -161,7 +161,7 @@ rn8209 = https://github.com/theengs/RN8209C-SDK.git#arduino
 [env]
 framework = arduino
 lib_deps =
-  ${libraries.pubsubclient}
+  ${libraries.picomqtt}
   ${libraries.arduinojson}
   ${libraries.arduinolog}
 build_flags =


### PR DESCRIPTION
## Description:

This replaces the MQTT library from [PubSubClient](https://github.com/knolleary/pubsubclient) to [PicoMQTT](https://github.com/mlesniew/PicoMQTT).  

This PR doesn't change functionality, the changes shouldn't affect the end user, because the project should work just as before.  

Switching to PicoMQTT opens the path to implementing a MQTT broker withing OMG.   

## TODO

A few things still need to be updated before this is merged:
- The project does not build for the `rfbridge-direct`, `shelly-plus1` and `nodemcuv2-pilight` environments.  These configurations use outdated board core versions, which are not supported by PicoMQTT.  Simply updating the configs to use newer core versions results in linker errors.
- Just like in the original code, MQTT settings are reverted to old values when a new configuration doesn't work.  However, the original logic around this was complex and recently updated, so it needs a careful review.      

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
