### PR TITLE
[ONB] Fix failsafe mode

### DIFF
--- a/main/ZsensorGPIOInput.ino
+++ b/main/ZsensorGPIOInput.ino
@@ -64,6 +64,7 @@ void MeasureGPIOInput() {
         resetTime = millis();
       } else if ((millis() - resetTime) > 3000) {
         Log.trace(F("Button Held" CR));
+        gatewayState = GatewayState::WAITING_ONBOARDING;
 // Switching off the relay during reset or failsafe operations
 #    ifdef ZactuatorONOFF
         uint8_t level = digitalRead(ACTUATOR_ONOFF_GPIO);
@@ -72,7 +73,7 @@ void MeasureGPIOInput() {
         }
 #    endif
         Log.notice(F("Erasing ESP Config, restarting" CR));
-        setupWiFiManager(true);
+        erase(true);
       }
     } else {
       resetTime = 0;


### PR DESCRIPTION
## Description:
Erasing the nvs before the start of WM prevent WM from starting, revert a part of #2075 Also remove the erase from setupWiFiManager method
Also replace the setMode by a gateway state change for better decoupling

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
