### PR TITLE
[RF] Allow configuration of CC1101 SPI pins

### DIFF
--- a/main/ZcommonRF.ino
+++ b/main/ZcommonRF.ino
@@ -36,6 +36,10 @@ void initCC1101() {
   int delayMS = 16;
   int delayMaxMS = 500;
   for (int i = 0; i < 10; i++) {
+#    if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && \
+        defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
+    ELECHOUSE_cc1101.setSpiPin(RF_MODULE_SCK, RF_MODULE_MISO, RF_MODULE_MOSI, RF_MODULE_CS);
+#    endif
     if (ELECHOUSE_cc1101.getCC1101()) {
       Log.notice(F("C1101 spi Connection OK" CR));
       ELECHOUSE_cc1101.Init();


### PR DESCRIPTION
If all CC1101 SPI pins are defined, use them to create the SPI device. Otherwise, default to the platform's SPI.

## Description:
The ELECHOUSE_cc1101 library is responsible for setting up the SPI device for the CC1101. Using anything other than the default VSPI for the platform requires calling [setSpiPin()](https://github.com/LSatan/SmartRC-CC1101-Driver-Lib/blob/b8c6af4c7c2214cd77a4e9b2e2cb37b24b393605/ELECHOUSE_CC1101_SRC_DRV.cpp#L309) before [getCC1101()](https://github.com/LSatan/SmartRC-CC1101-Driver-Lib/blob/b8c6af4c7c2214cd77a4e9b2e2cb37b24b393605/ELECHOUSE_CC1101_SRC_DRV.cpp#L617). I tested this on my Lolin D32 which shares the onboard LED with the VSPI CS pin, hence the desire to switch pins. If desired, I can open another PR to add the board config as well.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
