### PR TITLE
[DISC] Fix cosmetic issue in Home Assistant where devices don't link to gateway

### DIFF
--- a/main/mqttDiscovery.cpp
+++ b/main/mqttDiscovery.cpp
@@ -43,6 +43,7 @@
 
 extern bool ethConnected;
 extern JsonArray modules;
+String gateway_mac;
 
 char discovery_prefix[parameters_size + 1] = discovery_Prefix;
 // From https://github.com/home-assistant/core/blob/d7ac4bd65379e11461c7ce0893d3533d8d8b8cbf/homeassistant/const.py#L225
@@ -564,6 +565,7 @@ void createDiscovery(const char* sensor_type,
 
     device["sw"] = OMG_VERSION;
     identifiers.add(String(getMacAddress()));
+    gateway_mac = getMacAddress();
   } else {
     //The Connections
     if (device_id[0]) {
@@ -593,7 +595,7 @@ void createDiscovery(const char* sensor_type,
       }
     }
 
-    device["via_device"] = String(gateway_name); //device name of the board
+    device["via_device"] = String(gateway_mac); //mac address of the gateway so that the devices link to the gateway
   }
 
   sensor["device"] = device;

--- a/main/mqttDiscovery.cpp
+++ b/main/mqttDiscovery.cpp
@@ -43,7 +43,6 @@
 
 extern bool ethConnected;
 extern JsonArray modules;
-String gateway_mac;
 
 char discovery_prefix[parameters_size + 1] = discovery_Prefix;
 // From https://github.com/home-assistant/core/blob/d7ac4bd65379e11461c7ce0893d3533d8d8b8cbf/homeassistant/const.py#L225
@@ -565,7 +564,6 @@ void createDiscovery(const char* sensor_type,
 
     device["sw"] = OMG_VERSION;
     identifiers.add(String(getMacAddress()));
-    gateway_mac = getMacAddress();
   } else {
     //The Connections
     if (device_id[0]) {
@@ -595,7 +593,7 @@ void createDiscovery(const char* sensor_type,
       }
     }
 
-    device["via_device"] = String(gateway_mac); //mac address of the gateway so that the devices link to the gateway
+    device["via_device"] = String(getMacAddress()); //mac address of the gateway so that the devices link to the gateway
   }
 
   sensor["device"] = device;


### PR DESCRIPTION
## Description:

The `via_device` is set for each device when it is being created in Home Assistant. Currently this links to  the `gateway_name` which is incorrect so all the devices show up linking to an unknown entity.
In Home Assistant the OMG entity is named by it's MAC address, so this change now means that they are all correctly linked together. 

It will stop this from happening when looking in the MQTT Entities in Home Assistant. As the unnamed device is the missing `via_device` gateway_name.

<img width="1008" height="162" alt="image" src="https://github.com/user-attachments/assets/81f80629-cf89-4b66-88b4-f4f3a9e14a2e" />
and

| Before| After|
| - | - |
|<img width="326" height="326" alt="image" src="https://github.com/user-attachments/assets/305958b9-e3d8-4eb6-9e8c-d7be75d7d07a" />|<img width="325" height="328" alt="image" src="https://github.com/user-attachments/assets/f488edde-e2bb-48c4-a9f0-07d97971a4ef" />|



## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
