### PR TITLE
[DISC] Warning message for discovery prefix change

### DIFF
--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -281,7 +281,7 @@ void rtl_433_Callback(char* message) {
   String topic = subjectRTL_433toMQTT;
   String model = RFrtl_433_ESPdata["model"];
   String type = RFrtl_433_ESPdata["type"];
-  Log.notice(F("type: %s" CR), type.c_str());
+  // Log.notice(F("type: %s" CR), type.c_str());
   String uniqueid;
 
   const char naming_keys[5][8] = {"type", "model", "subtype", "channel", "id"}; // from rtl_433_mqtt_hass.py

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -281,7 +281,6 @@ void rtl_433_Callback(char* message) {
   String topic = subjectRTL_433toMQTT;
   String model = RFrtl_433_ESPdata["model"];
   String type = RFrtl_433_ESPdata["type"];
-  // Log.notice(F("type: %s" CR), type.c_str());
   String uniqueid;
 
   const char naming_keys[5][8] = {"type", "model", "subtype", "channel", "id"}; // from rtl_433_mqtt_hass.py

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -113,7 +113,8 @@ void announceDeviceTrigger(bool use_gateway_info,
                            char* device_mac);
 
 #ifdef discovery_Topic //Deprecated - use discovery_Prefix instead
-#  define discovery_Prefix "homeassistant"
+#  pragma message("compiler directive discovery_Topic is deprecated, use discovery_Prefix instead")
+#  define discovery_Prefix discovery_Topic
 #endif
 #ifndef discovery_Prefix
 #  define discovery_Prefix "homeassistant"


### PR DESCRIPTION
## Description:

I did a refresh this AM, as part of investigating #2064, and found that my Homebridge environment was filled with rtl_433 devices.  Went back and looked at the recent changes, and saw the compiler directive change from `discovery_Topic` to `discovery_Prefix` ( which is a better directive name ), and saw that the old directive was being overwritten with 'homeassistant', rather than being backwardly compatible with a warning.

## Proposed fix

1 - Add backward compatibility on the directive `discovery_Topic`
2 - Add a compiler warning when the backward compatibility is invoked. So that others are not impacted as I was.

PS I see that we are using the complier option '-w' which disables warnings, which prevents usage of `#warning`, hence my usage of `#  pragma message("compiler directive discovery_Topic is deprecated, use discovery_Prefix instead")`.  Maybe we should enable warnings, and fix the warnings.  I did see a lot of warnings when compiling with -w removed

PSS -  ZgatewayRTL_433 -> Log.notice(F("type: %s" CR), type.c_str());  I commented this out as it just fills the log with type: null messages

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
