### PR TITLE
[DISC] Removal of openHAB specific MQTT discovery patch

### DIFF
--- a/docs/integrate/openhab3.md
+++ b/docs/integrate/openhab3.md
@@ -76,13 +76,6 @@ Or use another upload method from the Upload section that requires credentials b
 
 You should see the gateway connected to your broker by checking with an MQTT client like MQTT Explorer.
 
-To make the auto discovery compatible with OpenHAB you have to send the following command with a retain flag.
-
-`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"ohdisc":true}'`
-
-You can also activate OpenHAB auto discovery by adding the gateway as a Thing, Model, and switching the button to ON. The name of the channel to add is "SYS: OpenHAB discovery".
-Once activated restart OpenMQTTGateway.
-
 ## Adding the things
 1. From the Administration click on "Things" under "Settings", you should see a number in the INBOX button
 

--- a/docs/use/gateway.md
+++ b/docs/use/gateway.md
@@ -35,18 +35,6 @@ If you want the settings to be kept upon gateway restart, you can save the state
 Auto discovery is enabled by default on release binaries and platformio.
 :::
 
-## AutoDiscovery compatible with OpenHAB (default: false)
-OpenHAB does not support the key `is_defined` in the json template, to remove it at runtime and make the auto discovery compatible you can use the following command with a retain flag.
-
-`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"ohdisc":true}'`
-
-If you want the settings to be kept upon gateway restart, you can save the state by adding `"save":true` (ESP32 only).
-`mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"ohdisc":true, "save":true}'`
-
-::: tip
-This command can also be used with other controllers that does not support the is_defined key.
-:::
-
 ## Activate Offline mode
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"offline":true,"save":true}'`

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -670,7 +670,6 @@ struct SYSConfig_s {
   bool blufi; // if true the gateway will be accesible with blufi
   bool offline;
   bool discovery; // HA discovery convention
-  bool ohdiscovery; // OH discovery specificities
 #ifdef LED_ADDRESSABLE
   int rgbbrightness; // brightness of the RGB LED
 #endif

--- a/main/ZgatewayRTL_433.ino
+++ b/main/ZgatewayRTL_433.ino
@@ -136,11 +136,7 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
           idWoKey.remove(idWoKey.length() - (strlen(parameters[i][0]) + 1));
           DISCOVERY_TRACE_LOG(F("idWoKey %s" CR), idWoKey.c_str());
           String value_template = "";
-          if (SYSConfig.ohdiscovery) {
-            value_template = "{{ value_json." + String(parameters[i][0]) + " }}";
-          } else {
-            value_template = "{{ value_json." + String(parameters[i][0]) + " | is_defined }}";
-          }
+          value_template = "{{ value_json." + String(parameters[i][0]) + " | is_defined }}";
           String topic = subjectRTL_433toMQTT;
 #    if valueAsATopic
           // Remove the key from the unique id to extract the device id
@@ -158,11 +154,7 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
 #    endif
           if (strcmp(parameters[i][0], "battery_ok") == 0) {
             if (strcmp(pdevice->modelName, "Govee-Water") == 0 || strcmp(pdevice->modelName, "Govee-Contact") == 0 || strcmp(pdevice->modelName, "Archos-TBH") == 0 || strcmp(pdevice->modelName, "FineOffset-WH31L") == 0 || strcmp(pdevice->modelName, "Fineoffset-WH45") == 0 || strcmp(pdevice->modelName, "Fineoffset-WN34") == 0 || strcmp(pdevice->modelName, "Fineoffset-WS80") == 0 || strcmp(pdevice->modelName, "Fineoffset-WH0290") == 0 || strcmp(pdevice->modelName, "Fineoffset-WH51") == 0 || strcmp(pdevice->modelName, "Kedsum-TH") == 0 || strcmp(pdevice->modelName, "AVE") == 0 || strcmp(pdevice->modelName, "TPMS") == 0) {
-              if (SYSConfig.ohdiscovery) {
-                value_template = "{{ (value_json." + String(parameters[i][0]) + " * 100) | round(0)}}";
-              } else {
-                value_template = "{{ (float(value_json." + String(parameters[i][0]) + ") * 100) | round(0) | is_defined }}";
-              }
+              value_template = "{{ (float(value_json." + String(parameters[i][0]) + ") * 100) | round(0) | is_defined }}";
               createDiscovery("sensor", //set Type
                               (char*)topic.c_str(), parameters[i][1], pdevice->uniqueId, //set state_topic,name,uniqueId
                               "", parameters[i][3], (char*)value_template.c_str(), //set availability_topic,device_class,value_template,

--- a/main/ZmqttDiscovery.ino
+++ b/main/ZmqttDiscovery.ino
@@ -303,16 +303,12 @@ void createDiscovery(const char* sensor_type,
   if (retainCmd)
     sensor["retain"] = retainCmd; // Retain command
   if (value_template && value_template[0]) {
-    if (strstr(value_template, " | is_defined") != NULL && SYSConfig.ohdiscovery) {
-      sensor["val_tpl"] = remove_substring(value_template, " | is_defined"); //OpenHAB compatible HA auto discovery
+    if (strcmp(sensor_type, "cover") == 0 && strcmp(state_class, "blind") == 0) {
+      sensor["tilt_status_tpl"] = value_template; // tilt_status_template for blind
+    } else if (strcmp(sensor_type, "cover") == 0 && strcmp(state_class, "curtain") == 0) {
+      sensor["pos_tpl"] = value_template; // position_template for curtain
     } else {
-      if (strcmp(sensor_type, "cover") == 0 && strcmp(state_class, "blind") == 0) {
-        sensor["tilt_status_tpl"] = value_template; // tilt_status_template for blind
-      } else if (strcmp(sensor_type, "cover") == 0 && strcmp(state_class, "curtain") == 0) {
-        sensor["pos_tpl"] = value_template; // position_template for curtain
-      } else {
-        sensor["val_tpl"] = value_template; //HA Auto discovery
-      }
+      sensor["val_tpl"] = value_template; //HA Auto discovery
     }
   }
   if (payload_on && payload_on[0]) {
@@ -585,16 +581,6 @@ void pubMqttDiscovery() {
                   subjectSYStoMQTT, "SYS: Auto discovery", (char*)getUniqueId("disc", "").c_str(), //set state_topic,name,uniqueId
                   will_Topic, "", "{{ value_json.disc }}", //set availability_topic,device_class,value_template,
                   "{\"disc\":true,\"save\":true}", "{\"disc\":false,\"save\":true}", "", //set,payload_on,payload_off,unit_of_meas,
-                  0, //set  off_delay
-                  Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoSYSset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
-                  "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain,
-                  stateClassNone, //State Class
-                  "false", "true" //state_off, state_on
-  );
-  createDiscovery("switch", //set Type
-                  subjectSYStoMQTT, "SYS: OpenHAB discovery", (char*)getUniqueId("ohdisc", "").c_str(), //set state_topic,name,uniqueId
-                  will_Topic, "", "{{ value_json.ohdisc }}", //set availability_topic,device_class,value_template,
-                  "{\"ohdisc\":true,\"save\":true}", "{\"ohdisc\":false,\"save\":true}", "", //set,payload_on,payload_off,unit_of_meas,
                   0, //set  off_delay
                   Gateway_AnnouncementMsg, will_Message, true, subjectMQTTtoSYSset, //set,payload_avalaible,payload_not avalaible   ,is a gateway entity, command topic
                   "", "", "", "", false, // device name, device manufacturer, device model, device MAC, retain,
@@ -1327,7 +1313,6 @@ void pubMqttDiscovery() {
       {"switch", "force_scan"}, // Now a button
       {"sensor", "interval"}, // Now a number
       {"sensor", "scanbcnct"}, // Now a number
-      {"switch", "ohdiscovery"}, // Now a new key
       {"switch", "discovery"}}; // Now a new key
 
   for (int i = 0; i < EntitiesCount; i++) {

--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -140,11 +140,6 @@ char discovery_prefix[parameters_size + 1] = discovery_Prefix;
 #endif
 
 /*-------------- Auto discovery macros-----------------*/
-// Set the line below to true so as to have autodiscovery working with OpenHAB
-#ifndef OpenHABDiscovery
-#  define OpenHABDiscovery false
-#endif
-
 // Home assistant autodiscovery value key definition
 #define jsonBatt        "{{ value_json.batt | is_defined }}"
 #define jsonLux         "{{ value_json.lux | is_defined }}"

--- a/main/main.ino
+++ b/main/main.ino
@@ -805,7 +805,6 @@ void SYSConfig_init() {
 #endif
 #ifdef ZmqttDiscovery
   SYSConfig.discovery = DEFAULT_DISCOVERY;
-  SYSConfig.ohdiscovery = OpenHABDiscovery;
 #endif
 #ifdef LED_ADDRESSABLE
   SYSConfig.rgbbrightness = DEFAULT_ADJ_BRIGHTNESS;
@@ -822,7 +821,6 @@ void SYSConfig_fromJson(JsonObject& SYSdata) {
 #endif
 #ifdef ZmqttDiscovery
   Config_update(SYSdata, "disc", SYSConfig.discovery);
-  Config_update(SYSdata, "ohdisc", SYSConfig.ohdiscovery);
 #endif
 #ifdef LED_ADDRESSABLE
   Config_update(SYSdata, "rgbb", SYSConfig.rgbbrightness);
@@ -843,7 +841,6 @@ void SYSConfig_save() {
 #  endif
 #  ifdef ZmqttDiscovery
   SYSdata["disc"] = SYSConfig.discovery;
-  SYSdata["ohdisc"] = SYSConfig.ohdiscovery;
 #  endif
 #  ifdef LED_ADDRESSABLE
   SYSdata["rgbb"] = SYSConfig.rgbbrightness;
@@ -2782,7 +2779,6 @@ String stateMeasures() {
   SYSdata["serial"] = SYSConfig.serial;
 #ifdef ZmqttDiscovery
   SYSdata["disc"] = SYSConfig.discovery;
-  SYSdata["ohdisc"] = SYSConfig.ohdiscovery;
 #endif
   SYSdata["env"] = ENV_NAME;
   uint32_t freeMem;
@@ -3369,13 +3365,6 @@ void XtoSYS(const char* topicOri, JsonObject& SYSdata) { // json object decoding
       } else {
         Log.warning(F("RGB brightness value invalid - ignoring command" CR));
       }
-    }
-#endif
-#ifdef ZmqttDiscovery
-    if (SYSdata.containsKey("ohdisc") && SYSdata["ohdisc"].is<bool>()) {
-      SYSConfig.ohdiscovery = SYSdata["ohdisc"];
-      Log.notice(F("OpenHAB discovery: %T" CR), SYSConfig.ohdiscovery);
-      publishState = true;
     }
 #endif
     if (SYSdata.containsKey("wifi_ssid") && SYSdata["wifi_ssid"].is<const char*>() && SYSdata.containsKey("wifi_pass") && SYSdata["wifi_pass"].is<const char*>()) {


### PR DESCRIPTION
Removal of openHAB specific MQTT discovery patch "ohdisc", as it is no longer required with openHAB 4.3 and later, and with openHAB before 4.3 MQTT discovery never was fully implemented anyway.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
