### PR TITLE
[SYS] Add Mutex to potect mqtt->publish() from concurrent…

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -734,7 +734,7 @@ void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
       Log.warning(F("MQTT not connected, aborting the publication" CR));
     }
 #ifdef ESP32
-  xSemaphoreGive(xMqttMutex);
+    xSemaphoreGive(xMqttMutex);
 #endif
   } else {
     Log.notice(F("[ OMG->MQTT deactivated or offline] topic: %s msg: %s " CR), topic, payload);

--- a/main/main.ino
+++ b/main/main.ino
@@ -95,6 +95,8 @@ std::queue<JsonBundle> jsonQueue;
 #  include <driver/adc.h>
 // Mutex  to protect the queue
 SemaphoreHandle_t xQueueMutex;
+// Mutex to protect mqtt publish
+SemaphoreHandle_t xMqttMutex;
 bool blufiConnectAP = false;
 #endif
 
@@ -718,6 +720,12 @@ void pubMQTT(const char* topic, const char* payload) {
  */
 void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
   if (SYSConfig.mqtt && !SYSConfig.offline) {
+#ifdef ESP32
+    if (xSemaphoreTake(xMqttMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
+      Log.error(F("xMqttMutex not taken" CR));
+      return;
+    }
+#endif
     if (mqtt && mqtt->connected()) {
       SendReceiveIndicatorON();
       Log.notice(F("[ OMG->MQTT ] topic: %s msg: %s " CR), topic, payload);
@@ -725,6 +733,9 @@ void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
     } else {
       Log.warning(F("MQTT not connected, aborting the publication" CR));
     }
+#ifdef ESP32
+  xSemaphoreGive(xMqttMutex);
+#endif
   } else {
     Log.notice(F("[ OMG->MQTT deactivated or offline] topic: %s msg: %s " CR), topic, payload);
   }
@@ -1286,6 +1297,7 @@ void setup() {
 #  endif
 #elif ESP32
   xQueueMutex = xSemaphoreCreateMutex();
+  xMqttMutex = xSemaphoreCreateMutex();
 #  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
   setupM5();
 #  endif


### PR DESCRIPTION
## Description:
Protecting mqtt->publish() fixed the problem with corruption of MQTT discovery config messages (#2012)


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
