### PR TITLE
[DISC] always auto-discover Presence/Tracker timeout

### DIFF
--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -301,6 +301,8 @@ void BM2_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, si
       float volt = ((output[2] | (output[1] << 8)) >> 4) / 100.0f;
       BLEdata["volt"] = volt;
       Log.trace(F("volt: %F" CR), volt);
+      // to avoid the BM2 device tracker going offline because of the voltage MQTT message without an RSSI value
+      BLEdata["rssi"] = -60;
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
       handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
     } else {

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -156,10 +156,6 @@ void BTConfig_fromJson(JsonObject& BTdata, bool startup = false) {
   if (startup == false) {
     if (BTdata.containsKey("hasspresence") && BTdata["hasspresence"] == false && BTConfig.presenceEnable == true) {
       BTdata["adaptivescan"] = true;
-#  ifdef ZmqttDiscovery
-      // Remove discovered entities
-      eraseTopic("number", (char*)getUniqueId("presenceawaytimer", "").c_str());
-#  endif
     } else if (BTdata.containsKey("hasspresence") && BTdata["hasspresence"] == true && BTConfig.presenceEnable == false) {
       BTdata["adaptivescan"] = false;
     }

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -423,17 +423,15 @@ void eraseTopic(const char* sensor_type, const char* unique_id) {
 
 #  ifdef ZgatewayBT
 void btPresenceParametersDiscovery() {
-  if (BTConfig.presenceEnable) {
-    createDiscovery("number", //set Type
-                    subjectBTtoMQTT, "BT: Presence detection timer", (char*)getUniqueId("presenceawaytimer", "").c_str(), //set state_topic,name,uniqueId
-                    will_Topic, "", "{{ value_json.presenceawaytimer/60000 }}", //set availability_topic,device_class,value_template,
-                    "{\"presenceawaytimer\":{{value*60000}},\"save\":true}", "", "min", //set,payload_on,payload_off,unit_of_meas,
-                    0, //set  off_delay
-                    Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoBTset, //set,payload_available,payload_not available   ,is a gateway entity, command topic
-                    "", "", "", "", false, // device name, device manufacturer, device model, device ID, retain,
-                    stateClassNone //State Class
-    );
-  }
+  createDiscovery("number", //set Type
+                  subjectBTtoMQTT, "BT: Presence/Tracker timeout", (char*)getUniqueId("presenceawaytimer", "").c_str(), //set state_topic,name,uniqueId
+                  will_Topic, "", "{{ value_json.presenceawaytimer/60000 }}", //set availability_topic,device_class,value_template,
+                  "{\"presenceawaytimer\":{{value*60000}},\"save\":true}", "", "min", //set,payload_on,payload_off,unit_of_meas,
+                  0, //set  off_delay
+                  Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoBTset, //set,payload_available,payload_not available   ,is a gateway entity, command topic
+                  "", "", "", "", false, // device name, device manufacturer, device model, device ID, retain,
+                  stateClassNone //State Class
+  );
 }
 
 void btScanParametersDiscovery() {


### PR DESCRIPTION
auto-discover Presence/Tracker timeout even when HASS presence is not active

Also inject an additional placeholder rssi key and value into the BM2 voltage connection message to avoid the message being registered as a device tracker AWAY

https://community.openmqttgateway.com/t/bm2-home-and-away/3315

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
