### PR TITLE
Modify gatewayRF auto discoverability

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -96,13 +96,13 @@ void RFtoMQTTdiscovery(uint64_t MQTTvalue) {
 #    endif
 
   String theUniqueId = getUniqueId(String(switchRF[0]), "-" + String(switchRF[1]));
-  String subType = String(switchRF[0]);
+  String type = String(switchRF[0]);
 
   announceDeviceTrigger(
       false,
       (char*)discovery_topic.c_str(),
-      "", 
-      (char*)subType.c_str(),
+      (char*)type.c_str(),
+      "",
       (char*)theUniqueId.c_str(),
       "", "", "", "");
 }

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -95,12 +95,14 @@ void RFtoMQTTdiscovery(uint64_t MQTTvalue) {
   String discovery_topic = String(subjectRFtoMQTT);
 #    endif
 
-  String theUniqueId = getUniqueId("-" + String(switchRF[0]), "-" + String(switchRF[1]));
+  String theUniqueId = getUniqueId(String(switchRF[0]), "-" + String(switchRF[1]));
+  String subType = String(switchRF[0]);
 
   announceDeviceTrigger(
       false,
       (char*)discovery_topic.c_str(),
-      "", "",
+      "", 
+      (char*)subType.c_str(),
       (char*)theUniqueId.c_str(),
       "", "", "", "");
 }


### PR DESCRIPTION
## Description:
Pass `switchRF[0]` as the subtype argument to `announceDeviceTrigger()` which will cause recieved codes to be picked up by home assistant as triggers, i.e. When setting up automations in Home Assistant, selecting a `device trigger` and an OMG device will allow the user to select a code picked up during the autoDiscover window as the trigger for the automation, for example `"1394004" pressed`

Also change `getUniqueId()` call to remove leading '-' which will prevent MQTT topics having '--' in them

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
