### PR TITLE
[RF] ZgatewatPilight: toggle RawEnabled only if Pilight is active

### DIFF
--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -198,7 +198,10 @@ Generate your RF signals by pressing a remote button or other and you will see :
 #### Enabling RAW packet return support
 First, you need to compile a binary with `Pilight_rawEnabled true` uncommented in config_RF.h.
 
-Once the device is online, you can turn on the RAW packet return support with the following MQTT command:
+Once the device is online and the active receiver is Pilght, you can toggle raw packet return.
+If current active receiver is not Pilight the toggle command will be ignored and harmless error message will be published.
+
+You can turn on the RAW packet return support with the following MQTT command:
 
 `mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoPilight/protocols" -m '{"rawEnabled":true}'`
 

--- a/main/ZgatewayPilight.ino
+++ b/main/ZgatewayPilight.ino
@@ -182,10 +182,12 @@ void XtoPilight(const char* topicOri, JsonObject& Pilightdata) {
     if (Pilightdata.containsKey("rawEnabled")) {
       Log.notice(F("Setting PiLight raw output enabled: %T" CR), (bool)Pilightdata["rawEnabled"]);
       pilightRawEnabled = (bool)Pilightdata["rawEnabled"];
-      disablePilightReceive();
-      delay(1);
-      enablePilightReceive();
-      success = true;
+      if (currentReceiver == ACTIVE_PILIGHT) {
+        disablePilightReceive();
+        delay(1);
+        enablePilightReceive();
+        success = true;
+      }
     }
 #  endif
 


### PR DESCRIPTION
## Description:
When enabling or disabling RawEnabled for Pilight gateway the PilightGateway is deactivated and activated.
The proposed change the rawenabled, only if current active receiver is Pilight. Trying to avoid situation such as: Active receiver is RTL , toggling RawEnabled will finally enable Pilight receiver and potentially there will be "race" between two active receivers, or potentially not "synchronized" changes to the radio module (RTL using RadioLib, Pilight using ELECHOUSE).

If accepted, the documentation regarding Pilight gateway, particular using rawenabled should clarify, that toggling is possible only if Pilight is the active receiver. And that if Pilight is not the active receiver, the mqtt error message when trying to toggle is normal. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
