### PR TITLE
[DOCS] Restore dev-version banner gate after VitePress migration

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -32,6 +32,12 @@ export default defineConfig({
   },
   themeConfig: {
     siteTitle: 'OpenMQTTGateway',
+    // @ts-expect-error custom fields consumed by index.md to render the dev-version banner
+    mode: meta.mode,
+    // @ts-expect-error
+    version: meta.version,
+    // @ts-expect-error
+    repo: meta.theme_config_repo,
     nav: commonNav,
     socialLinks: [
       { icon: 'github', link: `https://github.com/${meta.theme_config_repo}` }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,19 @@
 <script setup>
 import { useData } from 'vitepress'
-const { site } = useData()
-const isDev = site.value.title?.includes('edge') || site.value.title?.includes('dev')
+import { computed } from 'vue'
+const { theme } = useData()
+const isDev = theme.value.mode === 'dev'
+const version = theme.value.version
+const commitUrl = computed(() =>
+  theme.value.repo && version
+    ? `https://github.com/${theme.value.repo}/commit/${version}`
+    : null
+)
 </script>
 
 <div v-if="isDev" class="warning custom-block">
 <p class="custom-block-title">Development Version</p>
-<p>This is the edge version of the documentation. It is under active development and may contain bugs, incomplete features, or breaking changes. Use it at your own risk.</p>
+<p>This is the edge version of the documentation, built from commit <a v-if="commitUrl" :href="commitUrl"><code>{{ version }}</code></a><code v-else>{{ version }}</code>. It is under active development and may contain bugs, incomplete features, or breaking changes. Use it at your own risk.</p>
 </div>
 
 OpenMQTTGateway aims to unify various technologies and protocols into a single firmware. This reduces the need for multiple physical bridges and streamlines diverse technologies under the widely-used [MQTT](http://mqtt.org/) protocol.


### PR DESCRIPTION
## Description:
The VuePress->VitePress migration replaced the `themeConfig.mode === 'dev'` gate with a heuristic on `site.title`. CI overrides version with a short SHA (dev) or git tag (prod), so the title never contains "edge"/"dev" and the banner never renders on live deploys. Surface `meta.mode` in `themeConfig` and check it directly, mirroring the original behaviour.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
