### PR TITLE
add dynamic stacksize for procBLETask

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -852,6 +852,8 @@ void setupBTTasksAndBLE() {
       "procBLETask", /* Name of the task */
 #  if defined(USE_ESP_IDF) || defined(USE_BLUFI)
       13500,
+#  elif defined(OVERRIDE_PROC_BLE_TASK_STACK_SIZE)
+      OVERRIDE_PROC_BLE_TASK_STACK_SIZE,
 #  else
       8500, /* Stack size in bytes */
 #  endif


### PR DESCRIPTION
add OVERRIDE_PROC_BLE_TASK_STACK_SIZE to set the stacksize for the procBLETask by a define in the build_flags

## Description:
When using the ESP32s3-devkit-c1 with Arduino and using it as a ble gateway, the task watchdog for the stacksize gets triggerd, if you receive a request the same time it scans for new devices. This results in a crash. I testes it with 13500 and it works fine. I think a build flag which each user can set seperatly but doesn't have to is the best option to solve it.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
