### PR TITLE
[DISC] auto-discovery strcmp instead of substring only strstr

### DIFF
--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -125,7 +125,12 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
     if (overrideDiscovery || !isDiscovered(pdevice)) {
       size_t numRows = sizeof(parameters) / sizeof(parameters[0]);
       for (int i = 0; i < numRows; i++) {
-        if (strstr(pdevice->uniqueId, parameters[i][0]) != 0) {
+        char deviceKeyParameter[25];
+        memcpy(deviceKeyParameter, &pdevice->uniqueId[strlen(pdevice->uniqueId) - strlen(parameters[i][0])], strlen(parameters[i][0]));
+        deviceKeyParameter[strlen(parameters[i][0])] = '\0';
+        Log.trace(F("deviceKeyParameter: %s" CR), deviceKeyParameter);
+
+        if (strcmp(deviceKeyParameter, parameters[i][0]) == 0) {
           // Remove the key from the unique id to extract the device id
           String idWoKey = pdevice->uniqueId;
           idWoKey.remove(idWoKey.length() - (strlen(parameters[i][0]) + 1));

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -82,7 +82,7 @@ struct RTL_433device {
   bool isDisc;
 };
 
-const char parameters[53][4][24] = {
+const char parameters[51][4][24] = {
     // RTL_433 key, name, unit, device_class
     {"alarm", "Alarm", "", ""},
     {"battery_mV", "Battery Voltage", "mV", "voltage"},


### PR DESCRIPTION
To avoid auto-discovery issues due to substring comparison at
https://github.com/1technophile/OpenMQTTGateway/blob/development/main/ZgatewayRTL_433.ino#L128

strcmp instead of substring only strstr

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
