### PR TITLE
Allow running an MQTT broker within OMG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           - "theengs-bridge"
           - "esp32dev-ble-idf"
           - "theengs-bridge-v11"
+          - "esp32dev-ble-broker"
     runs-on: ubuntu-latest
     name: Build with PlatformIO
     steps:

--- a/environments.ini
+++ b/environments.ini
@@ -338,6 +338,24 @@ build_flags =
   '-DGateway_Name="OMG_ESP32_BLE"'
 custom_description = Regular BLE gateway with adaptive scanning activated, automatically adapts the scan parameters depending on your devices
 
+[env:esp32dev-ble-broker]
+platform = ${com.esp32_platform}
+board = esp32dev
+extra_scripts = ${com-esp32.extra_scripts}
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp32.lib_deps}
+  ${libraries.ble}
+  ${libraries.decoder}
+build_flags =
+  ${com-esp32.build_flags}
+  '-DZgatewayBT="BT"'
+  '-DLED_SEND_RECEIVE=2'
+  '-DLED_SEND_RECEIVE_ON=0'
+  '-DGateway_Name="OMG_ESP32_BLE"'
+  '-DMQTT_BROKER_MODE=true'
+custom_description = MQTT Broker with BLE gateway with adaptive scanning activated, automatically adapts the scan parameters depending on your devices
+
 [env:esp32dev-ble-mqtt-undecoded]
 platform = ${com.esp32_platform}
 board = esp32dev

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -212,6 +212,15 @@
 #  define AWS_IOT false
 #endif
 
+#ifndef MQTT_BROKER_MODE
+#  define MQTT_BROKER_MODE false
+#endif
+
+#if MQTT_BROKER_MODE
+// In MQTT broker mode the MQTT web config is not needed
+#  define WIFIMNG_HIDE_MQTT_CONFIG true
+#endif
+
 #define GITHUB_OTA_SERVER_CERT_HASH "d4d211b4553af9fac371f24c2268d59d2b0fec6b9aa0fdbbde068f078d7daf86" // SHA256 fingerprint of the certificate used by the OTA server
 
 #if AWS_IOT
@@ -264,6 +273,7 @@ const char* OTAserver_cert = "";
 
 #include <string>
 
+#if !MQTT_BROKER_MODE
 struct ss_cnt_parameters {
   std::string server_cert;
   std::string client_cert;
@@ -279,14 +289,15 @@ struct ss_cnt_parameters {
 };
 
 // Index 0 is used for connection parameters provided in the build that can be overloaded by WiFi Manager/Onboarding/WebUI,MQTT
-#define CNT_DEFAULT_INDEX 0
+#  define CNT_DEFAULT_INDEX 0
 // Index 1 and more are used for connection parameters provided at runtime by MQTT
-#define cnt_parameters_array_size 3
+#  define cnt_parameters_array_size 3
 
 ss_cnt_parameters cnt_parameters_array[cnt_parameters_array_size] = {
     {ss_server_cert, ss_client_cert, ss_client_key, OTAserver_cert, MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false},
     {"", "", "", "", MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false},
     {"", "", "", "", MQTT_SERVER, MQTT_PORT, MQTT_USER, MQTT_PASS, MQTT_SECURE_DEFAULT, MQTT_CERT_VALIDATE_DEFAULT, false}};
+#endif
 
 #define MIN_CERT_LENGTH 200 // Minimum length of a certificate to be considered valid
 

--- a/main/Zblufi.ino
+++ b/main/Zblufi.ino
@@ -145,6 +145,7 @@ static void example_event_callback(esp_blufi_cb_event_t event, esp_blufi_cb_para
       }
       if (!json.isNull()) {
         Log.trace(F("\nparsed json, size: %u" CR), json.memoryUsage());
+#  if !MQTT_BROKER_MODE
         if (json.containsKey("mqtt_server") && json["mqtt_server"].is<const char*>() && json["mqtt_server"].as<String>().length() > 0 && json["mqtt_server"].as<String>().length() < parameters_size)
           strcpy(cnt_parameters_array[CNT_DEFAULT_INDEX].mqtt_server, json["mqtt_server"]);
         if (json.containsKey("mqtt_port") && json["mqtt_port"].is<const char*>() && json["mqtt_port"].as<String>().length() > 0 && json["mqtt_port"].as<String>().length() < parameters_size)
@@ -166,12 +167,6 @@ static void example_event_callback(esp_blufi_cb_event_t event, esp_blufi_cb_para
           cnt_parameters_array[CNT_DEFAULT_INDEX].client_key = json["mqtt_client_key"].as<const char*>();
         if (json.containsKey("ota_server_cert") && json["ota_server_cert"].is<const char*>() && json["ota_server_cert"].as<String>().length() > MIN_CERT_LENGTH)
           cnt_parameters_array[CNT_DEFAULT_INDEX].ota_server_cert = json["ota_server_cert"].as<const char*>();
-        if (json.containsKey("gateway_name"))
-          strcpy(gateway_name, json["gateway_name"]);
-        if (json.containsKey("mqtt_topic"))
-          strcpy(mqtt_topic, json["mqtt_topic"]);
-        if (json.containsKey("ota_pass"))
-          strcpy(ota_pass, json["ota_pass"]);
 
         if (json.containsKey("cnt_index") && json["cnt_index"].is<int>() && json["cnt_index"].as<int>() > 0 && json["cnt_index"].as<int>() < 3) {
           cnt_index = json["cnt_index"].as<int>();
@@ -181,6 +176,14 @@ static void example_event_callback(esp_blufi_cb_event_t event, esp_blufi_cb_para
 
         // We suppose the connection is valid (could be tested before)
         cnt_parameters_array[cnt_index].validConnection = true;
+#  endif
+
+        if (json.containsKey("gateway_name"))
+          strcpy(gateway_name, json["gateway_name"]);
+        if (json.containsKey("mqtt_topic"))
+          strcpy(mqtt_topic, json["mqtt_topic"]);
+        if (json.containsKey("ota_pass"))
+          strcpy(ota_pass, json["ota_pass"]);
 
         saveConfig();
       }

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -807,7 +807,7 @@ void coreTask(void* pvParameters) {
         n++;
         delay(1000);
       }
-      if (!connected) {
+      if (!mqtt->connected()) {
         Log.warning(F("MQTT client or Network disconnected no BLE scan" CR));
       } else if (!BTProcessLock) {
         if (xSemaphoreTake(semaphoreBLEOperation, pdMS_TO_TICKS(30000)) == pdTRUE) {

--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -706,6 +706,7 @@ void handleMQ() {
       JsonObject WEBtoSYS = WEBtoSYSBuffer.to<JsonObject>();
       bool update = false;
 
+#  if !MQTT_BROKER_MODE
       if (server.hasArg("mh")) {
         WEBtoSYS["mqtt_server"] = server.arg("mh");
         if (strncmp(cnt_parameters_array[CNT_DEFAULT_INDEX].mqtt_server, server.arg("mh").c_str(), parameters_size)) {
@@ -746,6 +747,7 @@ void handleMQ() {
           WEBtoSYS.remove(it);
         }
       }
+#  endif
 
       if (server.hasArg("h")) {
         WEBtoSYS["gateway_name"] = server.arg("h");
@@ -802,7 +804,11 @@ void handleMQ() {
   response += String(script);
   response += String(style);
   // mqtt server (mh), mqtt port (ml), mqtt username (mu), mqtt password (mp), secure connection (sc), server certificate (msc), topic (mt)
+#  if MQTT_BROKER_MODE
+  snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, config_mqtt_body, jsonChar, gateway_name, "", "1883", "", "", gateway_name, mqtt_topic);
+#  else
   snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, config_mqtt_body, jsonChar, gateway_name, cnt_parameters_array[CNT_DEFAULT_INDEX].mqtt_server, cnt_parameters_array[CNT_DEFAULT_INDEX].mqtt_port, cnt_parameters_array[CNT_DEFAULT_INDEX].mqtt_user, (cnt_parameters_array[CNT_DEFAULT_INDEX].isConnectionSecure ? "checked" : ""), gateway_name, mqtt_topic);
+#  endif
   response += String(buffer);
   snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, footer, OMG_VERSION);
   response += String(buffer);


### PR DESCRIPTION
## Description:
This change adds the possibility to run a MQTT broker instead of an MQTT client on the microcontroller. 

To switch to broker mode, the `MQTT_BROKER_MODE` must be defined to `true`.  A new environment configuration `esp32dev-ble-broker` has been added and it has this preprocessor macro defined.  It is otherwise identical to `esp32dev-ble`. 

Currently the broker is listening on the WiFi interface, on port 1883.  To keep the PR small and simple, there currently are little configuration possibilities in broker mode.  However, the code is extendible and support for listening on different ports, allowing websocket connections, or listening on Ethernet can be easily added.  

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).