### PR TITLE
[WEBUI] Fix for TH1 external probe in display routine

### DIFF
--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -2054,7 +2054,7 @@ void webUIPubPrint(const char* topicori, JsonObject& data) {
                 }
               }
 
-              if (data.containsKey("extprobe")) {
+              if (data.containsKey("extprobe") && data["extprobe"]) {
                 property++;
                 properties[property] = " ext. probe";
               }


### PR DESCRIPTION
Fix for TH1 external probe in display routine only actually showing when connected.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
