### PR TITLE
[SYS] Improve max buffer

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -902,7 +902,7 @@ void setupBTTasksAndBLE() {
       procBLETask, /* Function to implement the task */
       "procBLETask", /* Name of the task */
 #  ifdef USE_BLUFI
-      13500,
+      12000,
 #  else
       8500, /* Stack size in bytes */
 #  endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -80,7 +80,7 @@ bool ready_to_sleep = false;
 #include <PubSubClient.h>
 
 struct JsonBundle {
-  StaticJsonDocument<JSON_MSG_BUFFER_MAX> doc;
+  StaticJsonDocument<JSON_MSG_BUFFER> doc;
 };
 
 std::queue<JsonBundle> jsonQueue;
@@ -416,7 +416,7 @@ void pubMainCore(JsonObject& data) {
 }
 
 // Add a document to the queue
-void enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER_MAX>& jsonDoc) {
+void enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc) {
   if (jsonDoc.size() == 0) {
     Log.error(F("Empty JSON, skipping" CR));
     return;
@@ -435,7 +435,7 @@ void enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER_MAX>& jsonDoc) {
 
 #ifdef ESP32
 // Semaphore check before enqueueing a document
-bool handleJsonEnqueue(const StaticJsonDocument<JSON_MSG_BUFFER_MAX>& jsonDoc, int timeout) {
+bool handleJsonEnqueue(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc, int timeout) {
   if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(timeout))) {
     enqueueJsonObject(jsonDoc);
     xSemaphoreGive(xQueueMutex);


### PR DESCRIPTION
## Description:
Having the max arduino json buffer is needed only when receiving certificates from MQTT as we are only sending hashes and not the full certificate to MQTT.
We reduce the size of the `procBLETask` to free more ram.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
