### PR TITLE
[SYS] Remove handleJsonQueue wrapper and use std::string

### DIFF
--- a/main/ZactuatorONOFF.ino
+++ b/main/ZactuatorONOFF.ino
@@ -311,6 +311,6 @@ void stateONOFFMeasures() {
   ONOFFdata["uselaststate"] = ONOFFConfig.useLastStateOnStart;
 #  endif
   ONOFFdata["origin"] = subjectGTWONOFFtoMQTT;
-  handleJsonEnqueue(ONOFFdata, QueueSemaphoreTimeOutTask);
+  enqueueJsonObject(ONOFFdata, QueueSemaphoreTimeOutTask);
 }
 #endif

--- a/main/ZdisplaySSD1306.ino
+++ b/main/ZdisplaySSD1306.ino
@@ -503,7 +503,7 @@ String stateSSD1306Display() {
   DISPLAYdata["log-oled"] = (bool)logToOLEDDisplay;
   DISPLAYdata["json-oled"] = (bool)jsonDisplay;
   DISPLAYdata["origin"] = subjectSSD1306toMQTT;
-  handleJsonEnqueue(DISPLAYdata);
+  enqueueJsonObject(DISPLAYdata);
 
   // apply
   Oled.display->setBrightness(round(displayBrightness * 2.55));

--- a/main/Zgateway2G.ino
+++ b/main/Zgateway2G.ino
@@ -91,7 +91,7 @@ bool _2GtoMQTT() {
     A6l.deleteSMS(unreadSMSLocs[i]); // we delete the SMS received
     Log.trace(F("Adv data 2GtoMQTT" CR));
     SMSdata["origin"] = subject2GtoMQTT;
-    return handleJsonEnqueue(SMSdata);
+    return enqueueJsonObject(SMSdata);
   }
   return false;
 }

--- a/main/ZgatewayBLEConnect.ino
+++ b/main/ZgatewayBLEConnect.ino
@@ -120,7 +120,7 @@ bool zBLEConnect::processActions(std::vector<BLEAction>& actions) {
         BLEdata["success"] = result;
         if (result || it.ttl <= 1) {
           buildTopicFromId(BLEdata, subjectBTtoMQTT);
-          handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+          enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
         }
       }
     }
@@ -160,7 +160,7 @@ void LYWSD03MMC_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pD
       BLEdata["volt"] = (float)(((pData[4] * 256) + pData[3]) / 1000.0);
       BLEdata["batt"] = (float)(((((pData[4] * 256) + pData[3]) / 1000.0) - 2.1) * 100);
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     } else {
       Log.notice(F("Invalid notification data" CR));
       return;
@@ -225,7 +225,7 @@ void DT24_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, s
       BLEdata["tempc"] = (float)(m_data[24] * 256) + m_data[25];
       BLEdata["tempf"] = (float)(convertTemp_CtoF((m_data[24] * 256) + m_data[25]));
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     } else {
       Log.notice(F("Invalid notification data" CR));
       return;
@@ -304,7 +304,7 @@ void BM2_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* pData, si
       // to avoid the BM2 device tracker going offline because of the voltage MQTT message without an RSSI value
       BLEdata["rssi"] = -60;
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     } else {
       Log.notice(F("Invalid notification data" CR));
       return;
@@ -362,7 +362,7 @@ void HHCCJCY01HHCC_connect::publishData() {
       BLEdata["id"] = (char*)mac_address.c_str();
       BLEdata["batt"] = (int)batteryValue;
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     } else {
       Log.notice(F("Failed getting characteristic" CR));
     }
@@ -394,7 +394,7 @@ void XMWSDJ04MMC_connect::notifyCB(NimBLERemoteCharacteristic* pChar, uint8_t* p
       BLEdata["volt"] = (float)((pData[4] | (pData[5] << 8)) / 1000.0);
       BLEdata["batt"] = (float)((((pData[4] | (pData[5] << 8)) / 1000.0) - 2.1) * 100);
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     } else {
       Log.notice(F("Invalid notification data" CR));
       return;
@@ -500,7 +500,7 @@ bool SBS1_connect::processActions(std::vector<BLEAction>& actions) {
           BLEdata["id"] = it.addr;
           BLEdata["state"] = it.value;
           buildTopicFromId(BLEdata, subjectBTtoMQTT);
-          handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+          enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
         }
       }
     }
@@ -600,7 +600,7 @@ bool SBBT_connect::processActions(std::vector<BLEAction>& actions) {
             BLEdata["direction"] = "up";
           }
           buildTopicFromId(BLEdata, subjectBTtoMQTT);
-          handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+          enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
         }
       }
     }

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -148,7 +148,7 @@ String stateBTMeasures(bool start) {
   String output;
   serializeJson(jo, output);
   jo["origin"] = subjectBTtoMQTT;
-  handleJsonEnqueue(jo, QueueSemaphoreTimeOutTask);
+  enqueueJsonObject(jo, QueueSemaphoreTimeOutTask);
   return (output);
 }
 
@@ -430,7 +430,7 @@ void updateDevicesStatus() {
         BLEdata["id"] = p->macAdr;
         BLEdata["state"] = "offline";
         buildTopicFromId(BLEdata, subjectBTtoMQTT);
-        handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+        enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
         // We set the lastUpdate to 0 to avoid replublishing the offline state
         p->lastUpdate = 0;
       }
@@ -444,7 +444,7 @@ void updateDevicesStatus() {
         BLEdata["id"] = p->macAdr;
         BLEdata["state"] = "offline";
         buildTopicFromId(BLEdata, subjectBTtoMQTT);
-        handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+        enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
         // We set the lastUpdate to 0 to avoid replublishing the offline state
         p->lastUpdate = 0;
       }
@@ -1244,13 +1244,13 @@ void PublishDeviceData(JsonObject& BLEdata) {
         BLEdata["mac"] = BLEdata["id"].as<std::string>();
         BLEdata["id"] = BLEdata["uuid"].as<std::string>();
       }
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     }
 
     // If the device is not a sensor and pubOnlySensors is true we don't publish this payload
     if (!BTConfig.pubOnlySensors || BLEdata.containsKey("model") || !BLEDecoder) { // Identified device
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     } else {
       Log.notice(F("Not a sensor device filtered" CR));
       return;
@@ -1271,10 +1271,10 @@ void PublishDeviceData(JsonObject& BLEdata) {
         BLEdata["mac"] = BLEdata["id"].as<std::string>();
         BLEdata["id"] = BLEdata["uuid"].as<std::string>();
       }
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
     }
     buildTopicFromId(BLEdata, subjectBTtoMQTT);
-    handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+    enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
   } else {
     Log.notice(F("Low rssi, device filtered" CR));
     return;
@@ -1351,7 +1351,7 @@ void immediateBTAction(void* pvParameters) {
       BLEdata["id"] = BLEactions.back().addr;
       BLEdata["success"] = false;
       buildTopicFromId(BLEdata, subjectBTtoMQTT);
-      handleJsonEnqueue(BLEdata, QueueSemaphoreTimeOutTask);
+      enqueueJsonObject(BLEdata, QueueSemaphoreTimeOutTask);
       BLEactions.pop_back();
       BTProcessLock = false;
     }

--- a/main/ZgatewayGFSunInverter.ino
+++ b/main/ZgatewayGFSunInverter.ino
@@ -59,7 +59,7 @@ void GFSunInverterDataHandler(GfSun2000Data data) {
   jdata["register"] = jregister;
 #  endif
   jdata["origin"] = subjectRFtoMQTT;
-  handleJsonEnqueue(jdata);
+  enqueueJsonObject(jdata);
 }
 
 void GFSunInverterErrorHandler(int errorId, char* errorMessage) {
@@ -72,7 +72,7 @@ void GFSunInverterErrorHandler(int errorId, char* errorMessage) {
   jdata["msg"] = errorMessage;
   jdata["id"] = errorId;
   jdata["origin"] = subjectRFtoMQTT;
-  handleJsonEnqueue(jdata);
+  enqueueJsonObject(jdata);
 }
 
 void setupGFSunInverter() {

--- a/main/ZgatewayIR.ino
+++ b/main/ZgatewayIR.ino
@@ -148,7 +148,7 @@ void IRtoMQTT() {
     } else if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of IR -->MQTT
       Log.trace(F("Adv data IRtoMQTT" CR));
       IRdata["origin"] = subjectIRtoMQTT;
-      handleJsonEnqueue(IRdata);
+      enqueueJsonObject(IRdata);
       Log.trace(F("Store val: %D" CR), MQTTvalue);
       storeSignalValue(MQTTvalue);
       if (repeatIRwMQTT) {

--- a/main/ZgatewayLORA.ino
+++ b/main/ZgatewayLORA.ino
@@ -473,11 +473,11 @@ void LORAtoMQTT() {
       LORAdataBuffer["origin"] = subjectLORAtoMQTT;
     }
 
-    handleJsonEnqueue(LORAdata);
+    enqueueJsonObject(LORAdata);
     if (repeatLORAwMQTT) {
       Log.trace(F("Pub LORA for rpt" CR));
       LORAdata["origin"] = subjectMQTTtoLORA;
-      handleJsonEnqueue(LORAdata);
+      enqueueJsonObject(LORAdata);
     }
   }
 }

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -81,11 +81,11 @@ void pilightCallback(const String& protocol, const String& message, int status,
     RFPiLightdata["repeats"] = (int)repeats;
     RFPiLightdata["status"] = (int)status;
     RFPiLightdata["origin"] = subjectPilighttoMQTT;
-    handleJsonEnqueue(RFPiLightdata);
+    enqueueJsonObject(RFPiLightdata);
     if (repeatPilightwMQTT) {
       Log.trace(F("Pub Pilight for rpt" CR));
       RFPiLightdata["origin"] = subjectMQTTtoPilight;
-      handleJsonEnqueue(RFPiLightdata);
+      enqueueJsonObject(RFPiLightdata);
     }
   }
 }
@@ -108,7 +108,7 @@ void pilightRawCallback(const uint16_t* pulses, size_t length) {
 
   // Enqueue data
   RFPiLightdata["origin"] = subjectPilighttoMQTT;
-  handleJsonEnqueue(RFPiLightdata);
+  enqueueJsonObject(RFPiLightdata);
 }
 #  endif
 

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -146,14 +146,14 @@ void RFtoMQTT() {
         RFtoMQTTdiscovery(MQTTvalue);
 #  endif
       RFdata["origin"] = subjectRFtoMQTT;
-      handleJsonEnqueue(RFdata);
+      enqueueJsonObject(RFdata);
       // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's
       Log.trace(F("Store val: %u" CR), (unsigned long)MQTTvalue);
       storeSignalValue(MQTTvalue);
       if (repeatRFwMQTT) {
         Log.trace(F("Pub RF for rpt" CR));
         RFdata["origin"] = subjectMQTTtoRF;
-        handleJsonEnqueue(RFdata);
+        enqueueJsonObject(RFdata);
       }
     }
   }

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -118,7 +118,7 @@ void RF2toMQTT() {
       RF2toMQTTdiscovery(RF2data);
 #  endif
     RF2data["origin"] = subjectRF2toMQTT;
-    handleJsonEnqueue(RF2data);
+    enqueueJsonObject(RF2data);
   }
 }
 

--- a/main/ZgatewayRFM69.ino
+++ b/main/ZgatewayRFM69.ino
@@ -212,7 +212,7 @@ void MQTTtoRFM69(char* topicOri, JsonObject& RFM69data) {
         Log.notice(F(" OK " CR));
         // Acknowledgement to the GTWRF topic
         RFM69data["origin"] = subjectGTWRFM69toMQTT;
-        handleJsonEnqueue(RFM69data);
+        enqueueJsonObject(RFM69data);
       } else {
         Log.error(F("MQTTtoRFM69 sending failed" CR));
       }

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -309,8 +309,7 @@ void rtl_433_Callback(char* message) {
       storeRTL_433Discovery(RFrtl_433_ESPdata, (char*)model.c_str(), (char*)type.c_str(), (char*)uniqueid.c_str());
 #  endif
     RFrtl_433_ESPdata["origin"] = (char*)topic.c_str();
-    handleJsonEnqueue(RFrtl_433_ESPdata);
-    //pub(topic.c_str(), RFrtl_433_ESPdata);
+    enqueueJsonObject(RFrtl_433_ESPdata);
     storeSignalValue(MQTTvalue);
     pubOled((char*)topic.c_str(), RFrtl_433_ESPdata);
   }

--- a/main/ZgatewaySERIAL.ino
+++ b/main/ZgatewaySERIAL.ino
@@ -182,11 +182,11 @@ void SERIALtoMQTT() {
             PublishDeviceData(SERIALdata);
 #      endif
           } else {
-            handleJsonEnqueue(SERIALdata);
+            enqueueJsonObject(SERIALdata);
           }
         } else {
           SERIALdata["origin"] = subjectSERIALtoMQTT;
-          handleJsonEnqueue(SERIALdata);
+          enqueueJsonObject(SERIALdata);
         }
 
 #    endif

--- a/main/ZgatewaySRFB.ino
+++ b/main/ZgatewaySRFB.ino
@@ -121,13 +121,13 @@ void _rfbDecode() {
     if (!isAduplicateSignal(MQTTvalue) && MQTTvalue != 0) { // conditions to avoid duplications of RF -->MQTT
       Log.trace(F("Adv data SRFBtoMQTT" CR));
       SRFBdata["origin"] = subjectSRFBtoMQTT;
-      handleJsonEnqueue(SRFBdata);
+      enqueueJsonObject(SRFBdata);
       Log.trace(F("Store val: %lu" CR), MQTTvalue);
       storeSignalValue(MQTTvalue);
       if (repeatSRFBwMQTT) {
         Log.trace(F("Publish SRFB for rpt" CR));
         SRFBdata["origin"] = subjectMQTTtoSRFB;
-        handleJsonEnqueue(SRFBdata);
+        enqueueJsonObject(SRFBdata);
       }
     }
     _rfbAck();

--- a/main/ZgatewayWeatherStation.ino
+++ b/main/ZgatewayWeatherStation.ino
@@ -36,7 +36,7 @@ void PairedDeviceAdded(byte newID) {
   RFdata["sensor"] = newID;
   RFdata["action"] = "paired";
   RFdata["origin"] = subjectRFtoMQTT;
-  handleJsonEnqueue(RFdata);
+  enqueueJsonObject(RFdata);
   wsdr.pair(NULL, PairedDeviceAdded);
 }
 
@@ -56,7 +56,7 @@ void sendWindSpeedData(byte id, float wind_speed, byte battery_status) {
     RFdata["wind_speed"] = wind_speed;
     RFdata["battery"] = bitRead(battery_status, 0) == 0 ? "OK" : "Low";
     RFdata["origin"] = subjectRFtoMQTT;
-    handleJsonEnqueue(RFdata);
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store wind speed val: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }
@@ -71,7 +71,7 @@ void sendRainData(byte id, float rain_volume, byte battery_status) {
     RFdata["rain_volume"] = rain_volume;
     RFdata["battery"] = bitRead(battery_status, 1) == 0 ? "OK" : "Low";
     RFdata["origin"] = subjectRFtoMQTT;
-    handleJsonEnqueue(RFdata);
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store rain_volume: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }
@@ -87,7 +87,7 @@ void sendWindData(byte id, int wind_direction, float wind_gust, byte battery_sta
     RFdata["wind_gust"] = wind_gust;
     RFdata["battery"] = bitRead(battery_status, 0) == 0 ? "OK" : "Low";
     RFdata["origin"] = subjectRFtoMQTT;
-    handleJsonEnqueue(RFdata);
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store wind data val: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }
@@ -104,7 +104,7 @@ void sendTemperatureData(byte id, float temperature, int humidity, byte battery_
     RFdata["humidity"] = humidity;
     RFdata["battery"] = bitRead(battery_status, 0) == 0 ? "OK" : "Low";
     RFdata["origin"] = subjectRFtoMQTT;
-    handleJsonEnqueue(RFdata);
+    enqueueJsonObject(RFdata);
     Log.trace(F("Store temp val: %lu" CR), MQTTvalue);
     storeSignalValue(MQTTvalue);
   }

--- a/main/ZsensorADC.ino
+++ b/main/ZsensorADC.ino
@@ -94,7 +94,7 @@ void MeasureADC() {
         ADCdata["mvolt_scaled"] = (int)voltage; // real scaled/calibrated value in mV
 #  endif
         ADCdata["origin"] = ADCTOPIC;
-        handleJsonEnqueue(ADCdata);
+        enqueueJsonObject(ADCdata);
         persistedadc = val;
       }
     }

--- a/main/ZsensorAHTx0.ino
+++ b/main/ZsensorAHTx0.ino
@@ -104,7 +104,7 @@ void MeasureAHTTempHum() {
         Log.notice(F("Same Humidity. Don't send it" CR));
       }
       AHTx0data["origin"] = AHTTOPIC;
-      handleJsonEnqueue(AHTx0data);
+      enqueueJsonObject(AHTx0data);
     }
     persisted_aht_tempc = ahtTempC.temperature;
     persisted_aht_hum = ahtHum.relative_humidity;

--- a/main/ZsensorBH1750.ino
+++ b/main/ZsensorBH1750.ino
@@ -101,7 +101,7 @@ void MeasureLightIntensity() {
         Log.trace(F("Same wattsm2 don't send it" CR));
       }
       BH1750data["origin"] = subjectBH1750toMQTT;
-      handleJsonEnqueue(BH1750data);
+      enqueueJsonObject(BH1750data);
     }
     persistedll = Lux;
     persistedlf = ftcd;

--- a/main/ZsensorBME280.ino
+++ b/main/ZsensorBME280.ino
@@ -188,7 +188,7 @@ void MeasureTempHumAndPressure() {
         Log.trace(F("Same Altitude Feet don't send it" CR));
       }
       BME280data["origin"] = BMETOPIC;
-      handleJsonEnqueue(BME280data);
+      enqueueJsonObject(BME280data);
     }
 
     persisted_bme_tempc = BmeTempC;

--- a/main/ZsensorC37_YL83_HMRD.ino
+++ b/main/ZsensorC37_YL83_HMRD.ino
@@ -67,7 +67,7 @@ void MeasureC37_YL83_HMRDWater() {
     }
     if (C37_YL83_HMRDdata.size() > 0) {
       C37_YL83_HMRDdata["origin"] = C37_YL83_HMRD_TOPIC;
-      handleJsonEnqueue(C37_YL83_HMRDdata);
+      enqueueJsonObject(C37_YL83_HMRDdata);
       if (sensorDigitalValue == 1) { //No water detected, all good we can sleep
         if (SYSConfig.powerMode > 0)
           ready_to_sleep = true;

--- a/main/ZsensorDHT.ino
+++ b/main/ZsensorDHT.ino
@@ -69,7 +69,7 @@ void MeasureTempAndHum() {
         Log.trace(F("Same temp don't send it" CR));
       }
       DHTdata["origin"] = DHTTOPIC;
-      handleJsonEnqueue(DHTdata);
+      enqueueJsonObject(DHTdata);
     }
     persistedh = h;
     persistedt = t;

--- a/main/ZsensorDS1820.ino
+++ b/main/ZsensorDS1820.ino
@@ -158,7 +158,7 @@ void MeasureDS1820Temp() {
           }
           String origin = String(OW_TOPIC) + "/" + ds1820_addr[i];
           DS1820data["origin"] = origin;
-          handleJsonEnqueue(DS1820data);
+          enqueueJsonObject(DS1820data);
           if (SYSConfig.powerMode > 0)
             ready_to_sleep = true;
         } else {

--- a/main/ZsensorGPIOInput.ino
+++ b/main/ZsensorGPIOInput.ino
@@ -92,7 +92,7 @@ void MeasureGPIOInput() {
         GPIOdata["gpio"] = "LOW";
       }
       GPIOdata["origin"] = subjectGPIOInputtoMQTT;
-      handleJsonEnqueue(GPIOdata);
+      enqueueJsonObject(GPIOdata);
 
 #  if defined(ZactuatorONOFF) && defined(ACTUATOR_TRIGGER)
       //Trigger the actuator if we are not at startup

--- a/main/ZsensorHCSR04.ino
+++ b/main/ZsensorHCSR04.ino
@@ -69,7 +69,7 @@ void MeasureDistance() {
         Log.trace(F("HC SR04 Distance hasn't changed" CR));
       }
       distance = d;
-      handleJsonEnqueue(HCSR04data);
+      enqueueJsonObject(HCSR04data);
     }
   }
 }

--- a/main/ZsensorHCSR501.ino
+++ b/main/ZsensorHCSR501.ino
@@ -64,7 +64,7 @@ void MeasureHCSR501() {
 #  endif
     if (HCSR501data.size() > 0) {
       HCSR501data["origin"] = subjectHCSR501toMQTT;
-      handleJsonEnqueue(HCSR501data);
+      enqueueJsonObject(HCSR501data);
     }
   }
 }

--- a/main/ZsensorHTU21.ino
+++ b/main/ZsensorHTU21.ino
@@ -101,7 +101,7 @@ void MeasureTempHum() {
         Log.notice(F("Same Humidity. Don't send it" CR));
       }
       HTU21data["origin"] = HTUTOPIC;
-      handleJsonEnqueue(HTU21data);
+      enqueueJsonObject(HTU21data);
     }
     persisted_htu_tempc = HtuTempC;
     persisted_htu_hum = HtuHum;

--- a/main/ZsensorINA226.ino
+++ b/main/ZsensorINA226.ino
@@ -73,7 +73,7 @@ void MeasureINA226() {
     INA226data["current"] = current;
     INA226data["power"] = power;
     INA226data["origin"] = subjectINA226toMQTT;
-    handleJsonEnqueue(INA226data);
+    enqueueJsonObject(INA226data);
   }
 }
 

--- a/main/ZsensorLM75.ino
+++ b/main/ZsensorLM75.ino
@@ -88,7 +88,7 @@ void MeasureTemp() {
         LM75data["tempc"] = (float)lm75TempC;
         LM75data["tempf"] = (float)lm75TempF;
         LM75data["origin"] = LM75TOPIC;
-        handleJsonEnqueue(LM75data);
+        enqueueJsonObject(LM75data);
       } else {
         Log.notice(F("Same Temp. Don't send it" CR));
       }

--- a/main/ZsensorMQ2.ino
+++ b/main/ZsensorMQ2.ino
@@ -67,7 +67,7 @@ void MeasureGasMQ2() {
     MQ2data["gas"] = analogRead(MQ2SENSORADCPIN);
     MQ2data["detected"] = digitalRead(MQ2SENSORDETECTPIN) == HIGH ? "false" : "true";
     MQ2data["origin"] = subjectMQ2toMQTT;
-    handleJsonEnqueue(MQ2data);
+    enqueueJsonObject(MQ2data);
   }
 }
 #endif

--- a/main/ZsensorRN8209.ino
+++ b/main/ZsensorRN8209.ino
@@ -95,7 +95,7 @@ void rn8209_loop(void* mode) {
       PublishingTimerRN8209 = now;
       if (RN8209data) {
         RN8209data["origin"] = subjectRN8209toMQTT;
-        handleJsonEnqueue(RN8209data, QueueSemaphoreTimeOutTask);
+        enqueueJsonObject(RN8209data, QueueSemaphoreTimeOutTask);
       }
     }
     //esp_task_wdt_reset();

--- a/main/ZsensorSHTC3.ino
+++ b/main/ZsensorSHTC3.ino
@@ -61,7 +61,7 @@ void MeasureTempAndHum() {
           Log.trace(F("Same temp don't send it" CR));
         }
         SHTC3data["origin"] = SHTC3TOPIC;
-        handleJsonEnqueue(SHTC3data);
+        enqueueJsonObject(SHTC3data);
       }
       persistedh = h;
       persistedt = t;

--- a/main/ZsensorTEMT6000.ino
+++ b/main/ZsensorTEMT6000.ino
@@ -68,7 +68,7 @@ void MeasureLightIntensityTEMT6000() {
       TEMT6000data["ftcd"] = (float)(lux) / 10.764;
       TEMT6000data["wattsm2"] = (float)(lux) / 683.0;
       TEMT6000data["origin"] = subjectTEMT6000toMQTT;
-      handleJsonEnqueue(TEMT6000data);
+      enqueueJsonObject(TEMT6000data);
     } else {
       Log.trace(F("Same lux value, do not send" CR));
     }

--- a/main/ZsensorTSL2561.ino
+++ b/main/ZsensorTSL2561.ino
@@ -105,7 +105,7 @@ void MeasureLightIntensityTSL2561() {
         TSL2561data["ftcd"] = (float)(event.light) / 10.764;
         TSL2561data["wattsm2"] = (float)(event.light) / 683.0;
         TSL2561data["origin"] = subjectTSL12561toMQTT;
-        handleJsonEnqueue(TSL2561data);
+        enqueueJsonObject(TSL2561data);
       } else {
         Log.trace(F("Same lux value, do not send" CR));
       }

--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -1741,7 +1741,7 @@ String stateWebUIStatus() {
 
   // WebUIdata["currentMessage"] = currentWebUIMessage;
   WebUIdata["origin"] = subjectWebUItoMQTT;
-  handleJsonEnqueue(WebUIdata);
+  enqueueJsonObject(WebUIdata);
   return output;
 }
 


### PR DESCRIPTION
## Description:
Remove handleJsonQueue wrapper and use std::string in the queue to reduce Arduino Framework dependency

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
