### PR TITLE
[BT] Fix crash when sending multiple BT commands at the same time

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -1551,8 +1551,14 @@ void MQTTtoBT(char* topicOri, JsonObject& BTdata) { // json object decoding
     BTConfig_fromJson(BTdata);
 
   } else if (cmpToMainTopic(topicOri, subjectMQTTtoBT)) {
-    KnownBTActions(BTdata);
-    MQTTtoBTAction(BTdata);
+    if (xSemaphoreTake(semaphoreBLEOperation, pdMS_TO_TICKS(5000)) == pdTRUE) {
+      KnownBTActions(BTdata);
+      MQTTtoBTAction(BTdata);
+      xSemaphoreGive(semaphoreBLEOperation);
+    } else {
+      Log.error(F("BLE busy - command not sent" CR));
+      gatewayState = GatewayState::ERROR;
+    }
   }
 }
 #endif


### PR DESCRIPTION
## Description:
When sending BLE commands at the same time (example triggering an automation to open several curtains), a restart was generated due to common access to the BLE actions vector.
Fixing this by adding the BLE operation semaphore to the command initiators

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
