### PR TITLE
Fix capitalization of rssithreshold in documentation

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -154,7 +154,7 @@ Registering protocol [102] "X10 Security"
 
 Delta applied to RSSI floor noise level to determine start and end of signal, defaults to 9db.
 
-`home/OpenMQTTGateway/commands/MQTTtoRF/config {"rssiThreshold": 9}`
+`home/OpenMQTTGateway/commands/MQTTtoRF/config {"rssithreshold": 9}`
 
 ### Retrieve current status of receiver
 


### PR DESCRIPTION
## Description:

See https://github.com/1technophile/OpenMQTTGateway/blob/8537b7498d887da910733da1818720361b585b25/main/ZcommonRF.ino#L208


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
