### PR TITLE
[RF] Fix CC1101 initialization on boot with saved RF config

### DIFF
--- a/main/rf/RFConfiguration.cpp
+++ b/main/rf/RFConfiguration.cpp
@@ -134,11 +134,14 @@ void RFConfiguration::saveOnStorage() {
  * is not found, a notice is logged, and the RF receiver is enabled with
  * default settings.
  *
+ * @param reinitReceiver If true (default), disables and re-enables the receiver.
+ *                       If false, only loads the configuration without reinitialization.
+ *
  * @note This function has specific behavior for ESP32 platforms. On ESP32,
  *       it uses the Preferences library to access stored configuration data.
  *       For other platforms, it directly enables the active receiver.
  */
-void RFConfiguration::loadFromStorage() {
+void RFConfiguration::loadFromStorage(bool reinitReceiver) {
 #ifdef ESP32
   StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
   preferences.begin(Gateway_Short_Name, true);
@@ -159,11 +162,13 @@ void RFConfiguration::loadFromStorage() {
   } else {
     preferences.end();
     Log.notice(F("RF Config not found using default" CR));
+  }
+#endif
+  // Disable and re-enable the receiver to ensure proper initialization
+  if (reinitReceiver) {
+    iRFReceiver.disable();
     iRFReceiver.enable();
   }
-#else
-  iRFReceiver.enable();
-#endif
 }
 
 /**
@@ -193,8 +198,8 @@ void RFConfiguration::loadFromMessage(JsonObject& RFdata) {
     // Restore the default (initial) configuration
     reInit();
   } else if (RFdata.containsKey("load") && RFdata["load"].as<bool>()) {
-    // Load the saved configuration, if not initialised
-    loadFromStorage();
+    // Load the saved configuration from storage (without receiver reinitialization)
+    loadFromStorage(false);
   }
 
   fromJson(RFdata);

--- a/main/rf/RFConfiguration.h
+++ b/main/rf/RFConfiguration.h
@@ -49,11 +49,14 @@ public:
   /**
    * Loads the RF configuration from persistent storage and applies it.
    *
+   * @param reinitReceiver If true (default), disables and re-enables the receiver.
+   *                       If false, only loads the configuration without reinitialization.
+   *
    * @note This function has specific behavior for ESP32 platforms. On ESP32,
    *       it uses the Preferences library to access stored configuration data.
    *       For other platforms, it directly enables the active receiver.
    */
-  void loadFromStorage();
+  void loadFromStorage(bool reinitReceiver = true);
 
   /**
    * Loads the RF configuration from a JSON object and applies it.


### PR DESCRIPTION
## Description:
When a saved RF configuration exists in NVS, loadFromStorage() was loading the config but not calling iRFReceiver.enable(), which meant initCC1101() was never invoked during boot. This caused the CC1101 to not receive signals until the user manually toggled the RF receiver via the WebUI.

This fix adds a reinitReceiver parameter to loadFromStorage() that controls whether to disable/enable the receiver after loading config. By default it's true (for boot-time initialization), but loadFromMessage() passes false to avoid double initialization when loading config from MQTT messages.

Fixes #2264

Co-authored-by: Florian <1technophile@users.noreply.github.com>
Co-authored-by: Odyno <odyno@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.ai/code)


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
