### PR TITLE
[BLE] Fix crash if BLE stack is not initialized when setting advertising

### DIFF
--- a/main/blufi.cpp
+++ b/main/blufi.cpp
@@ -202,6 +202,10 @@ void stop_connection_timer() {}
 #  endif
 
 void set_blufi_mfg_data () {
+  if (!NimBLEDevice::isInitialized() || !NimBLEDevice::getAdvertising()->isAdvertising()) {
+    Log.notice(F("Unable to set advertising data" CR));
+    return;
+  }
   ble_hs_adv_fields fields;
   ble_uuid16_t blufi_uuid = BLE_UUID16_INIT(BLUFI_APP_UUID);
   memset(&fields, 0, sizeof(fields));


### PR DESCRIPTION
## Description:
If the BLE stack is deinitialized and the gateway state changes it will attempt to update the advertisement data which will no longer be valid, causing a crash.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
