### PR TITLE
[SYS] Fix: Set WiFi hostname to gateway name

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1815,8 +1815,8 @@ void ESPRestart(byte reason) {
 
 #if defined(ESPWifiManualSetup)
 void setupWiFiFromBuild() {
-  WiFi.mode(WIFI_STA);
   WiFi.setHostname(gateway_name);
+  WiFi.mode(WIFI_STA);
   wifiMulti.addAP(wifi_ssid, wifi_password);
   THEENGS_LOG_TRACE(F("Connecting to %s" CR), wifi_ssid);
 #  ifdef wifi_ssid1

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1816,6 +1816,7 @@ void ESPRestart(byte reason) {
 #if defined(ESPWifiManualSetup)
 void setupWiFiFromBuild() {
   WiFi.mode(WIFI_STA);
+  WiFi.setHostname(gateway_name);
   wifiMulti.addAP(wifi_ssid, wifi_password);
   THEENGS_LOG_TRACE(F("Connecting to %s" CR), wifi_ssid);
 #  ifdef wifi_ssid1
@@ -2222,6 +2223,7 @@ void setupWiFiManager() {
 #  endif
 
   wifiManager.setDebugOutput(WM_DEBUG);
+  wifiManager.setHostname(gateway_name);
 
   // The extra parameters to be configured (can be either global or just in the setup)
   // After connecting, parameter.getValue() will get you the configured value

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1427,6 +1427,7 @@ void setup() {
   extern void setupWiFiFromBuild();
   setupWiFiFromBuild();
 #else
+  WiFi.setHostname(gateway_name);
   WiFi.mode(WIFI_STA);
   if (loadConfigFromFlash()) { // Config present
     THEENGS_LOG_NOTICE(F("Config loaded from flash" CR));
@@ -2223,7 +2224,6 @@ void setupWiFiManager() {
 #  endif
 
   wifiManager.setDebugOutput(WM_DEBUG);
-  wifiManager.setHostname(gateway_name);
 
   // The extra parameters to be configured (can be either global or just in the setup)
   // After connecting, parameter.getValue() will get you the configured value


### PR DESCRIPTION

## Description:
Add WiFi.setHostname() calls to ensure the ESP's WiFi hostname matches the configured gateway name instead of using the default ESP hostname.

- Add wifiManager.setHostname(gateway_name) in setupWiFiManager() for WiFiManager-based setups
- Add WiFi.setHostname(gateway_name) in setupWiFiFromBuild() for manual WiFi setup configurations (ESPWifiManualSetup)

This matches the existing behavior for Ethernet connections where ETH.setHostname(gateway_name) is already called.

Fixes #2150

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
