### PR TITLE
Update ZgatewaySERIAL.ino Fix tx issues

### DIFF
--- a/main/ZgatewaySERIAL.ino
+++ b/main/ZgatewaySERIAL.ino
@@ -48,12 +48,17 @@ const TickType_t semaphoreTimeout = pdMS_TO_TICKS(1000); // 1 second timeout
 #    define SEMAPHORE_SERIAL_GIVE
 #  endif
 
+#  ifdef SENDER_SERIAL_HEARTBEAT
+bool receiverReady = false;
+#  else
+bool receiverReady = true;
+#  endif
+
 // use pointer to stream class for serial communication to make code
 // compatible with both softwareSerial as hardwareSerial.
 Stream* SERIALStream = NULL;
 //unsigned long msgCount = 0;
 
-bool receiverReady = false;
 unsigned long lastHeartbeatReceived = 0;
 unsigned long lastHeartbeatAckReceived = 0;
 unsigned long lastHeartbeatSent = 0;


### PR DESCRIPTION
The serial gateway can only receive serial data and publish via mqtt, but can not convert mqtt into serial data. It is because the receiverReady is not handled correctly for the tx part. A quick work around is to set receiverReady to true. (it seems not used)

## Description:


## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
