### PR TITLE
[SYS] Add HASS_UNIT_PPM to availableHASSUnits array

### DIFF
--- a/main/mqttDiscovery.cpp
+++ b/main/mqttDiscovery.cpp
@@ -127,6 +127,7 @@ static const char* const availableHASSUnits[] = {
     HASS_UNIT_UGM3,
     HASS_UNIT_OHM,
     HASS_UNIT_PERCENT,
+    HASS_UNIT_PPM,
     HASS_UNIT_DEGREE,
     HASS_UNIT_CELSIUS,
     HASS_UNIT_FAHRENHEIT,


### PR DESCRIPTION
## Description

`HASS_UNIT_PPM` is defined in `config_mqttDiscovery.h` but was missing from the `availableHASSUnits` validation array in `mqttDiscovery.cpp`. 

This caused `unit_of_measurement` to be silently dropped for CO2 sensors during MQTT discovery, resulting in Home Assistant warnings:

```
Entity sensor.xxx_co2 is using native unit of measurement 'None' which is not a valid unit for the device class ('carbon_dioxide') it is using; expected one of ['ppm']
```

This fixes the unit_of_measurement for CO2 sensors like the Govee H5140 (added in theengs/decoder#684).

## Checklist
- [x] The pull request is done against the latest development branch
- [x] Only one feature/fix was added per PR and the code change compiles without warnings
- [x] I accept the [DCO](https://docs.openmqttgateway.com/participate/development.html#dco-music)