### PR TITLE
[RF] Fix CC1101 not initializing on boot when config exists

### DIFF
--- a/main/rf/RFConfiguration.cpp
+++ b/main/rf/RFConfiguration.cpp
@@ -156,6 +156,7 @@ void RFConfiguration::loadFromStorage() {
     JsonObject jo = jsonBuffer.as<JsonObject>();
     fromJson(jo);
     Log.notice(F("RF Config loaded" CR));
+    iRFReceiver.enable();
   } else {
     preferences.end();
     Log.notice(F("RF Config not found using default" CR));


### PR DESCRIPTION
Fixes #2264

When RF configuration was saved to NVS, the CC1101 module would not initialize properly on boot, requiring a manual toggle between RTL_433 and RF modes in the WebUI to activate it.

Root cause: The loadFromStorage() method in RFConfiguration.cpp loaded the saved configuration but failed to call iRFReceiver.enable() when config existed. This only affected users with saved configurations.

The "no config found" path correctly called enable(), and the loadFromMessage() method (used by WebUI) also called disable()/enable(), explaining why the WebUI workaround worked.

Solution: Add iRFReceiver.enable() after loading configuration in loadFromStorage() to match the behavior of both the "no config" branch and the loadFromMessage() method.

This ensures both code paths (config exists vs. doesn't exist) behave identically: load config, then enable receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description:


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
