### PR TITLE
[MEM] Enable PSRAM on Theengs Bridge (ESP32-WROVER-IE)

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -53,6 +53,7 @@ custom_hardware = RFBridge v1
 platform = ${com.esp32_platform}
 platform_packages = ${com.esp32_platform_packages}
 board = esp32dev
+board_build.flash_mode = qio
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
@@ -70,7 +71,7 @@ build_flags =
   '-DETH_PHY_POWER=5'
   '-DETH_PHY_MDC=23'
   '-DETH_PHY_MDIO=18'
-  '-DETH_CLK_MODE=ETH_CLOCK_GPIO16_OUT'
+  '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_OUT'
   '-DLED_ADDRESSABLE_PIN1=32'
   '-DLED_ADDRESSABLE_NUM=4'
   '-DLED_BROKER=0'
@@ -82,8 +83,9 @@ build_flags =
   '-DUSE_MAC_AS_GATEWAY_NAME'
   '-DGATEWAY_MANUFACTURER="Theengs"'
   '-DGATEWAY_MODEL="TBRIDGE01"'
-  ;'-DBOARD_HAS_PSRAM'
-  ;'-mfix-esp32-psram-cache-issue'
+  '-DBOARD_HAS_PSRAM'
+  '-mfix-esp32-psram-cache-issue'
+  '-mfix-esp32-psram-cache-strategy=memw'
 custom_description = 'BLE gateway with external antenna and Ethernet/WiFi connectivity, <a href="https://tbridge01.theengs.io/" target="_blank">user guide</a>'
 custom_hardware = Theengs Bridge gateway ethernet
 
@@ -91,6 +93,7 @@ custom_hardware = Theengs Bridge gateway ethernet
 platform = ${com.esp32_platform}
 platform_packages = ${com.esp32_platform_packages}
 board = esp32dev
+board_build.flash_mode = qio
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
@@ -106,7 +109,7 @@ build_flags =
   '-DETH_PHY_POWER=5'
   '-DETH_PHY_MDC=23'
   '-DETH_PHY_MDIO=18'
-  '-DETH_CLK_MODE=ETH_CLOCK_GPIO16_OUT'
+  '-DETH_CLK_MODE=ETH_CLOCK_GPIO0_OUT'
   '-DLED_ADDRESSABLE=true'
   '-DLED_ADDRESSABLE_PIN1=32'
   '-DLED_ADDRESSABLE_NUM=4'
@@ -120,9 +123,10 @@ build_flags =
   '-DUSE_MAC_AS_GATEWAY_NAME'
   '-DGATEWAY_MANUFACTURER="Theengs"'
   '-DGATEWAY_MODEL="TBRIDGE02"'
-  ;'-DBOARD_HAS_PSRAM'
+  '-DBOARD_HAS_PSRAM'
+  '-mfix-esp32-psram-cache-issue'
+  '-mfix-esp32-psram-cache-strategy=memw'
   ;'-DSELF_TEST=true'
-  ;'-mfix-esp32-psram-cache-issue'
 custom_description = 'BLE gateway with external antenna and Ethernet/WiFi connectivity, <a href="https://tbridge02.theengs.io/" target="_blank">user guide</a>'
 custom_hardware = Theengs Bridge gateway ethernet
 custom_img = img/Theengs-Bridge-ble-gateway.png

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2848,6 +2848,10 @@ String stateMeasures() {
 #  endif
   SYSdata["freestck"] = uxTaskGetStackHighWaterMark(NULL);
   SYSdata["powermode"] = SYSConfig.powerMode;
+  if (psramFound()) {
+    SYSdata["psram"] = true;
+    SYSdata["psramfree"] = ESP.getFreePsram();
+  }
 #endif
 
   SYSdata["eth"] = ethConnected;

--- a/platformio.ini
+++ b/platformio.ini
@@ -180,7 +180,7 @@ monitor_speed = 115200
 [com]
 esp8266_platform = espressif8266@4.2.1
 esp32_platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.33/platform-espressif32.zip
-esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.0/esp32-arduino-libs.tar.gz
+esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.3/esp32-arduino-libs.tar.gz
 esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 atmelavr_platform = atmelavr@3.3.0
 


### PR DESCRIPTION
## Description:
- Switch Ethernet RMII clock from GPIO16 to GPIO0 output mode, freeing GPIO16 for PSRAM chip select (SPICS1) on WROVER-IE
- Enable PSRAM with QIO flash mode and cache workaround flags
- Add PHY pre-power support for ETH_CLOCK_GPIO0_IN mode
- Report PSRAM status and free memory in SYS MQTT topic

Requires Theengs lib-builder update: remove LIBTIME from IRAM cache workaround (CONFIG_SPIRAM_CACHE_LIBTIME_IN_IRAM=n) to free ~3.5KB IRAM for the -mfix-esp32-psram-cache-issue flag.

Tested on Theengs Bridge v1.1: 4MB PSRAM detected, Ethernet 100Mbps on GPIO0, BLE scanning nominal.
## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
