### PR TITLE
[SYS] Fix connection validation on unknown indexes and improve erase method

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -257,10 +257,6 @@ const char* OTAserver_cert = "";
 #  define MQTT_SECURE_SIGNED_CLIENT 0 // If using a signed certificate for the broker and using client certificate/key set this to true or 1
 #endif
 
-#ifndef CNT_DEFAULT_INDEX
-#  define CNT_DEFAULT_INDEX 0 // Default set of connection parameters
-#endif
-
 #ifdef PRIVATE_CERTS
 #  include "certs/private_client_cert.h"
 #  include "certs/private_client_key.h"
@@ -272,6 +268,10 @@ const char* OTAserver_cert = "";
 #endif
 
 #include <string>
+
+#ifndef CNT_DEFAULT_INDEX
+#  define CNT_DEFAULT_INDEX 0 // Default set of connection parameters
+#endif
 
 #if !MQTT_BROKER_MODE
 struct ss_cnt_parameters {
@@ -288,9 +288,6 @@ struct ss_cnt_parameters {
   bool validConnection;
 };
 
-// Index 0 is used for connection parameters provided in the build that can be overloaded by WiFi Manager/Onboarding/WebUI,MQTT
-#  define CNT_DEFAULT_INDEX 0
-// Index 1 and more are used for connection parameters provided at runtime by MQTT
 #  define cnt_parameters_array_size 3
 
 ss_cnt_parameters cnt_parameters_array[cnt_parameters_array_size] = {

--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -46,7 +46,7 @@ QueueHandle_t webUIQueue;
 WebServer server(80);
 
 /*------------------- External functions ----------------------*/
-extern void eraseAndRestart();
+extern void erase(bool restart);
 extern unsigned long uptime();
 
 /*------------------- Web Console Globals ----------------------*/
@@ -1237,7 +1237,7 @@ void handleRT() {
     response += String(buffer);
     server.send(200, "text/html", response);
 
-    eraseAndRestart();
+    erase(true);
   } else {
     handleCN();
   }


### PR DESCRIPTION
## Description:
Before this fix, connections with Index 1 and 2 were supposed valid when not present in the configuration, generating attempts to connect with those indexes. 
Also improve the erase config by adding an erase when the config file is not present (ESP is connected to WiFi without the config file). This way the ESP will not reconnect to the WiFi AP.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
