### PR TITLE
Ability to set device name without suffix

### DIFF
--- a/main/config_mqttDiscovery.h
+++ b/main/config_mqttDiscovery.h
@@ -135,8 +135,16 @@ extern char discovery_prefix[];
 #  define GATEWAY_MANUFACTURER "OMG_community"
 #endif
 
+// ForceDeviceName: Set to true to force the device name to be from the name of the device and not the model
+// When enabled, device names will use BLE device name (may still include MAC suffix for uniqueness if device_id differs)
 #ifndef ForceDeviceName
-#  define ForceDeviceName false // Set to true to force the device name to be from the name of the device and not the model
+#  define ForceDeviceName false
+#endif
+
+// ForceDeviceNameNoSuffix: Set to true to force the device name to be from the name of the device without appending MAC suffix
+// This overrides ForceDeviceName behavior and ensures device name is used as-is without any MAC suffix
+#ifndef ForceDeviceNameNoSuffix
+#  define ForceDeviceNameNoSuffix false
 #endif
 
 /*-------------- Auto discovery macros-----------------*/

--- a/main/gatewayBT.cpp
+++ b/main/gatewayBT.cpp
@@ -507,7 +507,9 @@ void DT24Discovery(const char* mac, const char* sensorModel_id) {
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  createDiscoveryFromList(mac, DT24sensor, DT24parametersCount, "DT24", "ATorch", sensorModel_id);
+  // Use sensorModel_id (device name) as device_name if provided, otherwise use model name
+  const char* device_name = (sensorModel_id && sensorModel_id[0] != '\0') ? sensorModel_id : "DT24-BLE";
+  createDiscoveryFromList(mac, DT24sensor, DT24parametersCount, device_name, "ATorch", "DT24-BLE");
 }
 
 void BM2Discovery(const char* mac, const char* sensorModel_id) {
@@ -519,21 +521,27 @@ void BM2Discovery(const char* mac, const char* sensorModel_id) {
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  createDiscoveryFromList(mac, BM2sensor, BM2parametersCount, "BM2", "Generic", sensorModel_id);
+  // Use sensorModel_id (device name) as device_name if provided, otherwise use model name
+  const char* device_name = (sensorModel_id && sensorModel_id[0] != '\0') ? sensorModel_id : "BM2";
+  createDiscoveryFromList(mac, BM2sensor, BM2parametersCount, device_name, "Generic", "BM2");
 }
 
 void LYWSD03MMCDiscovery(const char* mac, const char* sensorModel) {
-#    define LYWSD03MMCparametersCount 4
+#    define LYWSD03MMCparametersCount 6
   THEENGS_LOG_TRACE(F("LYWSD03MMCDiscovery" CR));
   const char* LYWSD03MMCsensor[LYWSD03MMCparametersCount][9] = {
       {HASS_TYPE_SENSOR, "batt", mac, HASS_CLASS_BATTERY, jsonBatt, "", "", HASS_UNIT_PERCENT, stateClassMeasurement},
       {HASS_TYPE_SENSOR, "volt", mac, "", jsonVolt, "", "", HASS_UNIT_VOLT, stateClassMeasurement},
       {HASS_TYPE_SENSOR, "temp", mac, HASS_CLASS_TEMPERATURE, jsonTempc, "", "", HASS_UNIT_CELSIUS, stateClassMeasurement},
+      {HASS_TYPE_SENSOR, "tempc", mac, HASS_CLASS_TEMPERATURE, jsonTempc, "", "", HASS_UNIT_CELSIUS, stateClassMeasurement},
+      {HASS_TYPE_SENSOR, "tempf", mac, HASS_CLASS_TEMPERATURE, jsonTempf, "", "", HASS_UNIT_FAHRENHEIT, stateClassMeasurement},
       {HASS_TYPE_SENSOR, "hum", mac, HASS_CLASS_HUMIDITY, jsonHum, "", "", HASS_UNIT_PERCENT, stateClassMeasurement}
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  createDiscoveryFromList(mac, LYWSD03MMCsensor, LYWSD03MMCparametersCount, "LYWSD03MMC", "Xiaomi", sensorModel);
+  // Use sensorModel (device name) as device_name if provided, otherwise use model name
+  const char* device_name = (sensorModel && sensorModel[0] != '\0') ? sensorModel : "LYWSD03MMC";
+  createDiscoveryFromList(mac, LYWSD03MMCsensor, LYWSD03MMCparametersCount, device_name, "Xiaomi", "LYWSD03MMC");
 }
 
 void MHO_C401Discovery(const char* mac, const char* sensorModel) {
@@ -547,7 +555,9 @@ void MHO_C401Discovery(const char* mac, const char* sensorModel) {
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  createDiscoveryFromList(mac, MHO_C401sensor, MHO_C401parametersCount, "MHO_C401", "Xiaomi", sensorModel);
+  // Use sensorModel (device name) as device_name if provided, otherwise use model name
+  const char* device_name = (sensorModel && sensorModel[0] != '\0') ? sensorModel : "MHO_C401";
+  createDiscoveryFromList(mac, MHO_C401sensor, MHO_C401parametersCount, device_name, "Xiaomi", "MHO-C401");
 }
 
 void HHCCJCY01HHCCDiscovery(const char* mac, const char* sensorModel) {
@@ -562,7 +572,9 @@ void HHCCJCY01HHCCDiscovery(const char* mac, const char* sensorModel) {
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  createDiscoveryFromList(mac, HHCCJCY01HHCCsensor, HHCCJCY01HHCCparametersCount, "HHCCJCY01HHCC", "Xiaomi", sensorModel);
+  // Use sensorModel (device name) as device_name if provided, otherwise use model name
+  const char* device_name = (sensorModel && sensorModel[0] != '\0') ? sensorModel : "HHCCJCY01HHCC";
+  createDiscoveryFromList(mac, HHCCJCY01HHCCsensor, HHCCJCY01HHCCparametersCount, device_name, "Xiaomi", "HHCCJCY01HHCC");
 }
 
 void XMWSDJ04MMCDiscovery(const char* mac, const char* sensorModel) {
@@ -576,7 +588,9 @@ void XMWSDJ04MMCDiscovery(const char* mac, const char* sensorModel) {
       //component type,name,availability topic,device class,value template,payload on, payload off, unit of measurement
   };
 
-  createDiscoveryFromList(mac, XMWSDJ04MMCsensor, XMWSDJ04MMCparametersCount, "XMWSDJ04MMC", "Xiaomi", sensorModel);
+  // Use sensorModel (device name) as device_name if provided, otherwise use model name
+  const char* device_name = (sensorModel && sensorModel[0] != '\0') ? sensorModel : "XMWSDJ04MMC";
+  createDiscoveryFromList(mac, XMWSDJ04MMCsensor, XMWSDJ04MMCparametersCount, device_name, "Xiaomi", "XMWSDJ04MMC");
 }
 
 #  else
@@ -1126,12 +1140,15 @@ void launchBTDiscovery(bool overrideDiscovery) {
                p->sensorModel_id < BLEconectable::id::MAX) ||
               p->sensorModel_id == TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC || p->sensorModel_id == TheengsDecoder::BLE_ID_NUM::BM2) {
             // Discovery of sensors from which we retrieve data only by connect
+            // Use device name if available, otherwise use model name
+            const char* device_name_for_discovery = (p->name[0] != '\0') ? p->name : model.c_str();
+
             if (p->sensorModel_id == BLEconectable::id::DT24_BLE) {
-              DT24Discovery(macWOdots.c_str(), "DT24-BLE");
+              DT24Discovery(macWOdots.c_str(), device_name_for_discovery);
             }
             if (p->sensorModel_id == TheengsDecoder::BLE_ID_NUM::BM2) {
               // Sensor discovery
-              BM2Discovery(macWOdots.c_str(), "BM2");
+              BM2Discovery(macWOdots.c_str(), device_name_for_discovery);
               // Device tracker discovery
               String tracker_id = macWOdots + "-tracker";
               createDiscovery(HASS_TYPE_DEVICE_TRACKER,
@@ -1143,17 +1160,27 @@ void launchBTDiscovery(bool overrideDiscovery) {
                               stateClassNone);
             }
             if (p->sensorModel_id == BLEconectable::id::LYWSD03MMC) {
-              LYWSD03MMCDiscovery(macWOdots.c_str(), "LYWSD03MMC");
+              LYWSD03MMCDiscovery(macWOdots.c_str(), device_name_for_discovery);
             }
             if (p->sensorModel_id == BLEconectable::id::MHO_C401) {
-              MHO_C401Discovery(macWOdots.c_str(), "MHO-C401");
+              MHO_C401Discovery(macWOdots.c_str(), device_name_for_discovery);
             }
             if (p->sensorModel_id == BLEconectable::id::XMWSDJ04MMC) {
-              XMWSDJ04MMCDiscovery(macWOdots.c_str(), "XMWSDJ04MMC");
+              XMWSDJ04MMCDiscovery(macWOdots.c_str(), device_name_for_discovery);
             }
             if (p->sensorModel_id == TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC) {
-              HHCCJCY01HHCCDiscovery(macWOdots.c_str(), "HHCCJCY01HHCC");
+              HHCCJCY01HHCCDiscovery(macWOdots.c_str(), device_name_for_discovery);
             }
+
+            // Add RSSI sensor for connectable devices (RSSI is published in broadcast payload)
+            String rssi_id = macWOdots + "-rssi";
+            createDiscovery(HASS_TYPE_SENSOR,
+                            discovery_topic.c_str(), "rssi", rssi_id.c_str(),
+                            will_Topic, "signal_strength", jsonRSSI,
+                            "", "", "dB",
+                            0, "", "", false, "",
+                            device_name_for_discovery, brand.c_str(), model_id.c_str(), macWOdots.c_str(), false,
+                            stateClassMeasurement, nullptr, nullptr, nullptr, nullptr, true);
           } else {
             THEENGS_LOG_TRACE(F("Device UNKNOWN_MODEL %s" CR), p->macAdr);
           }
@@ -1429,7 +1456,23 @@ void process_bledata(JsonObject& BLEdata) {
   if ((BLEdata["type"].as<string>()).compare("RMAC") != 0 && model_id != TheengsDecoder::BLE_ID_NUM::IBEACON) { // Do not store in memory the random mac devices and iBeacons
     if (model_id >= 0) { // Broadcaster devices
       THEENGS_LOG_TRACE(F("Decoder found device: %s" CR), BLEdata["model_id"].as<const char*>());
-      if (model_id == TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC || model_id == TheengsDecoder::BLE_ID_NUM::BM2) { // Device that broadcast and can be connected
+      // Check if this is a connectable device by model_id string (for devices with custom names like PVVX firmware)
+      if (BLEdata.containsKey("model_id")) {
+        std::string model_id_str = BLEdata["model_id"].as<std::string>();
+        if (model_id_str.find("LYWSD03MMC") != std::string::npos) {
+          model_id = BLEconectable::id::LYWSD03MMC;
+          THEENGS_LOG_TRACE(F("Connectable device identified by model_id: LYWSD03MMC" CR));
+        } else if (model_id_str.find("MHO-C401") != std::string::npos || model_id_str.find("MHOC401") != std::string::npos) {
+          model_id = BLEconectable::id::MHO_C401;
+          THEENGS_LOG_TRACE(F("Connectable device identified by model_id: MHO-C401" CR));
+        } else if (model_id_str.find("XMWSDJ04MMC") != std::string::npos) {
+          model_id = BLEconectable::id::XMWSDJ04MMC;
+          THEENGS_LOG_TRACE(F("Connectable device identified by model_id: XMWSDJ04MMC" CR));
+        }
+      }
+      if (model_id == TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC || model_id == TheengsDecoder::BLE_ID_NUM::BM2 ||
+          model_id == BLEconectable::id::LYWSD03MMC || model_id == BLEconectable::id::MHO_C401 ||
+          model_id == BLEconectable::id::XMWSDJ04MMC) { // Device that broadcast and can be connected
         createOrUpdateDevice(mac, device_flags_connect, model_id, mac_type, deviceName);
       } else {
         createOrUpdateDevice(mac, device_flags_init, model_id, mac_type, deviceName);

--- a/main/gatewayBT.cpp
+++ b/main/gatewayBT.cpp
@@ -398,6 +398,20 @@ void createOrUpdateDevice(const char* mac, uint8_t flags, int model, int mac_typ
     device->lastUpdate = millis();
     device->macType = mac_type;
 
+    // Update device name if provided and current name is empty, or if name has changed
+    if (name != nullptr && name[0] != '\0') {
+      if (device->name[0] == '\0' || strcmp(device->name, name) != 0) {
+        // Check name length
+        if (strlen(name) > 20) {
+          THEENGS_LOG_WARNING(F("Name too long, truncating" CR));
+          strncpy(device->name, name, 20);
+          device->name[19] = '\0';
+        } else {
+          strcpy(device->name, name);
+        }
+      }
+    }
+
     if (flags & device_flags_isDisc) {
       device->isDisc = true;
     }

--- a/main/mqttDiscovery.cpp
+++ b/main/mqttDiscovery.cpp
@@ -654,11 +654,20 @@ void createDiscovery(const char* sensor_type,
 
     // generate unique device name by adding the second half of the device_id only if device_name and device_id are different and we don't want to use the BLE name
     if (device_name[0]) {
+#  ifdef ForceDeviceNameNoSuffix
+      // ForceDeviceNameNoSuffix is enabled: always use the device name as-is without MAC suffix
+      device["name"] = device_name;
+#  else
+      // Original ForceDeviceName behavior: use BLE device name instead of model
+      // If ForceDeviceName is disabled, may add MAC suffix for uniqueness
       if (strcmp(device_id, device_name) != 0 && device_id[0] && !ForceDeviceName) {
+        // Append MAC suffix (last 6 chars) if device_id and device_name differ and ForceDeviceName is disabled
         device["name"] = device_name + String("-") + String(device_id + 6);
       } else {
+        // Use device name as-is (ForceDeviceName enabled, or device_id matches device_name, or no device_id)
         device["name"] = device_name;
       }
+#  endif
     }
 
     device["via_device"] = String(getMacAddress()); //mac address of the gateway so that the devices link to the gateway


### PR DESCRIPTION

## Description:

Add the ability to `ForceDeviceName` without suffixing the last 6 digits' mac address. Simply compile with `-DForceDeviceNameNoSuffix` to do so.

Need to be careful that each device has a distinct name so that there is no collision during discovery.

Also added : 
- missing "tempc" and "tempf" (keeping "temp" which is celcius for backward compat).
- rssi diagnostic value for all connectable devices.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
