### PR TITLE
Touch Based Display Blanking

### DIFF
--- a/main/config_SSD1306.h
+++ b/main/config_SSD1306.h
@@ -105,6 +105,22 @@
 #define subjectMQTTtoSSD1306set "/commands/MQTTtoSSD1306/config"
 #define subjectSSD1306toMQTT    "/SSD1306toMQTT"
 
+/*-------------------Display Blanking via Touch----------------------*/
+
+#ifdef DISPLAY_BLANKING
+#  ifndef DISPLAY_BLANKING_TOUCH_GPIO
+#    define DISPLAY_BLANKING_TOUCH_GPIO 2 // GPIO pin for touch sensor
+#  endif
+#  ifndef DISPLAY_BLANKING_START
+#    define DISPLAY_BLANKING_START 30 // 30 seconds after last touch
+#  endif
+#  ifndef DISPLAY_BLANKING_THRESHOLD
+#    define DISPLAY_BLANKING_THRESHOLD 10
+#  endif
+#  define TOUCH_READINGS  100 // Number of readings to average
+#  define TOUCH_THRESHOLD 0.2 // 20% change in reading
+#endif
+
 /*-------------------EXTERNAL FUNCTIONS----------------------*/
 
 extern void setupSSD1306();


### PR DESCRIPTION
## Description:

I had an interesting thought the other day, what about leveraging the ESP32 Touch sensor, and use it to enable the SSD1306 display ?

This is a quick pull request with the feature.

To enable, add 'DISPLAY_BLANKING=true' to your compiler directives, and connect a wire to `DISPLAY_BLANKING_TOUCH_GPIO` ( defaults to GPIO 2 ).

Then when you touch the wire, the screen turns on for 30 seconds.   If you build a case, just expose the wire.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
