### PR TITLE
Allow multiple RF modules simulatenously

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -39,12 +39,12 @@ Note that with CC1101 this frequency will be used as the default sending frequen
 
 Switching of the active transceiver (RTL_433 receiver only) module is available between the RF, RF2, and (RTL_433 or Pilight) gateway modules, allowing for changing of signal decoders without redeploying the OpenMQTTGateway package.  Sending a JSON message to the command topic will change the active transceiver module.
 
-To change the RF gateway module, which will receive, send a json message to the RF gateway module command subject (home/OpenMQTTGateway/commands/MQTTtoRF/config) with the corresponding value of the key "active" 
+To change the RF gateway module, which will receive, send a json message to the RF gateway module command subject (home/OpenMQTTGateway/commands/MQTTtoRF/config) with the corresponding value of the key "active". Add these numbers together to enable multiple modules (e.g. to enable Pilight and RF, send 3, since 1 (for Pilight) + 2 (for RF) = 3).
 
 1 - PiLight<br>
 2 - RF<br>
-3 - RTL_433<br>
-4 - RF2
+4 - RTL_433<br>
+8 - RF2
 
 Example to receive from the RF gateway:
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoRF/config" -m '{"active":2}'`

--- a/main/ZcommonRF.ino
+++ b/main/ZcommonRF.ino
@@ -1,13 +1,13 @@
-/*  
+/*
   Theengs OpenMQTTGateway - We Unite Sensors in One Open-Source Interface
 
-   Act as a wifi or ethernet gateway between your BLE/433mhz/infrared IR signal and an MQTT broker 
+   Act as a wifi or ethernet gateway between your BLE/433mhz/infrared IR signal and an MQTT broker
    Send and receiving command by MQTT
-  
+
     Copyright: (c)Florian ROBERT
-  
+
     This file is part of OpenMQTTGateway.
-    
+
     OpenMQTTGateway is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -70,99 +70,75 @@ bool validFrequency(float mhz) {
 
 int currentReceiver = ACTIVE_NONE;
 
-#  if !defined(ZgatewayRFM69) && !defined(ZactuatorSomfy)
-// Check if a receiver is available
-bool validReceiver(int receiver) {
-  switch (receiver) {
-#    ifdef ZgatewayPilight
-    case ACTIVE_PILIGHT:
-      return true;
-#    endif
-#    ifdef ZgatewayRF
-    case ACTIVE_RF:
-      return true;
-#    endif
-#    ifdef ZgatewayRTL_433
-    case ACTIVE_RTL:
-      return true;
-#    endif
-#    ifdef ZgatewayRF2
-    case ACTIVE_RF2:
-      return true;
-#    endif
-    default:
-      Log.error(F("ERROR: stored receiver %d not available" CR), receiver);
-  }
-  return false;
-}
-#  endif
-
 void disableCurrentReceiver() {
   Log.trace(F("disableCurrentReceiver: %d" CR), currentReceiver);
-  switch (currentReceiver) {
-    case ACTIVE_NONE:
-      break;
+  if (currentReceiver == ACTIVE_NONE) {
+    return;
+  }
+  bool recognized = false;
 #  ifdef ZgatewayPilight
-    case ACTIVE_PILIGHT:
-      disablePilightReceive();
-      break;
+  if ((currentReceiver & ACTIVE_PILIGHT) == ACTIVE_PILIGHT) {
+    disablePilightReceive();
+    recognized = true;
+  }
 #  endif
 #  ifdef ZgatewayRF
-    case ACTIVE_RF:
-      disableRFReceive();
-      break;
+  if ((currentReceiver & ACTIVE_RF) == ACTIVE_RF) {
+    disableRFReceive();
+    recognized = true;
+  }
 #  endif
 #  ifdef ZgatewayRTL_433
-    case ACTIVE_RTL:
-      disableRTLreceive();
-      break;
+  if ((currentReceiver & ACTIVE_RTL) == ACTIVE_RTL) {
+    disableRTLreceive();
+    recognized = true;
+  }
 #  endif
 #  ifdef ZgatewayRF2
-    case ACTIVE_RF2:
-      disableRF2Receive();
-      break;
+  if ((currentReceiver & ACTIVE_RF2) == ACTIVE_RF2) {
+    disableRF2Receive();
+    recognized = true;
+  }
 #  endif
-    default:
-      Log.error(F("ERROR: unsupported receiver %d" CR), RFConfig.activeReceiver);
+  if (!recognized) {
+    Log.error(F("ERROR: unsupported receiver %d" CR), currentReceiver); // This should be currentReceiver, not RFConfig.activeReceiver
   }
 }
 
 void enableActiveReceiver() {
   Log.trace(F("enableActiveReceiver: %d" CR), RFConfig.activeReceiver);
-  switch (RFConfig.activeReceiver) {
+  initCC1101(); // Okay to do this even with an invalid receiver selected, right?
+  bool recognized = false;
 #  ifdef ZgatewayPilight
-    case ACTIVE_PILIGHT:
-      initCC1101();
-      enablePilightReceive();
-      currentReceiver = ACTIVE_PILIGHT;
-      break;
+  if ((RFConfig.activeReceiver & ACTIVE_PILIGHT) == ACTIVE_PILIGHT) {
+    enablePilightReceive();
+    recognized = true;
+  }
 #  endif
 #  ifdef ZgatewayRF
-    case ACTIVE_RF:
-      initCC1101();
-      enableRFReceive();
-      currentReceiver = ACTIVE_RF;
-      break;
+  if ((RFConfig.activeReceiver & ACTIVE_RF) == ACTIVE_RF) {
+    enableRFReceive();
+    recognized = true;
+  }
 #  endif
 #  ifdef ZgatewayRTL_433
-    case ACTIVE_RTL:
-      initCC1101();
-      enableRTLreceive();
-      currentReceiver = ACTIVE_RTL;
-      break;
+  if ((RFConfig.activeReceiver & ACTIVE_RTL) == ACTIVE_RTL) {
+    enableRTLreceive();
+    recognized = true;
+  }
 #  endif
 #  ifdef ZgatewayRF2
-    case ACTIVE_RF2:
-      initCC1101();
-      enableRF2Receive();
-      currentReceiver = ACTIVE_RF2;
-      break;
+  if ((RFConfig.activeReceiver & ACTIVE_RF2) == ACTIVE_RF2) {
+    enableRF2Receive();
+    recognized = true;
+  }
 #  endif
-    case ACTIVE_RECERROR:
-      Log.error(F("ERROR: no receiver selected" CR));
-      break;
-    default:
-      Log.error(F("ERROR: unsupported receiver %d" CR), RFConfig.activeReceiver);
+  if (recognized) {
+    currentReceiver = RFConfig.activeReceiver;
+  } else if (RFConfig.activeReceiver == ACTIVE_RECERROR) {
+    Log.error(F("ERROR: no receiver selected" CR));
+  } else {
+    Log.error(F("ERROR: unsupported receiver %d" CR), RFConfig.activeReceiver);
   }
 }
 
@@ -173,7 +149,7 @@ String stateRFMeasures() {
   RFdata["active"] = RFConfig.activeReceiver;
 #  if defined(ZradioCC1101) || defined(ZradioSX127x)
   RFdata["frequency"] = RFConfig.frequency;
-  if (RFConfig.activeReceiver == ACTIVE_RTL) {
+  if ((RFConfig.activeReceiver & ACTIVE_RTL) == ACTIVE_RTL) {
 #    ifdef ZgatewayRTL_433
     RFdata["rssithreshold"] = (int)getRTLrssiThreshold();
     RFdata["rssi"] = (int)getRTLCurrentRSSI();

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -294,7 +294,7 @@ extern void disablePilightReceive() {
 extern void enablePilightReceive() {
   Log.notice(F("Switching to Pilight Receiver: %F" CR), RFConfig.frequency);
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
-  Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
+  Log.notice(F("RF_PILIGHT_RECEIVER_GPIO: %d " CR), RF_PILIGHT_RECEIVER_GPIO);
   Log.trace(F("ZgatewayPilight command topic: %s%s%s" CR), mqtt_topic, gateway_name, subjectMQTTtoPilight);
 
   initCC1101();
@@ -305,7 +305,7 @@ extern void enablePilightReceive() {
     rf.setPulseTrainCallBack(pilightRawCallback);
   }
 #  endif
-  rf.initReceiver(RF_RECEIVER_GPIO);
+  rf.initReceiver(RF_PILIGHT_RECEIVER_GPIO);
   pinMode(RF_EMITTER_GPIO, OUTPUT); // Set this here, because if this is the RX pin it was reset to INPUT by Serial.end();
   rf.enableReceiver();
   loadPilightConfig();

--- a/main/ZgatewayRF.ino
+++ b/main/ZgatewayRF.ino
@@ -220,7 +220,7 @@ void XtoRF(const char* topicOri, const char* datacallback) {
 #    ifdef ZradioCC1101 // set Receive on and Transmitt off
   ELECHOUSE_cc1101.SetRx(RFConfig.frequency);
   mySwitch.disableTransmit();
-  mySwitch.enableReceive(RF_RECEIVER_GPIO);
+  mySwitch.enableReceive(RF_RF_RECEIVER_GPIO);
 #    endif
 }
 #  endif
@@ -275,14 +275,14 @@ void enableRFReceive() {
   Log.notice(F("Enable RF Receiver: %FMhz" CR), RFConfig.frequency);
   //RF init parameters
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
-  Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
+  Log.notice(F("RF_RF_RECEIVER_GPIO: %d " CR), RF_RF_RECEIVER_GPIO);
 
 #  ifdef RF_DISABLE_TRANSMIT
   mySwitch.disableTransmit();
 #  else
   mySwitch.enableTransmit(RF_EMITTER_GPIO);
 #  endif
-  receiveInterupt = RF_RECEIVER_GPIO;
+  receiveInterupt = RF_RF_RECEIVER_GPIO;
   mySwitch.setRepeatTransmit(RF_EMITTER_REPEAT);
   mySwitch.enableReceive(receiveInterupt);
   Log.trace(F("ZgatewayRF command topic: %s%s%s" CR), mqtt_topic, gateway_name, subjectMQTTtoRF);

--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -308,10 +308,10 @@ void disableRF2Receive() {
 
 void enableRF2Receive() {
   Log.trace(F("enableRF2Receive" CR));
-  NewRemoteReceiver::init(RF_RECEIVER_GPIO, 2, rf2Callback);
+  NewRemoteReceiver::init(RF_RF2_RECEIVER_GPIO, 2, rf2Callback);
 
   Log.notice(F("RF_EMITTER_GPIO: %d " CR), RF_EMITTER_GPIO);
-  Log.notice(F("RF_RECEIVER_GPIO: %d " CR), RF_RECEIVER_GPIO);
+  Log.notice(F("RF_RF2_RECEIVER_GPIO: %d " CR), RF_RF2_RECEIVER_GPIO);
   Log.trace(F("ZgatewayRF2 command topic: %s%s%s" CR), mqtt_topic, gateway_name, subjectMQTTtoRF2);
   pinMode(RF_EMITTER_GPIO, OUTPUT);
   digitalWrite(RF_EMITTER_GPIO, LOW);

--- a/main/ZwebUI.ino
+++ b/main/ZwebUI.ino
@@ -1101,10 +1101,10 @@ std::map<int, String> activeReceiverOptions = {
     {2, "RF"},
 #    endif
 #    ifdef ZgatewayRTL_433
-    {3, "RTL_433"},
+    {4, "RTL_433"},
 #    endif
 #    if defined(ZgatewayRF2) && !defined(ZradioSX127x)
-    {4, "RF2 (restart required)"}
+    {8, "RF2 (restart required)"}
 #    endif
 };
 

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -195,8 +195,8 @@ const char parameters[51][4][24] = {
  * Active  Module
  * 1 = ZgatewayPilight
  * 2 = ZgatewayRF
- * 3 = ZgatewayRTL_433
- * 4 = ZgatewayRF2
+ * 4 = ZgatewayRTL_433
+ * 8 = ZgatewayRF2
  */
 
 struct RFConfig_s {
@@ -210,8 +210,8 @@ struct RFConfig_s {
 #define ACTIVE_RECERROR 0
 #define ACTIVE_PILIGHT  1
 #define ACTIVE_RF       2
-#define ACTIVE_RTL      3
-#define ACTIVE_RF2      4
+#define ACTIVE_RTL      4
+#define ACTIVE_RF2      8
 
 RFConfig_s RFConfig;
 
@@ -223,11 +223,25 @@ RFConfig_s RFConfig;
 #endif
 
 /*-------------------PIN DEFINITIONS----------------------*/
-#ifndef RF_RECEIVER_GPIO
+#ifndef RF_PILIGHT_RECEIVER_GPIO
 #  ifdef ESP8266
-#    define RF_RECEIVER_GPIO 0 // D3 on nodemcu // put 4 with rf bridge direct mod
+#    define RF_PILIGHT_RECEIVER_GPIO 0 // D3 on nodemcu // put 4 with rf bridge direct mod
 #  elif ESP32
-#    define RF_RECEIVER_GPIO 27 // D27 on DOIT ESP32
+#    define RF_PILIGHT_RECEIVER_GPIO 27 // D27 on DOIT ESP32
+#  endif
+#endif
+#ifndef RF_RF_RECEIVER_GPIO
+#  ifdef ESP8266
+#    define RF_RF_RECEIVER_GPIO 0 // D3 on nodemcu // put 4 with rf bridge direct mod
+#  elif ESP32
+#    define RF_RF_RECEIVER_GPIO 27 // D27 on DOIT ESP32
+#  endif
+#endif
+#ifndef RF_RF2_RECEIVER_GPIO
+#  ifdef ESP8266
+#    define RF_RF2_RECEIVER_GPIO 0 // D3 on nodemcu // put 4 with rf bridge direct mod
+#  elif ESP32
+#    define RF_RF2_RECEIVER_GPIO 27 // D27 on DOIT ESP32
 #  endif
 #endif
 


### PR DESCRIPTION
## Description:
So this is how I've been successfully using the Pilight and RF modules simultaneously on the same OMG installation. I have a normal RXB6 receiver, and its same data pin goes to 2 different pins on the ESP8266 (presumably to take advantage of the hardware interrupts thereof).

The code change is **dead simple**: just enable all the RF modules you want instead of only enabling one.

I use a bitfield for setting the active receiver (0000), so you can set multiple receivers at the same time with e.g. 0011, meaning {"active": 3} for Pilight + RF. Do this using the usual active receiver setting thing (e.g. publish `{"active": 3}` to `rf/OpenMQTTGateway/commands/MQTTtoRF/config`).

There are obviously some things that might not work that I haven't tried, like CC1101 using Pilight + RF or HA discovery, but I'm just a simple man, I use the old fashioned RXB6 variants for most OOK things like this. The code will need adjustment and sanity checks like this. Since I'm not sure how you'd want to implement configurations and etc, this is a draft, but it works perfectly for my purposes, so I wanted to share it in hopes of getting a variation of it merged for others' benefit. (see #450)

Thanks @1technophile for your efforts and openminded kindness through the years.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
