### PR TITLE
[RF] Disable the active RF receive when transmitting with RC-Switch and "Kaku"

### DIFF
--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -236,8 +236,8 @@ void XtoRF(const char* topicOri, JsonObject& RFdata) { // json object decoding
       Log.notice(F("RF Protocol:%d" CR), valuePRT);
       Log.notice(F("RF Pulse Lgth: %d" CR), valuePLSL);
       Log.notice(F("Bits nb: %d" CR), valueBITS);
-#    ifdef ZradioCC1101
       disableCurrentReceiver();
+#    ifdef ZradioCC1101
       initCC1101();
       int txPower = RFdata["txpower"] | RF_CC1101_TXPOWER;
       ELECHOUSE_cc1101.setPA((int)txPower);

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -133,7 +133,7 @@ void rf2Callback(unsigned int period, unsigned long address, unsigned long group
 
 #  if simpleReceiving
 void XtoRF2(const char* topicOri, const char* datacallback) {
-  NewRemoteReceiver::disable();
+  disableCurrentReceiver();
   pinMode(RF_EMITTER_GPIO, OUTPUT);
   initCC1101();
 
@@ -235,8 +235,8 @@ void XtoRF2(const char* topicOri, const char* datacallback) {
   }
 #    ifdef ZradioCC1101
   ELECHOUSE_cc1101.SetRx(RFConfig.frequency); // set Receive on
-  NewRemoteReceiver::enable();
 #    endif
+  enableActiveReceiver();
 }
 #  endif
 
@@ -266,7 +266,7 @@ void XtoRF2(const char* topicOri, JsonObject& RF2data) { // json object decoding
           valueUNIT = 0;
         if (valuePERIOD == 0)
           valuePERIOD = 272;
-        NewRemoteReceiver::disable();
+        disableCurrentReceiver();
         NewRemoteTransmitter transmitter(valueCODE, RF_EMITTER_GPIO, valuePERIOD, RF2_EMITTER_REPEAT);
         Log.trace(F("Sending" CR));
         if (valueGROUP) {
@@ -283,7 +283,7 @@ void XtoRF2(const char* topicOri, JsonObject& RF2data) { // json object decoding
           }
         }
         Log.notice(F("MQTTtoRF2 OK" CR));
-        NewRemoteReceiver::enable();
+        enableActiveReceiver();
 
         success = true;
       }


### PR DESCRIPTION
Pilight RF transmit is behaving this way already.

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
