### PR TITLE
Update main.ino - Remove restartesp from discovery_prefix stanza

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -3339,7 +3339,6 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
 #ifdef ZmqttDiscovery
       if (SYSdata.containsKey("discovery_prefix")) {
         strncpy(discovery_prefix, SYSdata["discovery_prefix"], parameters_size);
-        restartESP = true; //Need to reset so all devices get re-discovered & published to new discovery_prefix
       }
 #endif
       if (SYSdata.containsKey("gateway_name")) {


### PR DESCRIPTION
## Description:
Revert from original patch as not necessary and also prevents saving of new MQTT variable values
See https://github.com/1technophile/OpenMQTTGateway/issues/1996#issuecomment-2313638704


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
