### PR TITLE
[BT] Consistent checking for BLEDecryptor as a Boolean

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -654,13 +654,13 @@ void storeSignalValue(uint64_t);
 
 #ifdef ZgatewayBT
 #  ifndef BLEDecryptor
-#    define BLEDecryptor true //true if decrypt encrypted PVVX or BTHome v2 service data
-#  endif
-#  ifndef JSON_BLE_AES_CUSTOM_KEYS
-#    define JSON_BLE_AES_CUSTOM_KEYS 256 // 42 byte BLE Custom Key * 6 rounded up to 256.
-#  endif
-#  ifndef BLE_AES
-#    define BLE_AES "00112233445566778899001122334455"
+#    define BLEDecryptor true //true if decrypt encrypted PVVX, BTHome v2 or Victron Energy broadcast data
+#    ifndef JSON_BLE_AES_CUSTOM_KEYS
+#      define JSON_BLE_AES_CUSTOM_KEYS 256 // 42 byte BLE Custom Key * 6 rounded up to 256.
+#    endif
+#    ifndef BLE_AES
+#      define BLE_AES "00112233445566778899001122334455"
+#    endif
 #  endif
 #endif
 

--- a/main/config_WebContent.h
+++ b/main/config_WebContent.h
@@ -62,7 +62,7 @@
 #else
 #  define configure_6
 #endif
-#ifdef BLEDecryptor
+#if BLEDecryptor
 #  define configure_7 "<p><form action='bl' method='post'><button>Configure BLE</button></form></p>"
 #else
 #  define configure_7
@@ -223,7 +223,7 @@ const char config_lora_body[] = body_header
     "</form>"
     "</fieldset>" body_footer_config_menu;
 
-#ifdef BLEDecryptor
+#if BLEDecryptor
 const char config_ble_body[] = body_header "<fieldset class=\"set1\"><legend><span><b>Configure BLE</b></span></legend><form method='post' action='bl'><p><b>BLE AES Default Key (32 char hex)</b></p><input id='bk' name='bk' minlength='32' maxlength='32' placeholder=" BLE_AES " value='%s' oninput='bkv()'><p id='bke' style='color:red;'></p><hr><p><b>BLE Key Pairs</b></p><p>MacAddress:AESKey with space separator</p><p><textarea id='kp' name='kp' placeholder='A4C138012345:00112233445566778899001122334455' rows='3' cols='46' oninput='kpv()'>%s</textarea></p><p id='kpe' style='color:red;'></p><br><button id='s' name='save' type='submit' class='button bgrn'>Save</button></form></fieldset>" body_footer_config_menu;
 
 // Client side javascript validation of the Default AES Key is hex, and the custom keys are in the correct format. This pushes the theengs-bridge-v11 way of the file size, so reducing it now and leaving it commented out

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -95,7 +95,7 @@ char mqtt_topic[parameters_size + 1] = Base_Topic;
 char gateway_name[parameters_size + 1] = Gateway_Name;
 unsigned long lastDiscovery = 0;
 
-#ifdef BLEDecryptor
+#if BLEDecryptor
   char ble_aes[parameters_size] = BLE_AES;
   StaticJsonDocument<JSON_BLE_AES_CUSTOM_KEYS> ble_aes_keys;
 #endif
@@ -2028,7 +2028,7 @@ void saveConfig() {
 #  endif
   json["gateway_name"] = gateway_name;
   json["ota_pass"] = ota_pass;
-#  ifdef BLEDecryptor
+#  if BLEDecryptor
   json["ble_aes"] = ble_aes;
   json["ble_aes_keys"] = ble_aes_keys;
 #  endif
@@ -2179,7 +2179,7 @@ bool loadConfigFromFlash() {
           }
 #  endif
         }
-#  ifdef BLEDecryptor
+#  if BLEDecryptor
         if (json.containsKey("ble_aes")) {
           strcpy(ble_aes, json["ble_aes"]);
           Log.trace(F("loaded default BLE AES key %s" CR), ble_aes);
@@ -3461,7 +3461,7 @@ void XtoSYS(const char* topicOri, JsonObject& SYSdata) { // json object decoding
       mqttSetupPending = true; // trigger reconnect in loop using the new topic/name
     }
 
-#ifdef BLEDecryptor
+#if BLEDecryptor
     if (SYSdata.containsKey("ble_aes") || SYSdata.containsKey("ble_aes_keys")) {
       if (SYSdata.containsKey("ble_aes")) {
         strncpy(ble_aes, SYSdata["ble_aes"], parameters_size);

--- a/main/webUI.cpp
+++ b/main/webUI.cpp
@@ -955,7 +955,7 @@ void handleLO() {
   server.send(200, "text/html", response);
 }
 
-#  ifdef BLEDecryptor
+#  if BLEDecryptor
 /**
  * @brief /BL - Config BLE
  * T: handleBL: uri: /bl, args: 3, method: 1
@@ -1777,7 +1777,7 @@ void WebUISetup() {
 #  endif
   server.on("/lo", handleLO); // Configure Logging
 
-#  ifdef BLEDecryptor
+#  if BLEDecryptor
   server.on("/bl", HTTP_POST, handleBL); // Configure BLE
 #  endif
 


### PR DESCRIPTION
Consistent checking for BLEDecryptor as a Boolean, not just as a Define, so that
```
…
#    define BLEDecryptor true //true if decrypt encrypted PVVX, BTHome v2 or Victron Energy broadcast data
…
```
also behaves correctly when set to **false**.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
