### PR TITLE
[BT] Add capability to remove the decoder when using BT

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -362,9 +362,9 @@ board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.ble}
-  ${libraries.decoder}
 build_flags =
   ${com-esp32.build_flags}
+  '-DBLEDecoder=false'
   '-DZgatewayBT="BT"'
   '-DLED_SEND_RECEIVE=2'
   '-DLED_SEND_RECEIVE_ON=0'

--- a/main/config_BT.h
+++ b/main/config_BT.h
@@ -121,6 +121,16 @@ extern String stateBTMeasures(bool);
 #  define EnableBT true
 #endif
 
+#ifndef BLEDecoder
+#  define BLEDecoder true //true if we use the Theengs decoder
+#endif
+
+#if !BLEDecoder
+#  define UNKWNON_MODEL -1
+#else
+#  define UNKWNON_MODEL TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL
+#endif
+
 #ifndef BLE_CNCT_TIMEOUT
 #  define BLE_CNCT_TIMEOUT 3000
 #endif


### PR DESCRIPTION
## Description:
Add the capability not to use the decoder with the BT gateway, this is useful for users that want to do the parsing and payload processing outside of the scanning ESP32

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
