### PR TITLE
[SYS] Refine json buffer maximum size

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -158,7 +158,7 @@
 #  if MQTT_SECURE_DEFAULT
 #    define JSON_MSG_BUFFER_MAX 2048 // Json message buffer size increased to handle certificate changes through MQTT, used for the queue and the coming MQTT messages
 #  else
-#    define JSON_MSG_BUFFER_MAX JSON_MSG_BUFFER
+#    define JSON_MSG_BUFFER_MAX 898 // Minimum size for the cover MQTT discovery message
 #  endif
 #endif
 

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -240,7 +240,7 @@ void createDiscovery(const char* sensor_type,
                      const char* payload_available, const char* payload_not_available, bool gateway_entity, const char* cmd_topic,
                      const char* device_name, const char* device_manufacturer, const char* device_model, const char* device_id, bool retainCmd,
                      const char* state_class, const char* state_off, const char* state_on, const char* enum_options, const char* command_template) {
-  StaticJsonDocument<1024> jsonBuffer;
+  StaticJsonDocument<JSON_MSG_BUFFER_MAX> jsonBuffer;
   JsonObject sensor = jsonBuffer.to<JsonObject>();
 
   // If a component cannot render it's state (f.i. KAKU relays) no state topic


### PR DESCRIPTION
## Description:
The add of the cover component requires an MQTT discovery message with a minimum size > of the current JSON_MSG_BUFFER
We use JSON_MSG_BUFFER_MAX in the createDiscovery method and increase its size to 898.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
