### PR TITLE
Add protection for jsonQueue when emptying queue via emptyQueue()

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -1,4 +1,4 @@
-f/*
+/*
   OpenMQTTGateway  - ESP8266 or Arduino program for home automation
 
    Act as a gateway between your 433mhz, infrared IR, BLE, LoRa signal and one interface like an MQTT broker

--- a/main/main.ino
+++ b/main/main.ino
@@ -583,8 +583,8 @@ void emptyQueue() {
   Log.trace(F("Dequeue JSON" CR));
 #ifdef ESP32
   if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
-	Log.error(F("xQueueMutex not taken" CR));
-	return;
+	  Log.error(F("xQueueMutex not taken" CR));
+	  return;
   }
 #endif
   bundle = jsonQueue.front();
@@ -728,8 +728,8 @@ void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
   if (SYSConfig.XtoMQTT && !SYSConfig.offline) {
 #ifdef ESP32
     if (xSemaphoreTake(xMqttMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
-        Log.error(F("xMqttMutex not taken" CR));
-		return;
+      Log.error(F("xMqttMutex not taken" CR));
+		  return;
     }
 #endif
     if (mqtt && mqtt->connected()) {
@@ -2458,11 +2458,11 @@ void loop() {
 #endif
 #ifdef ESP32
     if (xSemaphoreTake(xMqttMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdTRUE) {
-	  mqtt->loop();
-	  xSemaphoreGive(xMqttMutex);	  
+	    mqtt->loop();
+	    xSemaphoreGive(xMqttMutex);	  
     } else {
-	  Log.error(F("xMqttMutex not taken" CR));
-	}
+	    Log.error(F("xMqttMutex not taken" CR));
+	  }
 #else
     mqtt->loop();
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -95,6 +95,8 @@ std::queue<JsonBundle> jsonQueue;
 #  include <driver/adc.h>
 // Mutex  to protect the queue
 SemaphoreHandle_t xQueueMutex;
+// Mutex to protect mqtt publish
+SemaphoreHandle_t xMqttMutex;
 bool blufiConnectAP = false;
 #endif
 
@@ -715,6 +717,12 @@ void pubMQTT(const char* topic, const char* payload) {
  */
 void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
   if (SYSConfig.XtoMQTT && !SYSConfig.offline) {
+#ifdef ESP32
+    if (xSemaphoreTake(xMqttMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
+        Log.error(F("xMqttMutex not taken" CR));
+		return;
+    }
+#endif
     if (mqtt && mqtt->connected()) {
       SendReceiveIndicatorON();
       Log.trace(F("[ OMG->MQTT ] topic: %s msg: %s " CR), topic, payload);
@@ -722,6 +730,9 @@ void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
     } else {
       Log.warning(F("MQTT not connected, aborting the publication" CR));
     }
+#ifdef ESP32
+	xSemaphoreGive(xMqttMutex);
+#endif
   } else {
     Log.notice(F("[ OMG->MQTT deactivated or offline] topic: %s msg: %s " CR), topic, payload);
   }
@@ -1280,6 +1291,7 @@ void setup() {
 #  endif
 #elif ESP32
   xQueueMutex = xSemaphoreCreateMutex();
+  xMqttMutex = xSemaphoreCreateMutex();
 #  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
   setupM5();
 #  endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -9,7 +9,7 @@
  - publish MQTT data to a different topic related to received signals (RF, IR, BLE, GSM)
 
   Copyright: (c)Florian ROBERT
-fxque
+
     This file is part of OpenMQTTGateway.
 
     OpenMQTTGateway is free software: you can redistribute it and/or modify

--- a/main/main.ino
+++ b/main/main.ino
@@ -581,8 +581,8 @@ void emptyQueue() {
   Log.trace(F("Dequeue JSON" CR));
 #ifdef ESP32
   if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
-	  Log.error(F("xQueueMutex not taken" CR));
-	  return;
+    Log.error(F("xQueueMutex not taken" CR));
+    return;
   }
 #endif
   bundle = jsonQueue.front();

--- a/main/main.ino
+++ b/main/main.ino
@@ -1,4 +1,4 @@
-/*
+f/*
   OpenMQTTGateway  - ESP8266 or Arduino program for home automation
 
    Act as a gateway between your 433mhz, infrared IR, BLE, LoRa signal and one interface like an MQTT broker
@@ -2447,7 +2447,16 @@ void loop() {
 #if defined(ZwebUI) && defined(ESP32)
     WebUILoop();
 #endif
+#ifdef ESP32
+    if (xSemaphoreTake(xMqttMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdTRUE) {
+	  mqtt->loop();
+	  xSemaphoreGive(xMqttMutex);	  
+    } else {
+	  Log.error(F("xMqttMutex not taken" CR));
+	}
+#else
     mqtt->loop();
+#endif
     if (mqtt->connected()) { // MQTT client is still connected
       InfoIndicatorON();
       failure_number_ntwk = 0;

--- a/main/main.ino
+++ b/main/main.ino
@@ -581,8 +581,17 @@ void emptyQueue() {
   }
   JsonBundle bundle;
   Log.trace(F("Dequeue JSON" CR));
+#ifdef ESP32
+  if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
+	Log.error(F("xQueueMutex not taken" CR));
+	return;
+  }
+#endif
   bundle = jsonQueue.front();
   jsonQueue.pop();
+#ifdef ESP32
+  xSemaphoreGive(xQueueMutex);
+#endif
   JsonObject obj = bundle.doc.as<JsonObject>();
   pubMainCore(obj);
   queueLengthSum++;

--- a/main/main.ino
+++ b/main/main.ino
@@ -9,7 +9,7 @@
  - publish MQTT data to a different topic related to received signals (RF, IR, BLE, GSM)
 
   Copyright: (c)Florian ROBERT
-
+fxque
     This file is part of OpenMQTTGateway.
 
     OpenMQTTGateway is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Description:
The jsonQueue is already protected during queue additions (via push) via the routine `handleJsonEnqueue`.
This adds protection for the complementary queue deletions via `emptyQueue` (via pop) since you probably don't want to be popping while another thread is pushing.


## Checklist:
  - [X ] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
