### PR TITLE
[RF] GatewayRF2: fix json formatted sending, when the active receiver is not RF2

### DIFF
--- a/main/ZgatewayRF2.ino
+++ b/main/ZgatewayRF2.ino
@@ -248,7 +248,7 @@ void XtoRF2(const char* topicOri, JsonObject& RF2data) { // json object decoding
     int boolSWITCHTYPE = RF2data["switchType"] | 99;
     bool success = false;
     if (boolSWITCHTYPE != 99) {
-      NewRemoteReceiver::disable();
+      disableCurrentReceiver();
       pinMode(RF_EMITTER_GPIO, OUTPUT);
       initCC1101();
       Log.trace(F("MQTTtoRF2 switch type ok" CR));
@@ -266,7 +266,6 @@ void XtoRF2(const char* topicOri, JsonObject& RF2data) { // json object decoding
           valueUNIT = 0;
         if (valuePERIOD == 0)
           valuePERIOD = 272;
-        disableCurrentReceiver();
         NewRemoteTransmitter transmitter(valueCODE, RF_EMITTER_GPIO, valuePERIOD, RF2_EMITTER_REPEAT);
         Log.trace(F("Sending" CR));
         if (valueGROUP) {
@@ -283,7 +282,6 @@ void XtoRF2(const char* topicOri, JsonObject& RF2data) { // json object decoding
           }
         }
         Log.notice(F("MQTTtoRF2 OK" CR));
-        enableActiveReceiver();
 
         success = true;
       }


### PR DESCRIPTION
## Description:
Catch that recently. 
I was using CC1101 module and active receiver RTL. When sending (via mqtt publisher) RF2 code the board "goes in guru meditation".
The proposed commit fix the issue.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
