### PR TITLE
[BLUFI] Add Blufi activation and deactivation at runtime

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -824,6 +824,7 @@ enum PowerMode { DEACTIVATED = -1,
 struct SYSConfig_s {
   bool mqtt; // if true the gateway will publish the received data on the MQTT broker
   bool serial; // if true the gateway will publish the received data on the SERIAL
+  bool blufi; // if true the gateway will be accesible with blufi
   bool offline;
   bool discovery; // HA discovery convention
   bool ohdiscovery; // OH discovery specificities
@@ -838,6 +839,9 @@ struct SYSConfig_s {
 #endif
 #ifndef DEFAULT_SERIAL
 #  define DEFAULT_SERIAL false
+#endif
+#ifndef DEFAULT_BLUFI
+#  define DEFAULT_BLUFI true
 #endif
 #ifndef DEFAULT_OFFLINE
 #  define DEFAULT_OFFLINE false

--- a/main/Zblufi.ino
+++ b/main/Zblufi.ino
@@ -396,7 +396,25 @@ bool startBlufi() {
   NimBLEDevice::init(advName);
   esp_blufi_gatt_svr_init();
   ble_gatts_start();
+  Log.notice(F("BLUFI started" CR));
   return esp_blufi_profile_init() == ESP_OK;
+}
+
+bool stopBlufi() {
+  esp_err_t result = ESP_OK;
+  if (omg_blufi_ble_connected) {
+    esp_blufi_disconnect();
+    delay(50);
+  }
+
+  ble_gap_adv_stop();
+  result = esp_blufi_profile_deinit();
+  if (result != ESP_OK) {
+    Log.error(F("Failed to deinit blufi profile: %d" CR), result);
+    return false;
+  }
+  Log.notice(F("BLUFI stopped" CR));
+  return true;
 }
 
 #endif // defined(ESP32) && defined(USE_BLUFI)

--- a/main/main.ino
+++ b/main/main.ino
@@ -780,6 +780,9 @@ void SYSConfig_init() {
   SYSConfig.mqtt = DEFAULT_MQTT;
   SYSConfig.serial = DEFAULT_SERIAL;
   SYSConfig.offline = DEFAULT_OFFLINE;
+#if USE_BLUFI
+  SYSConfig.blufi = DEFAULT_BLUFI;
+#endif
 #ifdef ZmqttDiscovery
   SYSConfig.discovery = DEFAULT_DISCOVERY;
   SYSConfig.ohdiscovery = OpenHABDiscovery;
@@ -794,6 +797,9 @@ void SYSConfig_fromJson(JsonObject& SYSdata) {
   Config_update(SYSdata, "mqtt", SYSConfig.mqtt);
   Config_update(SYSdata, "serial", SYSConfig.serial);
   Config_update(SYSdata, "offline", SYSConfig.offline);
+#if USE_BLUFI
+  Config_update(SYSdata, "blufi", SYSConfig.blufi);
+#endif
 #ifdef ZmqttDiscovery
   Config_update(SYSdata, "disc", SYSConfig.discovery);
   Config_update(SYSdata, "ohdisc", SYSConfig.ohdiscovery);
@@ -812,6 +818,9 @@ void SYSConfig_save() {
   SYSdata["serial"] = SYSConfig.serial;
   SYSdata["offline"] = SYSConfig.offline;
   SYSdata["powermode"] = SYSConfig.powerMode;
+#  if USE_BLUFI
+  SYSdata["blufi"] = SYSConfig.blufi;
+#  endif
 #  ifdef ZmqttDiscovery
   SYSdata["disc"] = SYSConfig.discovery;
   SYSdata["ohdisc"] = SYSConfig.ohdiscovery;
@@ -1266,7 +1275,8 @@ void setup() {
 #endif
 
 #if defined(ESP32) && defined(USE_BLUFI)
-  startBlufi();
+  if (SYSConfig.blufi)
+    startBlufi();
 #endif
 
 #if defined(ESPWifiManualSetup)
@@ -2644,6 +2654,9 @@ String stateMeasures() {
 #ifdef RGB_INDICATORS
   SYSdata["rgbb"] = SYSConfig.rgbbrightness;
 #endif
+#if USE_BLUFI
+  SYSdata["blufi"] = SYSConfig.blufi;
+#endif
 #ifdef ZmqttDiscovery
   SYSdata["disc"] = SYSConfig.discovery;
   SYSdata["ohdisc"] = SYSConfig.ohdiscovery;
@@ -3177,6 +3190,7 @@ void readCntParameters(int index) {
 void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
   if (cmpToMainTopic(topicOri, subjectMQTTtoSYSset)) {
     bool restartESP = false;
+    bool publishState = false;
     Log.trace(F("MQTTtoSYS json" CR));
     if (SYSdata.containsKey("cmd")) {
       const char* cmd = SYSdata["cmd"];
@@ -3188,7 +3202,7 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
         setupwifi(true);
 #endif
       } else if (strstr(cmd, statusCmd) != NULL) { //erase and restart
-        stateMeasures();
+        publishState = true;
       }
     }
 #ifdef RGB_INDICATORS
@@ -3201,7 +3215,7 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
         updatePowerIndicator();
 #  endif
         Log.notice(F("RGB brightness: %d" CR), SYSConfig.rgbbrightness);
-        stateMeasures();
+        publishState = true;
       } else {
         Log.error(F("RGB brightness value invalid - ignoring command" CR));
       }
@@ -3211,7 +3225,7 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
     if (SYSdata.containsKey("ohdisc") && SYSdata["ohdisc"].is<bool>()) {
       SYSConfig.ohdiscovery = SYSdata["ohdisc"];
       Log.notice(F("OpenHAB discovery: %T" CR), SYSConfig.ohdiscovery);
-      stateMeasures();
+      publishState = true;
     }
 #endif
     if (SYSdata.containsKey("wifi_ssid") && SYSdata["wifi_ssid"].is<char*>() && SYSdata.containsKey("wifi_pass") && SYSdata["wifi_pass"].is<char*>()) {
@@ -3404,12 +3418,26 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
       SYSConfig.powerMode = SYSdata["powermode"];
       Log.notice(F("Power mode: %d" CR), SYSConfig.powerMode);
     }
+#if USE_BLUFI
+    if (SYSdata.containsKey("blufi") && SYSdata["blufi"].is<bool>()) {
+      bool res = false;
+      if (SYSdata["blufi"] && !SYSConfig.blufi) { // Start Blufi
+        res = startBlufi();
+      } else if (!SYSdata["blufi"] && SYSConfig.blufi) { // Stop Blufi
+        res = stopBlufi();
+      }
+      if (res)
+        SYSConfig.blufi = SYSdata["blufi"];
+      publishState = true;
+      Log.notice(F("Blufi: %T" CR), SYSConfig.blufi);
+    }
+#endif
     if (SYSdata.containsKey("disc")) {
       if (SYSdata["disc"].is<bool>()) {
         if (SYSdata["disc"] == true && SYSConfig.discovery == false)
           lastDiscovery = millis();
         SYSConfig.discovery = SYSdata["disc"];
-        stateMeasures();
+        publishState = true;
         if (SYSConfig.discovery)
           pubMqttDiscovery();
       } else {
@@ -3419,6 +3447,9 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
     }
     if (SYSdata.containsKey("save") && SYSdata["save"].as<bool>()) {
       SYSConfig_save();
+    }
+    if (publishState) {
+      stateMeasures();
     }
     if (restartESP) {
       ESPRestart(7);


### PR DESCRIPTION
## Description:
Enable to start and stop BluFi during runtime with an MQTT command

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
