### PR TITLE
[SYS] Fixed data corruption associated with jsonQueue enqueueing and dequeuing

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -607,7 +607,7 @@ void emptyQueue() {
   if (error) {
     Log.error(F("deserialize jsonQueue.front() failed: %s, buffer capacity: %u" CR), error.c_str(), jsonBuffer.capacity());
   } else {
-    pubMainCore(obj);
+    jsonDispatch(obj);
   }
   queueLengthSum++;
 }

--- a/main/main.ino
+++ b/main/main.ino
@@ -89,7 +89,7 @@ struct JsonBundle {
   StaticJsonDocument<JSON_MSG_BUFFER> doc;
 };
 
-std::queue<JsonBundle> jsonQueue;
+std::queue<String> jsonQueue;
 
 #ifdef ESP32
 #  include <driver/adc.h>
@@ -483,36 +483,46 @@ void jsonDispatch(JsonObject& data) {
 }
 
 // Add a document to the queue
-void enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc) {
+boolean enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc, int timeout) {
   if (jsonDoc.size() == 0) {
     Log.error(F("Empty JSON, skipping" CR));
-    return;
+    return true;
   }
   if (queueLength >= QueueSize) {
     Log.warning(F("%d Doc(s) in queue, doc blocked" CR), queueLength);
     blockedMessages++;
-    return;
+    return false;
   }
-  JsonBundle bundle;
-  bundle.doc = jsonDoc;
-  jsonQueue.push(bundle);
+  Log.trace(F("Enqueue JSON" CR));
+  String jsonString;
+  serializeJson(jsonDoc, jsonString);
+#ifdef ESP32
+  // Semaphore check before enqueueing a document
+  if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(timeout)) == pdFALSE) {
+	Log.error(F("xQueueMutex not taken" CR));
+	blockedMessages++;
+	return false;
+  }
+#endif
+  jsonQueue.push(jsonString);
+#ifdef ESP32
+  xSemaphoreGive(xQueueMutex);
+#endif
   Log.trace(F("Queue length: %d" CR), jsonQueue.size());
+  return true;
+}
+
+// Semaphore check before enqueueing a document
+bool handleJsonEnqueue(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc, int timeout) {
+  return enqueueJsonObject(jsonDoc, timeout);
+}
+
+// Semaphore check before enqueueing a document with default timeout QueueSemaphoreTimeOutLoop
+bool handleJsonEnqueue(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc) {
+  return handleJsonEnqueue(jsonDoc, QueueSemaphoreTimeOutLoop);
 }
 
 #ifdef ESP32
-// Semaphore check before enqueueing a document
-bool handleJsonEnqueue(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc, int timeout) {
-  if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(timeout))) {
-    enqueueJsonObject(jsonDoc);
-    xSemaphoreGive(xQueueMutex);
-    return true;
-  } else {
-    Log.error(F("xQueueMutex not taken" CR));
-    blockedMessages++;
-    return false;
-  }
-}
-
 #  include "mbedtls/sha256.h"
 
 std::string generateHash(const std::string& input) {
@@ -527,20 +537,10 @@ std::string generateHash(const std::string& input) {
   return std::string(hashString);
 }
 #else
-bool handleJsonEnqueue(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc, int timeout) {
-  enqueueJsonObject(jsonDoc);
-  return true;
-}
-
 std::string generateHash(const std::string& input) {
   return "Not implemented for ESP8266";
 }
 #endif
-
-// Semaphore check before enqueueing a document with default timeout QueueSemaphoreTimeOutLoop
-bool handleJsonEnqueue(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc) {
-  return handleJsonEnqueue(jsonDoc, QueueSemaphoreTimeOutLoop);
-}
 
 /*
  * Add the jsonObject id as a topic to the jsonObject origin
@@ -589,12 +589,26 @@ void emptyQueue() {
   if (queueLength == 0) {
     return;
   }
-  JsonBundle bundle;
   Log.trace(F("Dequeue JSON" CR));
-  bundle = jsonQueue.front();
+  DynamicJsonDocument jsonBuffer(JSON_MSG_BUFFER);  
+  JsonObject obj = jsonBuffer.to<JsonObject>();  
+#ifdef ESP32
+  if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
+	Log.error(F("xQueueMutex not taken" CR));
+	return;
+  }
+#endif
+  Log.notice(F("Dequeue JSON: %s" CR), jsonQueue.front().c_str()); //JJKCRAP
+  auto error = deserializeJson(jsonBuffer, jsonQueue.front());
   jsonQueue.pop();
-  JsonObject obj = bundle.doc.as<JsonObject>();
-  jsonDispatch(obj);
+#ifdef ESP32
+  xSemaphoreGive(xQueueMutex);
+#endif
+  if (error) {
+	Log.error(F("deserialize pop json.Queue failed: %s, buffer capacity: %u" CR), error.c_str(), jsonBuffer.capacity());
+  } else {
+	pubMainCore(obj);
+  }
   queueLengthSum++;
 }
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -605,7 +605,7 @@ void emptyQueue() {
   xSemaphoreGive(xQueueMutex);
 #endif
   if (error) {
-    Log.error(F("deserialize pop json.Queue failed: %s, buffer capacity: %u" CR), error.c_str(), jsonBuffer.capacity());
+    Log.error(F("deserialize jsonQueue.front() failed: %s, buffer capacity: %u" CR), error.c_str(), jsonBuffer.capacity());
   } else {
     pubMainCore(obj);
   }

--- a/main/main.ino
+++ b/main/main.ino
@@ -61,7 +61,7 @@ unsigned long timer_sys_measures = 0;
 // Time used to wait before system checkings
 unsigned long timer_sys_checks = 0;
 
-#define ARDUINOJSON_USE_LONG_LONG 1
+#define ARDUINOJSON_USE_LONG_LONG     1
 #define ARDUINOJSON_ENABLE_STD_STRING 1
 
 #include <queue>

--- a/main/main.ino
+++ b/main/main.ino
@@ -598,7 +598,6 @@ void emptyQueue() {
     return;
   }
 #endif
-  Log.notice(F("Dequeue JSON: %s" CR), jsonQueue.front().c_str()); //JJKCRAP
   auto error = deserializeJson(jsonBuffer, jsonQueue.front());
   jsonQueue.pop();
 #ifdef ESP32

--- a/main/main.ino
+++ b/main/main.ino
@@ -61,7 +61,7 @@ unsigned long timer_sys_measures = 0;
 // Time used to wait before system checkings
 unsigned long timer_sys_checks = 0;
 
-#define ARDUINOJSON_USE_LONG_LONG     1
+#define ARDUINOJSON_USE_LONG_LONG 1
 #define ARDUINOJSON_ENABLE_STD_STRING 1
 
 #include <queue>
@@ -499,9 +499,9 @@ boolean enqueueJsonObject(const StaticJsonDocument<JSON_MSG_BUFFER>& jsonDoc, in
 #ifdef ESP32
   // Semaphore check before enqueueing a document
   if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(timeout)) == pdFALSE) {
-	Log.error(F("xQueueMutex not taken" CR));
-	blockedMessages++;
-	return false;
+    Log.error(F("xQueueMutex not taken" CR));
+    blockedMessages++;
+    return false;
   }
 #endif
   jsonQueue.push(jsonString);
@@ -590,12 +590,12 @@ void emptyQueue() {
     return;
   }
   Log.trace(F("Dequeue JSON" CR));
-  DynamicJsonDocument jsonBuffer(JSON_MSG_BUFFER);  
-  JsonObject obj = jsonBuffer.to<JsonObject>();  
+  DynamicJsonDocument jsonBuffer(JSON_MSG_BUFFER);
+  JsonObject obj = jsonBuffer.to<JsonObject>();
 #ifdef ESP32
   if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
-	Log.error(F("xQueueMutex not taken" CR));
-	return;
+    Log.error(F("xQueueMutex not taken" CR));
+    return;
   }
 #endif
   Log.notice(F("Dequeue JSON: %s" CR), jsonQueue.front().c_str()); //JJKCRAP
@@ -605,9 +605,9 @@ void emptyQueue() {
   xSemaphoreGive(xQueueMutex);
 #endif
   if (error) {
-	Log.error(F("deserialize pop json.Queue failed: %s, buffer capacity: %u" CR), error.c_str(), jsonBuffer.capacity());
+    Log.error(F("deserialize pop json.Queue failed: %s, buffer capacity: %u" CR), error.c_str(), jsonBuffer.capacity());
   } else {
-	pubMainCore(obj);
+    pubMainCore(obj);
   }
   queueLengthSum++;
 }


### PR DESCRIPTION
- Changed `jsonQueue` structure and associated routines to use json String rather than json Object
- Added Mutex protection to `emptyQueue()`
- Moved Mutex protection to within `enqueueJsonObject()` to significantly shorten lock time

## Description:
This fixes a **severe** bug whereby any MQTT messages enqueued on the jsonQueue were subject to unpredictable data corruption if the encoded json documents were more than one level deep since pushing/popping onto & from the queue do only shallow copies. This corruption could happen even with a queue size of one if the memory is overwritten.
In practice, this caused sporadic data MQTT message corruption for me as discussed in https://github.com/1technophile/OpenMQTTGateway/issues/2014

1. _NOTE YOU SHOULD ALSO BE ABLE TO REVERT THE REVERT THE CHANGE IN `ZgatewayRTL_433.ino` that called `pub` directly instead of using the JSON queue_ It's pretty likely that this PR fixes the cause of the instability that others experienced.
2. _NOTE THAT THIS PR SUPERSEDES https://github.com/1technophile/OpenMQTTGateway/pull/2025_

Specifically, the PR does the following:
- Changes the format of the queue (and the associated actions `enqueueJsonObject()` and `emptyQueue()`) to push/pull JSON strings rather than Documents onto the queue
- Extends the Mutex protection (xQueueMutex) that was previously applied only to enqueuing als to `emptyQueue()`
- Shortens the lock time by moving the Mutex for enqueueing into the  `enqueueJsonObject()` routine rather than `handleJsonObject()` since only the actual push needs to be protected while the deserializing and other actions don't

Note this leaves `handleJsonObject()` as a stub that just calls `eqnueueJsonObject()`.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
