### PR TITLE
[DISC] Whitelist immediate change

### DIFF
--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -124,6 +124,12 @@ A white list is a list of MAC addresses permitted to be published by OMG
 to set white list
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["01:23:14:55:16:15","4C:65:77:88:9C:79","4C:65:A6:66:3C:79"]}'`
 
+to temporarily disable white/black list
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"ignoreWBlist":true}'`
+
+to enable white/black list back
+`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"ignoreWBlist":false}'`
+
 ::: tip
 So as to keep your white/black list persistent you can publish it with the retain option of MQTT (-r with mosquitto_pub or retain check box of MQTT Explorer)
 `mosquitto_pub -r -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["01:23:14:55:16:15","4C:65:77:88:9C:79","4C:65:A6:66:3C:79"]}'`

--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -124,14 +124,6 @@ A white list is a list of MAC addresses permitted to be published by OMG
 to set white list
 `mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["01:23:14:55:16:15","4C:65:77:88:9C:79","4C:65:A6:66:3C:79"]}'`
 
-Note: if you want to filter (white or black list) on BLE sensors that are auto discovered, you need to wait for the discovery before applying the white or black list, or temporarily disable it:
-
-to temporarily disable white/black list
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"ignoreWBlist":true}'`
-
-to enable white/black list back
-`mosquitto_pub -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"ignoreWBlist":false}'`
-
 ::: tip
 So as to keep your white/black list persistent you can publish it with the retain option of MQTT (-r with mosquitto_pub or retain check box of MQTT Explorer)
 `mosquitto_pub -r -t home/OpenMQTTGateway/commands/MQTTtoBT/config -m '{"white-list":["01:23:14:55:16:15","4C:65:77:88:9C:79","4C:65:A6:66:3C:79"]}'`

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -391,8 +391,13 @@ void createOrUpdateDevice(const char* mac, uint8_t flags, int model, int mac_typ
     if (model != UNKWNON_MODEL && device->sensorModel_id == UNKWNON_MODEL) {
       newDevices++;
       device->isDisc = false;
+      device->sensorModel_id = model;
     }
 
+    // If a device has been added to the white-list, flag it so it can be auto-detected
+    if (!device->isWhtL && flags & device_flags_isWhiteL) {
+      newDevices++;
+    }
     if (flags & device_flags_isWhiteL || flags & device_flags_isBlackL) {
       device->isWhtL = flags & device_flags_isWhiteL;
       device->isBlkL = flags & device_flags_isBlackL;

--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -388,8 +388,9 @@ void createOrUpdateDevice(const char* mac, uint8_t flags, int model, int mac_typ
       device->connect = true;
     }
 
-    if (model != UNKWNON_MODEL) {
-      device->sensorModel_id = model;
+    if (model != UNKWNON_MODEL && device->sensorModel_id == UNKWNON_MODEL) {
+      newDevices++;
+      device->isDisc = false;
     }
 
     if (flags & device_flags_isWhiteL || flags & device_flags_isBlackL) {


### PR DESCRIPTION
Today when adding a BLE device that is auto discovered you need to temporarily disable the white-list first and then add the new device to the list, as described in the [docs.](https://docs.openmqttgateway.com/use/ble.html#setting-a-white-or-black-list) 

With this change you just update the list and it gets discovered. (You need to restart the gateway if you have not enabled discovery)

See discussion in [Theengs community](https://community.openmqttgateway.com/t/why-do-we-need-to-temporarily-disable-the-white-list-when-adding-a-new-entry/3584)

The PR has been built and tested on environment `esp32-lolin32lite-ble`

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
