### PR TITLE
[CI] Configure Claude GitHub Actions to use Opus model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model opus'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model opus'
+          claude_args: '--model claude-opus-4-5-20251101'
 


### PR DESCRIPTION
## Summary
- Configure both Claude GitHub Actions workflows to use Claude Opus 4.5
- Uses the correct model ID: `claude-opus-4-5-20251101`
- Ensures advanced reasoning capabilities for complex firmware codebase reviews

## Changes
- **claude.yml**: Added `--model claude-opus-4-5-20251101` to claude_args
- **claude-code-review.yml**: Added `--model claude-opus-4-5-20251101` to claude_args

## Why Opus?
OpenMQTTGateway is a complex multi-protocol firmware with:
- 80+ hardware configurations
- Memory-constrained embedded systems (ESP8266/ESP32)
- Intricate RF signal processing and timing-critical code
- Critical integration with home automation platforms

Opus provides the advanced reasoning needed for thorough code reviews.

## Test Plan
- [ ] Trigger @claude mention in a PR comment
- [ ] Verify Claude Opus 4.5 is used (check action logs)
- [ ] Confirm code review workflow runs on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)