### PR TITLE
[SYS] Detect IDF environnement with USE_ESP_IDF

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -851,7 +851,7 @@ void setupBTTasksAndBLE() {
   xTaskCreatePinnedToCore(
       procBLETask, /* Function to implement the task */
       "procBLETask", /* Name of the task */
-#  ifdef USE_BLUFI
+#  if defined(USE_ESP_IDF) || defined(USE_BLUFI)
       12500,
 #  else
       8500, /* Stack size in bytes */


### PR DESCRIPTION
## Description:
Rather than `USE_BLUFI` only, as IDF can be used without BLUFI
The macro `USE_ESP_IDF` needs to be added to the environments that use ESP IDF but not BLUFI

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
