### PR TITLE
[DOCS] Fix dev docs deploying to /dev/dev/ instead of /dev/

### DIFF
--- a/scripts/ci_site.sh
+++ b/scripts/ci_site.sh
@@ -113,11 +113,8 @@ create_configuration_files() {
     local url_prefix="$1"
     local version="$2"
     local mode="$3"
-    local dest_line=""
-
-    if [[ "$mode" == "dev" ]]; then
-        dest_line="    \"dest\": \"generated/site/dev\","
-    fi
+    # Note: dest is always "generated/site" (from defaults.json).
+    # The dev subdirectory is handled by destination_dir in the GitHub Actions deploy step.
 
     # download common config
     download_common_config
@@ -130,7 +127,6 @@ create_configuration_files() {
     "title": "Theengs OpenMQTTGateway",
     "version": "${version}",
     "url_prefix": "${url_prefix}",
-    ${dest_line}
     "mode": "${mode}"
 }
 EOF


### PR DESCRIPTION
## Summary
- The `ci_site.sh` script was overriding the VuePress `dest` to `generated/site/dev` when building in dev mode
- Since `task-docs.yml` already uses `destination_dir: "dev"` in the `peaceiris/actions-gh-pages` deploy step, this caused the site content to be nested at `/dev/dev/` on the `gh-pages` branch
- As a result, `https://docs.openmqttgateway.com/dev/` shows nothing — the actual content was at `/dev/dev/`
- This fix removes the `dest` override from `ci_site.sh` and lets the deploy action handle the subdirectory placement

## Test plan
- [x] Trigger a manual run of `build_and_docs_to_dev.yml`
- [x] Verify `https://docs.openmqttgateway.com/dev/` loads correctly
- [x] Verify `https://docs.openmqttgateway.com/` (prod) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)