### PR TITLE
[ONB] Enable BluFi onboarding with other modules than BT gateway

### DIFF
--- a/main/Zblufi.ino
+++ b/main/Zblufi.ino
@@ -26,7 +26,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #if defined(ESP32) && defined(USE_BLUFI)
-
+#  include "NimBLEDevice.h"
 #  include "esp_blufi_api.h"
 
 extern "C" {


### PR DESCRIPTION
## Description:
With this modification, BluFi onboarding can be used with other OMG modules like RF, IR... without the BT module

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
