### PR TITLE
[DISC] Add RSSI as diagnostic entity_category for Bluetooth devices

### DIFF
--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -79,6 +79,11 @@ extern void createDiscoveryFromList(const char* mac,
  * @param device_mac set device MAC,
  * @param retainCmd set retain
  * @param state_class set state class
+ * @param state_off state off value
+ * @param state_on state on value
+ * @param enum_options options
+ * @param command_template command template
+ * @param diagnostic_entity true if entity_category is diagnostic
  *
  * */
 extern void createDiscovery(const char* sensor_type,
@@ -88,7 +93,8 @@ extern void createDiscovery(const char* sensor_type,
                             int off_delay,
                             const char* payload_available, const char* payload_not_available, bool gateway_entity, const char* command_topic,
                             const char* device_name, const char* device_manufacturer, const char* device_model, const char* device_mac, bool retainCmd,
-                            const char* state_class, const char* state_off = nullptr, const char* state_on = nullptr, const char* enum_options = nullptr, const char* command_template = nullptr);
+                            const char* state_class, const char* state_off = nullptr, const char* state_on = nullptr, const char* enum_options = nullptr,
+                            const char* command_template = nullptr, bool diagnostic_entity = false);
 
 /**
  * @brief Create a message for Discovery Device Trigger. For HA @see https://www.home-assistant.io/integrations/device_trigger.mqtt/
@@ -170,6 +176,7 @@ extern char discovery_prefix[];
 #define jsonInuse       "{{ value_json.power | is_defined | float > 0 }}"
 #define jsonInuseRN8209 "{% if value_json.power > 0.02 -%} on {% else %} off {%- endif %}"
 #define jsonVoltBM2     "{% if value_json.uuid is not defined and value_json.volt is defined -%} {{value_json.volt}} {%- endif %}"
+#define jsonRSSI        "{{ value_json.rssi | is_defined }}"
 
 #define stateClassNone            ""
 #define stateClassMeasurement     "measurement"

--- a/main/gatewayBT.cpp
+++ b/main/gatewayBT.cpp
@@ -1110,6 +1110,17 @@ void launchBTDiscovery(bool overrideDiscovery) {
               }
             }
           }
+
+          String rssi_name = String(model_id.c_str()) + "-rssi";    // rssi diagnostic entity_category
+          String rssi_id = macWOdots + "-rssi";
+          createDiscovery("sensor",
+                          discovery_topic.c_str(), rssi_name.c_str(), rssi_id.c_str(),
+                          will_Topic, "signal_strength", jsonRSSI,
+                          "", "", "dB",
+                          0, "", "", false, "",
+                          model.c_str(), brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
+                          stateClassMeasurement, nullptr, nullptr, nullptr, nullptr, true);
+
         } else {
           if ((p->sensorModel_id > BLEconectable::id::MIN &&
                   p->sensorModel_id < BLEconectable::id::MAX) ||

--- a/main/mqttDiscovery.cpp
+++ b/main/mqttDiscovery.cpp
@@ -378,6 +378,11 @@ std::string remove_substring(std::string s, const std::string& p) {
  * @param device_id set device(BLE)/entity(RTL_433) identification,
  * @param retainCmd set retain
  * @param state_class set state class
+ * @param state_off state off value
+ * @param state_on state on value
+ * @param enum_options options
+ * @param command_template command template
+ * @param diagnostic_entity true if entity_category is diagnostic
  *
  * */
 void createDiscovery(const char* sensor_type,
@@ -387,7 +392,8 @@ void createDiscovery(const char* sensor_type,
                      int off_delay,
                      const char* payload_available, const char* payload_not_available, bool gateway_entity, const char* cmd_topic,
                      const char* device_name, const char* device_manufacturer, const char* device_model, const char* device_id, bool retainCmd,
-                     const char* state_class, const char* state_off, const char* state_on, const char* enum_options, const char* command_template) {
+                     const char* state_class, const char* state_off, const char* state_on, const char* enum_options,
+                     const char* command_template, bool diagnostic_entity) {
   StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
   JsonObject sensor = jsonBuffer.to<JsonObject>();
 
@@ -535,6 +541,10 @@ void createDiscovery(const char* sensor_type,
     } else {
       sensor["cmd_t"] = command_topic; //command_topic
     }
+  }
+
+  if (diagnostic_entity) {  // entity_category
+    sensor["ent_cat"] = "diagnostic";
   }
 
   if (enum_options != nullptr) {


### PR DESCRIPTION
## Description:

It would be very useful to track the RSSI of Bluetooth devices as the data is sent by OMG but not displayed against the entity. As per @1technophile suggestion I have added it as a diagnostic entity_category.

<img width="660" height="516" alt="image" src="https://github.com/user-attachments/assets/76c8011b-042f-4b19-be17-e6e9242dc0f3" />

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
