### PR TITLE
[SYS] Fix ESP8266 discovery publications

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -152,13 +152,14 @@
 #ifndef JSON_MSG_BUFFER
 #  if defined(ESP32)
 #    define JSON_MSG_BUFFER 1024 // adjusted to minimum size covering largest home assistant discovery messages
+#    if MQTT_SECURE_DEFAULT
+#      define JSON_MSG_BUFFER_MAX 2048 // Json message buffer size increased to handle certificate changes through MQTT, used for the queue and the coming MQTT messages
+#    else
+#      define JSON_MSG_BUFFER_MAX 1024 // Minimum size for the cover MQTT discovery message
+#    endif
 #  elif defined(ESP8266)
-#    define JSON_MSG_BUFFER 512 // Json message max buffer size, don't put 768 or higher it is causing unexpected behaviour on ESP8266, certificates handling with ESP8266 is not tested
-#  endif
-#  if MQTT_SECURE_DEFAULT
-#    define JSON_MSG_BUFFER_MAX 2048 // Json message buffer size increased to handle certificate changes through MQTT, used for the queue and the coming MQTT messages
-#  else
-#    define JSON_MSG_BUFFER_MAX 1024 // Minimum size for the cover MQTT discovery message
+#    define JSON_MSG_BUFFER     512 // Json message max buffer size, don't put 768 or higher it is causing unexpected behaviour on ESP8266, certificates handling with ESP8266 is not tested
+#    define JSON_MSG_BUFFER_MAX 832 // Minimum size for MQTT discovery message
 #  endif
 #endif
 

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -242,7 +242,7 @@ void createDiscovery(const char* sensor_type,
                      const char* payload_available, const char* payload_not_available, bool gateway_entity, const char* cmd_topic,
                      const char* device_name, const char* device_manufacturer, const char* device_model, const char* device_id, bool retainCmd,
                      const char* state_class, const char* state_off, const char* state_on, const char* enum_options, const char* command_template) {
-  StaticJsonDocument<JSON_MSG_BUFFER_MAX> jsonBuffer;
+  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
   JsonObject sensor = jsonBuffer.to<JsonObject>();
 
   // If a component cannot render it's state (f.i. KAKU relays) no state topic

--- a/main/main.ino
+++ b/main/main.ino
@@ -526,7 +526,7 @@ void emptyQueue() {
     return;
   }
   Log.trace(F("Dequeue JSON" CR));
-  DynamicJsonDocument jsonBuffer(JSON_MSG_BUFFER);
+  DynamicJsonDocument jsonBuffer(JSON_MSG_BUFFER_MAX);
   JsonObject obj = jsonBuffer.to<JsonObject>();
 #ifdef ESP32
   if (xSemaphoreTake(xQueueMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {


### PR DESCRIPTION
## Description:
Before this PR discovery messages at start were not published with ESP8266 due to memory, this PR fixes it.
Also we don't need to use `JSON_MSG_BUFFER_MAX` with ESP32 into discovery messages as we have now a base of `1024` with `JSON_MSG_BUFFER` which is more than the requirement for the [cover discovery message](https://github.com/1technophile/OpenMQTTGateway/pull/2005)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
