### PR TITLE
[RF][BREAKING] Improve Home Assistant auto discoverability

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -219,6 +219,7 @@ build_flags =
   ${com-esp32.build_flags}
   '-DZgatewayRF="RF"'
   '-DGateway_Name="OMG_ESP32_RF"'
+  '-DvalueAsATopic=true'
 custom_description = RF gateway using RCSwitch library
 
 [env:esp32dev-pilight]
@@ -1378,6 +1379,7 @@ build_flags =
   ${com-esp.build_flags}
   '-DZgatewayRF="RF"'
   '-DGateway_Name="OMG_ESP8266_RF"'
+  '-DvalueAsATopic=true'
 board_build.flash_mode = dout
 custom_description = The historic RF gateway using RCSwitch library
 
@@ -1395,6 +1397,7 @@ build_flags =
   '-DZgatewayRF="RF"'
   '-DZradioCC1101="CC1101"'
   '-DGateway_Name="OMG_ESP8266_RF-CC1101"'
+  '-DvalueAsATopic=true'
 board_build.flash_mode = dout
 custom_description = RF gateway using RCSwitch library with CC1101
 

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -120,7 +120,6 @@ void RFtoMQTT() {
     int length = mySwitch.getReceivedBitlength();
     const char* binary = dec2binWzerofill(MQTTvalue, length);
 
-    RFdata["action"] = String("received");
     RFdata["value"] = (uint64_t)MQTTvalue;
     RFdata["protocol"] = (int)mySwitch.getReceivedProtocol();
     RFdata["length"] = (int)mySwitch.getReceivedBitlength();
@@ -149,8 +148,6 @@ void RFtoMQTT() {
         RFtoMQTTdiscovery(MQTTvalue);
 #  endif
       RFdata["origin"] = subjectRFtoMQTT;
-      enqueueJsonObject(RFdata);
-      RFdata["action"] = String("");
       enqueueJsonObject(RFdata);
       // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's
       Log.trace(F("Store val: %u" CR), (unsigned long)MQTTvalue);

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -101,7 +101,7 @@ void RFtoMQTTdiscovery(uint64_t MQTTvalue) {
   announceDeviceTrigger(
       false,
       (char*)discovery_topic.c_str(),
-      "recieved",
+      "received",
       (char*)subType.c_str(),
       (char*)theUniqueId.c_str(),
       "", "", "", "");
@@ -120,7 +120,7 @@ void RFtoMQTT() {
     int length = mySwitch.getReceivedBitlength();
     const char* binary = dec2binWzerofill(MQTTvalue, length);
 
-    RFdata["action"] = String("recieved");
+    RFdata["action"] = String("received");
     RFdata["value"] = (uint64_t)MQTTvalue;
     RFdata["protocol"] = (int)mySwitch.getReceivedProtocol();
     RFdata["length"] = (int)mySwitch.getReceivedBitlength();

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -101,7 +101,7 @@ void RFtoMQTTdiscovery(uint64_t MQTTvalue) {
   announceDeviceTrigger(
       false,
       (char*)discovery_topic.c_str(),
-      "recieved", 
+      "recieved",
       (char*)subType.c_str(),
       (char*)theUniqueId.c_str(),
       "", "", "", "");

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -95,12 +95,14 @@ void RFtoMQTTdiscovery(uint64_t MQTTvalue) {
   String discovery_topic = String(subjectRFtoMQTT);
 #    endif
 
-  String theUniqueId = getUniqueId("-" + String(switchRF[0]), "-" + String(switchRF[1]));
+  String theUniqueId = getUniqueId(String(switchRF[0]), "-" + String(switchRF[1]));
+  String subType = String(switchRF[0]);
 
   announceDeviceTrigger(
       false,
       (char*)discovery_topic.c_str(),
-      "", "",
+      "recieved", 
+      (char*)subType.c_str(),
       (char*)theUniqueId.c_str(),
       "", "", "", "");
 }
@@ -118,6 +120,7 @@ void RFtoMQTT() {
     int length = mySwitch.getReceivedBitlength();
     const char* binary = dec2binWzerofill(MQTTvalue, length);
 
+    RFdata["action"] = String("recieved");
     RFdata["value"] = (uint64_t)MQTTvalue;
     RFdata["protocol"] = (int)mySwitch.getReceivedProtocol();
     RFdata["length"] = (int)mySwitch.getReceivedBitlength();
@@ -146,6 +149,8 @@ void RFtoMQTT() {
         RFtoMQTTdiscovery(MQTTvalue);
 #  endif
       RFdata["origin"] = subjectRFtoMQTT;
+      enqueueJsonObject(RFdata);
+      RFdata["action"] = String("");
       enqueueJsonObject(RFdata);
       // Casting "receivedSignal[o].value" to (unsigned long) because ArduinoLog doesn't support uint64_t for ESP's
       Log.trace(F("Store val: %u" CR), (unsigned long)MQTTvalue);


### PR DESCRIPTION
## Description:
This is a proposed change to improve Home Assistant auto discoverability for devices using the "RF" (RCSwitch) library

Pass "received" as the type argument and switchRF[0] as the subtype argument to announceDeviceTrigger() which will cause received codes to be picked up by home assistant as triggers, i.e. When setting up automations in Home Assistant, selecting a `device` trigger and an OMG device will allow the user to select a code picked up during the autoDiscover window as the trigger for the automation, for example "1394004" received. In order to support this, the `'-DvalueAsATopic=true'` argument must be added to all environments using the "RF" Library because the changes modify the payload sent to the devices 433toMQTT/[Value] topic to include an `action` value that gets set to "received" and then back to "" as this appears to be how home assistant recognises the trigger.

Also change the getUniqueId() call to remove the leading '-' since the getUniqueId() function as defined in `ZmqttDiscovery.ino` already suffixes a "-" between the MAC address and the `name` parameter which will prevent MQTT topics having '--' in them. This doesnt provide any real benefit but makes things look nicer if using a tool like MQTT Explorer to inspect the raw messages as they come through.

I acknowledge that this my be a potentially breaking change for existing users and so this may not be accepted on this basis.

### Mitigation Guide for people not using HA, or using a manual HA yaml configuration
The changes proposed in this PR will break existing configurations for people not using HA, or using a manual HA yaml configuration. 
Thankfully for simple configurations where you are looking for a single value, the resolution is fairly straight forward. You simply need to append the "code" you are checking for to the end of the MQTT topic.

An existing manual HA MQTT configuration may look like this:
```yaml
mqtt:
  binary_sensor:
    - name: "doorbell"
      state_topic: "home/OpenMQTTGateway/433toMQTT"
      value_template: >- 
        {% if value_json.value == '14163857' %}
          {{'ON'}}
        {% else %}
          {{states('binary_sensor.doorbell') | upper}}
        {% endif %}
      off_delay: 30
      device_class: 'sound'
```

To update this configuration to work with the new implementation:
```yaml
mqtt:
  binary_sensor:
    - name: "doorbell"
      state_topic: "home/OpenMQTTGateway/433toMQTT/14163857"
      force_update: true  # Sends update events even if the value hasn’t changed (which will always be the case)
      value_template: >- 
        {% if value_json.value == '14163857' %}
          {{'ON'}}
        {% else %}
          {{states('binary_sensor.doorbell') | upper}}
        {% endif %}
      off_delay: 30
      device_class: 'sound'
```

For more complex implementations, like Door Sensors or other scenarios where you are checking for 2 different codes, you will need to create seperate sensors for each "code" and then check which one was most recently updated.
In Home Assistant this will require the use of a binary template sensor to compare the `last_updated` of the 2 binary sensors to determine the current state based on which one was most recently triggered.

An existing manual HA MQTT configuration may look like this:
```yaml
mqtt:
  binary_sensor:
    - name: "test"
      state_topic: "home/OpenMQTTGateway/433toMQTT"
      value_template: >-
        {% if value_json.value == 7821834 %}
          {{'ON'}}
        {% elif value_json.value == 7821838 %}
          {{'OFF'}}
        {% else %}
          {{states('binary_sensor.test') | upper}}
        {% endif %}
      qos: 0
      device_class: opening
```

The new configuration will look like this:
```yaml
mqtt:
  binary_sensor:
    - name: "front_door_open"
      unique_id: front_door_open  # must be set in order to 'hide' this sensor in the front end (if you wish)
      force_update: true  # Sends update events even if the value hasn’t changed (which will always be the case)
      state_topic: "home/OpenMQTTGateway/433toMQTT/7821834"
      value_template: >-
        {% if value_json.value == 7821834 %}
          {{'ON'}}
        {% endif %}

    - name: "front_door_closed"
      unique_id: front_door_closed  # must be set in order to 'hide' this sensor in the front end (if you wish)
      force_update: true  # Sends update events even if the value hasn’t changed (which will always be the case)
      state_topic: "home/OpenMQTTGateway/433toMQTT/7821838"
      value_template: >-
        {% if value_json.value == 7821838 %}
          {{'ON'}}
        {% endif %}

binary_sensor:
  - platform: template
    sensors:
      front_door:
        friendly_name: "Front Door"
        value_template: >-
          {% if states.binary_sensor.front_door_open.last_changed > states.binary_sensor.front_door_closed.last_changed %}
            {{'ON'}}
          {% else %}
            {{'OFF'}}
          {% endif %}
        device_class: opening
```
Alternativley, You could create an automation with multiple triggers (1 trigger for each code) which then updates a binary helper depending on which trigger started the automation using "Trigger ID's"

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
