### PR TITLE
HA: RF, RF2, Pilight modules as sensors. Subscribe topic, according valueAsATopic.

### DIFF
--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -1083,7 +1083,12 @@ void pubMqttDiscovery() {
 
   //trc(gatewayRF[1]);
   createDiscovery(gatewayRF[0],
-                  subjectRFtoMQTT, gatewayRF[1], (char*)getUniqueId(gatewayRF[1], gatewayRF[2]).c_str(),
+#    if valueAsATopic
+                  subjectRFtoMQTTvalueAsATopic,
+#    else
+                  subjectRFtoMQTT,
+#    endif
+                  gatewayRF[1], (char*)getUniqueId(gatewayRF[1], gatewayRF[2]).c_str(),
                   will_Topic, gatewayRF[3], gatewayRF[4],
                   gatewayRF[5], gatewayRF[6], gatewayRF[7],
                   0, Gateway_AnnouncementMsg, will_Message, true, "",
@@ -1101,7 +1106,12 @@ void pubMqttDiscovery() {
 
   //trc(gatewayRF2[1]);
   createDiscovery(gatewayRF2[0],
-                  subjectRF2toMQTT, gatewayRF2[1], (char*)getUniqueId(gatewayRF2[1], gatewayRF2[2]).c_str(),
+#    if valueAsATopic
+                  subjectRF2toMQTTvalueAsATopic,
+#    else
+                  subjectRF2toMQTT,
+#    endif
+                  gatewayRF2[1], (char*)getUniqueId(gatewayRF2[1], gatewayRF2[2]).c_str(),
                   will_Topic, gatewayRF2[3], gatewayRF2[4],
                   gatewayRF2[5], gatewayRF2[6], gatewayRF2[7],
                   0, Gateway_AnnouncementMsg, will_Message, true, "",
@@ -1202,7 +1212,12 @@ void pubMqttDiscovery() {
 
   //trc(gatewayPilight[1]);
   createDiscovery(gatewayPilight[0],
-                  subjectPilighttoMQTT, gatewayPilight[1], (char*)getUniqueId(gatewayPilight[1], gatewayPilight[2]).c_str(),
+#    if valueAsATopic
+                  subjectPilighttoMQTTvalueAsATopic,
+#    else
+                  subjectPilighttoMQTT,
+#    endif
+                  gatewayPilight[1], (char*)getUniqueId(gatewayPilight[1], gatewayPilight[2]).c_str(),
                   will_Topic, gatewayPilight[3], gatewayPilight[4],
                   gatewayPilight[5], gatewayPilight[6], gatewayPilight[7],
                   0, Gateway_AnnouncementMsg, will_Message, true, "",

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -144,14 +144,15 @@ const char parameters[51][4][24] = {
 #endif
 /*-------------------RF topics & parameters----------------------*/
 //433Mhz MQTT Subjects and keys
-#define subjectMQTTtoRF       "/commands/MQTTto433"
-#define subjectRFtoMQTT       "/433toMQTT"
-#define subjectcommonRFtoMQTT "/RFtoMQTT"
-#define subjectGTWRFtoMQTT    "/433toMQTT"
-#define RFprotocolKey         "433_" // protocol will be defined if a subject contains RFprotocolKey followed by a value of 1 digit
-#define RFbitsKey             "RFBITS_" // bits  will be defined if a subject contains RFbitsKey followed by a value of 2 digits
-#define repeatRFwMQTT         false // do we repeat a received signal by using MQTT with RF gateway
-#define RFpulselengthKey      "PLSL_" // pulselength will be defined if a subject contains RFprotocolKey followed by a value of 3 digits
+#define subjectMQTTtoRF              "/commands/MQTTto433"
+#define subjectRFtoMQTT              "/433toMQTT"
+#define subjectRFtoMQTTvalueAsATopic "/433toMQTT/#"
+#define subjectcommonRFtoMQTT        "/RFtoMQTT"
+#define subjectGTWRFtoMQTT           "/433toMQTT"
+#define RFprotocolKey                "433_" // protocol will be defined if a subject contains RFprotocolKey followed by a value of 1 digit
+#define RFbitsKey                    "RFBITS_" // bits  will be defined if a subject contains RFbitsKey followed by a value of 2 digits
+#define repeatRFwMQTT                false // do we repeat a received signal by using MQTT with RF gateway
+#define RFpulselengthKey             "PLSL_" // pulselength will be defined if a subject contains RFprotocolKey followed by a value of 3 digits
 // subject monitored to listen traffic processed by other gateways to store data and avoid ntuple
 #define subjectMultiGTWRF "+/+/433toMQTT"
 //RF number of signal repetition - Can be overridden by specifying "repeat" in a JSON message.
@@ -162,22 +163,24 @@ const char parameters[51][4][24] = {
 
 /*-------------------RF2 topics & parameters----------------------*/
 //433Mhz newremoteswitch MQTT Subjects and keys
-#define subjectMQTTtoRF2    "/commands/MQTTtoRF2"
-#define subjectRF2toMQTT    "/RF2toMQTT"
-#define subjectGTWRF2toMQTT "/RF2toMQTT"
-#define RF2codeKey          "ADDRESS_" // code will be defined if a subject contains RF2codeKey followed by a value of 7 digits
-#define RF2periodKey        "PERIOD_" // period  will be defined if a subject contains RF2periodKey followed by a value of 3 digits
-#define RF2unitKey          "UNIT_" // number of your unit value  will be defined if a subject contains RF2unitKey followed by a value of 1-2 digits
-#define RF2groupKey         "GROUP_" // number of your group value  will be defined if a subject contains RF2groupKey followed by a value of 1 digit
-#define RF2dimKey           "DIM" // number of your dim value will be defined if a subject contains RF2dimKey and the payload contains the dim value as digits
+#define subjectMQTTtoRF2              "/commands/MQTTtoRF2"
+#define subjectRF2toMQTT              "/RF2toMQTT"
+#define subjectRF2toMQTTvalueAsATopic "/RF2toMQTT/#"
+#define subjectGTWRF2toMQTT           "/RF2toMQTT"
+#define RF2codeKey                    "ADDRESS_" // code will be defined if a subject contains RF2codeKey followed by a value of 7 digits
+#define RF2periodKey                  "PERIOD_" // period  will be defined if a subject contains RF2periodKey followed by a value of 3 digits
+#define RF2unitKey                    "UNIT_" // number of your unit value  will be defined if a subject contains RF2unitKey followed by a value of 1-2 digits
+#define RF2groupKey                   "GROUP_" // number of your group value  will be defined if a subject contains RF2groupKey followed by a value of 1 digit
+#define RF2dimKey                     "DIM" // number of your dim value will be defined if a subject contains RF2dimKey and the payload contains the dim value as digits
 
 /*-------------------ESPPiLight topics & parameters----------------------*/
 //433Mhz Pilight MQTT Subjects and keys
-#define subjectMQTTtoPilight         "/commands/MQTTtoPilight"
-#define subjectMQTTtoPilightProtocol "/commands/MQTTtoPilight/protocols"
-#define subjectPilighttoMQTT         "/PilighttoMQTT"
-#define subjectGTWPilighttoMQTT      "/PilighttoMQTT"
-#define repeatPilightwMQTT           false // do we repeat a received signal by using MQTT with Pilight gateway
+#define subjectMQTTtoPilight              "/commands/MQTTtoPilight"
+#define subjectMQTTtoPilightProtocol      "/commands/MQTTtoPilight/protocols"
+#define subjectPilighttoMQTT              "/PilighttoMQTT"
+#define subjectPilighttoMQTTvalueAsATopic "/PilighttoMQTT/#"
+#define subjectGTWPilighttoMQTT           "/PilighttoMQTT"
+#define repeatPilightwMQTT                false // do we repeat a received signal by using MQTT with Pilight gateway
 //#define Pilight_rawEnabled true   // enables Pilight RAW return - switchable via MQTT
 
 /*-------------------RTL_433 topics & parameters----------------------*/


### PR DESCRIPTION
## Description:
The RF sensors discovery are created with topics like "/433toMQTT"
If valueAsATopic is defined, then published messages are not in the main topic, but in subtree.
Change the topic to be like "/433toMQTT/#" , when valueAsATopic is defined.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
