### PR TITLE
[WebUI] Fix BLE config page connection reset on load

### DIFF
--- a/main/webUI.cpp
+++ b/main/webUI.cpp
@@ -1089,7 +1089,9 @@ void handleBL() {
   serializeJson(modules, jsonChar, measureJson(modules) + 1);
   beginChunkedResponse();
   sendHeaderChunk((String(gateway_name) + " - Configure BLE").c_str());
-  server.sendContent(ble_script);
+  if (strlen(ble_script) > 0) {
+    server.sendContent(ble_script);
+  }
   server.sendContent(script);
   server.sendContent(style);
 


### PR DESCRIPTION
## Description:
ble_script is defined as "" (empty string). Passing it to server.sendContent("") signals end of HTTP chunked transfer, closing the response prematurely. All subsequent chunks then fail with errno 104 "Connection reset by peer".

Guard the call with a length check so the empty string is never sent as a chunk terminator.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
