### PR TITLE
[DISC] Fix via device discovery when using a secondary module

### DIFF
--- a/main/ZgatewaySERIAL.ino
+++ b/main/ZgatewaySERIAL.ino
@@ -205,6 +205,12 @@ void SERIALtoX() {
           } else {
             // send as json
             if (SERIALdata.containsKey("origin") || SERIALdata.containsKey("topic")) {
+#      ifdef ZmqttDiscovery
+              // We need to assign the discovery message to the primary module instead of the secondary module
+              if (SERIALdata.containsKey("device") && SERIALdata["device"].containsKey("via_device")) {
+                SERIALdata["device"]["via_device"] = gateway_name;
+              }
+#      endif
               enqueueJsonObject(SERIALdata);
             } else {
               SERIALdata["origin"] = subjectSERIALtoMQTT;


### PR DESCRIPTION
## Description:
When using a secondary module communicating by Serial we want the via_device identifier to be the one of the primary module and not the secondary one.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
