### PR TITLE
[BT] Increase procBLEtask stack size to avoid reset when adapting the scan parameters

### DIFF
--- a/main/ZgatewayBT.ino
+++ b/main/ZgatewayBT.ino
@@ -857,9 +857,9 @@ void setupBTTasksAndBLE() {
       procBLETask, /* Function to implement the task */
       "procBLETask", /* Name of the task */
 #  if defined(USE_ESP_IDF) || defined(USE_BLUFI)
-      13500,
+      14000,
 #  else
-      8500, /* Stack size in bytes */
+      9000, /* Stack size in bytes */
 #  endif
       NULL, /* Task input parameter */
       2, /* Priority of the task (set higher than core task) */


### PR DESCRIPTION
## Description:
This fix the issue of the gateway resetting when the device detected require to adapt automatically the scan parameters

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
