### PR TITLE
[RTL] Correct string handling for type key in NAMING_KEYS

### DIFF
--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -88,12 +88,10 @@ void createOrUpdateDeviceRTL_433(const char* id, const char* model, const char* 
     if (strlcpy(device->modelName, model, modelNameSize) > modelNameSize) {
       Log.warning(F("[rtl_433] Device model %s exceeds available space" CR), model); // Remove from production release ?
     };
-    // #1909 begin
     if (strlcpy(device->type, type, typeSize) > typeSize) {
       Log.warning(F("[rtl_433] Device type %s exceeds available space" CR), type); // Remove from production release ?
     }
     DISCOVERY_TRACE_LOG(F("[rtl_433] Device type is %s." CR), device->type); // Remove from production release ?
-    // #1909 end
     device->isDisc = flags & device_flags_isDisc;
     RTL_433devices.push_back(device);
     newRTL_433Devices++;
@@ -144,7 +142,6 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
 #    if valueAsATopic
           // Remove the key from the unique id to extract the device id
           String idWoKeyAndModel = idWoKey;
-          // #1909 check if type is given 
           if (strcmp(pdevice->type, "null")) {
             idWoKeyAndModel.remove(0, (strlen(pdevice->modelName) + strlen(pdevice->type) + 1)); // type is present
             topic = topic + "/" + String(pdevice->type) + "/" + String(pdevice->modelName); 
@@ -253,8 +250,8 @@ void rtl_433_Callback(char* message) {
   unsigned long MQTTvalue = (int)RFrtl_433_ESPdata["id"] + round((float)RFrtl_433_ESPdata["temperature_C"]);
   String topic = subjectRTL_433toMQTT;
   String model = RFrtl_433_ESPdata["model"];
-  String type = RFrtl_433_ESPdata["type"];      // #1909
-  Log.notice(F("type: %s" CR), type.c_str());   // #1909
+  String type = RFrtl_433_ESPdata["type"];      
+  Log.notice(F("type: %s" CR), type.c_str());   
   String uniqueid;
 
   const char naming_keys[5][8] = {"type", "model", "subtype", "channel", "id"}; // from rtl_433_mqtt_hass.py
@@ -275,7 +272,7 @@ void rtl_433_Callback(char* message) {
 
   uniqueid.replace("/", "-");
 
-  DISCOVERY_TRACE_LOG(F("uniqueid: %s" CR), uniqueid.c_str());  // #1909
+  DISCOVERY_TRACE_LOG(F("uniqueid: %s" CR), uniqueid.c_str());  
   if (!isAduplicateSignal(MQTTvalue)) {
 #  ifdef ZmqttDiscovery
     if (SYSConfig.discovery)

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -144,14 +144,14 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
           String idWoKeyAndModel = idWoKey;
           if (strcmp(pdevice->type, "null")) {
             idWoKeyAndModel.remove(0, (strlen(pdevice->modelName) + strlen(pdevice->type) + 1)); // type is present
-            topic = topic + "/" + String(pdevice->type) + "/" + String(pdevice->modelName); 
+            topic = topic + "/" + String(pdevice->type) + "/" + String(pdevice->modelName);
           } else {
-            idWoKeyAndModel.remove(0, (strlen(pdevice->modelName))); 
-            topic = topic + "/" + String(pdevice->modelName); 
+            idWoKeyAndModel.remove(0, (strlen(pdevice->modelName)));
+            topic = topic + "/" + String(pdevice->modelName);
           }
           DISCOVERY_TRACE_LOG(F("idWoKeyAndModel %s" CR), idWoKeyAndModel.c_str());
           idWoKeyAndModel.replace("-", "/");
-          topic = topic + idWoKeyAndModel; 
+          topic = topic + idWoKeyAndModel;
 #    endif
           if (strcmp(parameters[i][0], "tamper") == 0 || strcmp(parameters[i][0], "alarm") == 0 || strcmp(parameters[i][0], "motion") == 0) {
             createDiscovery("binary_sensor", //set Type
@@ -250,8 +250,8 @@ void rtl_433_Callback(char* message) {
   unsigned long MQTTvalue = (int)RFrtl_433_ESPdata["id"] + round((float)RFrtl_433_ESPdata["temperature_C"]);
   String topic = subjectRTL_433toMQTT;
   String model = RFrtl_433_ESPdata["model"];
-  String type = RFrtl_433_ESPdata["type"];      
-  Log.notice(F("type: %s" CR), type.c_str());   
+  String type = RFrtl_433_ESPdata["type"];
+  Log.notice(F("type: %s" CR), type.c_str());
   String uniqueid;
 
   const char naming_keys[5][8] = {"type", "model", "subtype", "channel", "id"}; // from rtl_433_mqtt_hass.py
@@ -272,7 +272,7 @@ void rtl_433_Callback(char* message) {
 
   uniqueid.replace("/", "-");
 
-  DISCOVERY_TRACE_LOG(F("uniqueid: %s" CR), uniqueid.c_str());  
+  DISCOVERY_TRACE_LOG(F("uniqueid: %s" CR), uniqueid.c_str());
   if (!isAduplicateSignal(MQTTvalue)) {
 #  ifdef ZmqttDiscovery
     if (SYSConfig.discovery)

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -73,12 +73,12 @@ extern void launchRTL_433Discovery(bool overrideDiscovery);
 
 #    define uniqueIdSize  60 // longest model + longest key
 #    define modelNameSize 31 // longest model
-#    define typeSize      10 // longest type  // #1909
+#    define typeSize      10 // longest type  
 
 struct RTL_433device {
   char uniqueId[uniqueIdSize];
   char modelName[modelNameSize];
-  char type[typeSize];    // #1909
+  char type[typeSize];  
   bool isDisc;
 };
 

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -1,15 +1,15 @@
-/*  
+/*
   Theengs OpenMQTTGateway - We Unite Sensors in One Open-Source Interface
 
-   Act as a gateway between your 433mhz, infrared IR, BLE, LoRa signal and one interface like an MQTT broker 
+   Act as a gateway between your 433mhz, infrared IR, BLE, LoRa signal and one interface like an MQTT broker
    Send and receiving command by MQTT
- 
+
    This files enables to set your parameter for the radiofrequency gateways (ZgatewayRF and ZgatewayRF2) with RCswitch and newremoteswitch library
-  
+
     Copyright: (c)Florian ROBERT
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -73,12 +73,12 @@ extern void launchRTL_433Discovery(bool overrideDiscovery);
 
 #    define uniqueIdSize  60 // longest model + longest key
 #    define modelNameSize 31 // longest model
-#    define typeSize      10 // longest type  
+#    define typeSize      10 // longest type
 
 struct RTL_433device {
   char uniqueId[uniqueIdSize];
   char modelName[modelNameSize];
-  char type[typeSize];  
+  char type[typeSize];
   bool isDisc;
 };
 

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -73,10 +73,12 @@ extern void launchRTL_433Discovery(bool overrideDiscovery);
 
 #    define uniqueIdSize  60 // longest model + longest key
 #    define modelNameSize 31 // longest model
+#    define typeSize      10 // longest type  // #1909
 
 struct RTL_433device {
   char uniqueId[uniqueIdSize];
   char modelName[modelNameSize];
+  char type[typeSize];    // #1909
   bool isDisc;
 };
 


### PR DESCRIPTION
Extend class structure RTL_433device and modify code to create correct state topic in discovery message to support sensors, that send type key as well as sensors, that don't. Actually only TPMS sensors use type=TPMS. See issue #1909.

## Description:
The key type of the naming_keys array in ZgatewayRTL_433.ino was not used to create the state topic in discovery messages. Thcaused, that for TPMS sensors the state topic was incorrectly created. With this change, both cases are respected, when key is used and when key is not used.

I tested with my sensors TPMS Jansite-Solar (FSK) and AmbientWeather-TX8300-1-65 (OOK). The sensors were correctly discovered and configured in my openHAB instance.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
