### PR TITLE
[WEBUI] Update ZwebUI.ino - Convert WiFi.SSID() to c_string (JJK)

### DIFF
--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -616,7 +616,7 @@ void handleWI() {
       response += String(wifi_script);
       response += String(script);
       response += String(style);
-      snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, config_wifi_body, jsonChar, gateway_name, WiFiScan.c_str(), WiFi.SSID());
+      snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, config_wifi_body, jsonChar, gateway_name, WiFiScan.c_str(), WiFi.SSID().c_str());
       response += String(buffer);
       snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, footer, OMG_VERSION);
       response += String(buffer);
@@ -675,7 +675,7 @@ void handleWI() {
   response += String(wifi_script);
   response += String(script);
   response += String(style);
-  snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, config_wifi_body, jsonChar, gateway_name, WiFiScan.c_str(), WiFi.SSID());
+  snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, config_wifi_body, jsonChar, gateway_name, WiFiScan.c_str(), WiFi.SSID().c_str());
   response += String(buffer);
   snprintf(buffer, WEB_TEMPLATE_BUFFER_MAX_SIZE, footer, OMG_VERSION);
   response += String(buffer);


### PR DESCRIPTION
## Description: This fixes ONE of the TWO bugs mentioned in https://github.com/1technophile/OpenMQTTGateway/issues/2012
Specifically, the WiFi Network **always** displayed as garbage in the WebUI WiFi Configuration screen.
Problem is that WiFi.SSID() needs to be converted to a c_string -- so the fix is trivial.

I am surprised that nobody else has noted this bug as it seemingly applies to all installations and goes back to at least v1.60.

Please add this fix asap as it restores basic WebUI functionality for pretty much all users.


## Checklist:
  - [X ] The pull request is done against the latest development branch
  - [X ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
