### PR TITLE
[SYS] Fix default connection

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -287,7 +287,7 @@ struct ss_cnt_parameters {
 #define cnt_parameters_array_size 3
 
 ss_cnt_parameters cnt_parameters_array[cnt_parameters_array_size] = {
-    {ss_server_cert, ss_client_cert, ss_client_key, OTAserver_cert, MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, true},
+    {ss_server_cert, ss_client_cert, ss_client_key, OTAserver_cert, MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false},
     {"", "", "", "", MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false},
     {"", "", "", "", MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false}};
 

--- a/main/Zblufi.ino
+++ b/main/Zblufi.ino
@@ -179,6 +179,9 @@ static void example_event_callback(esp_blufi_cb_event_t event, esp_blufi_cb_para
           cnt_index = CNT_DEFAULT_INDEX;
         }
 
+        // We suppose the connection is valid (could be tested before)
+        cnt_parameters_array[cnt_index].validConnection = true;
+
         saveConfig();
       }
       break;

--- a/main/main.ino
+++ b/main/main.ino
@@ -1841,6 +1841,9 @@ bool loadConfigFromFlash() {
           strcat(key, index_suffix);
           if (json.containsKey(key)) {
             cnt_parameters_array[i].validConnection = json[key].as<bool>();
+          } else {
+            // For backward compatibility, if valid_cnt is not found, we assume the connection is valid
+            cnt_parameters_array[i].validConnection = true;
           }
         }
         if (json.containsKey("cnt_index")) {
@@ -2056,9 +2059,9 @@ void setupwifi(bool reset_settings) {
     cnt_parameters_array[cnt_index].client_cert = processCert(custom_client_cert.getValue());
     cnt_parameters_array[cnt_index].client_key = processCert(custom_client_key.getValue());
 #    endif
+#  endif
     // We suppose the connection is valid (could be tested before)
     cnt_parameters_array[cnt_index].validConnection = true;
-#  endif
 
     //save the custom parameters to FS
     saveConfig();


### PR DESCRIPTION
## Description:
Instead of having the connection index 0 considered valid per default, set the status to `true` once the onboarding parameters have been entered.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
