### PR TITLE
fix stacksize in procBLETask

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -852,7 +852,9 @@ void setupBTTasksAndBLE() {
       "procBLETask", /* Name of the task */
 #  if defined(USE_ESP_IDF) || defined(USE_BLUFI)
       13500,
-#  else
+#  elif defined(OVERRIDE_PROC_BLE_TASK_STACK_SIZE)
+      OVERRIDE_PROC_BLE_TASK_STACK_SIZE,
+# else
       8500, /* Stack size in bytes */
 #  endif
       NULL, /* Task input parameter */


### PR DESCRIPTION
add OVERRIDE_PROC_BLE_TASK_STACK_SIZE as value for custom stacksize in the procBLETask

## Description:
When using Arduino and ESP32s3-devkit-c1 as a BLE gateway the stackwatchpoint gets triggered, when it scans for devies and gets triggered at the same time. I just tested it with 13500 and it works fine. I think a define, which the user can set in the build_flags is the best option to keep it flexible

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
