### PR TITLE
Add RTL_433 device whitelist support

### DIFF
--- a/docs/integrate/home_assistant.md
+++ b/docs/integrate/home_assistant.md
@@ -74,6 +74,8 @@ mqtt:
 
 Alternatively the rssi signal could be used also.
 
+The gateway device also exposes an `RTL_433: Whitelist` switch through MQTT discovery. When the whitelist switch is enabled, only matching RTL_433 devices are published to MQTT and discovered as Home Assistant entities. The whitelist entries can be edited from the OpenMQTTGateway WebUI RF configuration page or with MQTT commands.
+
 ### RF (RCSwitch based gateway) Auto discovery specificity
 With OpenMQTTGateway [configured to receive RF signals](../setitup/rf.html) messages are transmitted accordingly.
 

--- a/docs/use/rf.md
+++ b/docs/use/rf.md
@@ -72,6 +72,45 @@ This feature is only available on a ESP32 based device with a supported transcei
 
 For the most recent support decoder list please check the [rtl_433_esp](https://github.com/NorthernMan54/rtl_433_ESP?tab=readme-ov-file#ook-signal-device-decoders) repository.
 
+### RTL_433 device whitelist
+
+The RTL_433 gateway can filter received devices with a whitelist. When the whitelist is enabled, only devices matching one of the configured RTL_433 device identifiers are published to MQTT. Other received RTL_433 messages are ignored.
+
+The device identifier is built from the RTL_433 decoded fields in this order:
+
+`type/model/subtype/channel/id`
+
+Depending on the protocol, some parts may be absent. The WebUI shows the identifiers detected during the current runtime, making it easier to select devices without typing them manually.
+
+The whitelist can be configured from:
+
+- the WebUI RF configuration page
+- MQTT commands to the SYS command topic
+- Home Assistant, when MQTT discovery is enabled
+
+The whitelist supports up to 5 device identifiers.
+
+Enable or disable the whitelist:
+
+```bash
+mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"rtl433wle":true,"save":true}'
+mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"rtl433wle":false,"save":true}'
+```
+
+Set whitelist entries:
+
+```bash
+mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"rtl433wl1":"OOK/Acurite-Tower/1/12345","rtl433wl2":"OOK/Prologue-TH/9/1/215","save":true}'
+```
+
+Clear one whitelist entry by sending an empty string:
+
+```bash
+mosquitto_pub -t "home/OpenMQTTGateway/commands/MQTTtoSYS/config" -m '{"rtl433wl2":"","save":true}'
+```
+
+The current whitelist state is published in the SYS state topic with the keys `rtl433wle` and `rtl433wl1` to `rtl433wl5`.
+
 ### Change Signal RSSI Threshold Delta
 
 Delta applied to RSSI floor noise level to determine start and end of signal, defaults to 9db.

--- a/main/config_RF.h
+++ b/main/config_RF.h
@@ -61,17 +61,17 @@ extern int getRTLMessageCount();
 extern int getRTLAverageRSSI();
 extern int getOOKThresh();
 
+#  define uniqueIdSize  60 // longest model + longest key
+#  define modelNameSize 31 // longest model
+#  define typeSize      10 // longest type
+
 #  ifdef ZmqttDiscovery
 extern void launchRTL_433Discovery(bool overrideDiscovery);
 // This structure stores the entities of the RTL 433 devices and is they have been discovered or not
 // The uniqueId is composed of the device id + the key
-
-#    define uniqueIdSize  60 // longest model + longest key
-#    define modelNameSize 31 // longest model
-#    define typeSize      10 // longest type
-
 struct RTL_433device {
   char uniqueId[uniqueIdSize];
+  char deviceId[uniqueIdSize];
   char modelName[modelNameSize];
   char type[typeSize];
   bool isDisc;
@@ -131,6 +131,15 @@ const char parameters[51][4][24] = {
     {"wind_speed_km_h", "Wind speed", "km/h", "wind_speed"},
     {"wind_speed_m_s", "Wind speed", "m/s", "wind_speed"}};
 #  endif
+extern void RTL_433Config_addState(JsonObject& data);
+extern bool RTL_433Config_fromJson(JsonObject& data);
+extern bool RTL_433Config_save();
+extern bool RTL_433Config_load();
+extern void RTL_433Config_setWhitelistEnabled(bool enabled);
+extern bool RTL_433Config_isWhitelistEnabled();
+extern void RTL_433Config_clearWhitelist();
+extern bool RTL_433Config_addWhitelistId(const char* id);
+extern String RTL_433Config_webWhitelist();
 #  ifdef RTL_433_DISCOVERY_LOGGING
 #    define DISCOVERY_TRACE_LOG(...) THEENGS_LOG_TRACE(__VA_ARGS__)
 #  else

--- a/main/config_WebContent.h
+++ b/main/config_WebContent.h
@@ -153,6 +153,8 @@ const char config_rf_body[] = body_header
     "<p><b>Active library</b><br>"
     "<select id='ar' name='ar'>%s</select></p>"
 
+    "%s"
+
     /* // Need testing
     "<p><b>OOK Threshold</b><br>"
     "<input type='number' id='oo' name='oo' step='any' value='%d'></p>"

--- a/main/gatewayRTL_433.cpp
+++ b/main/gatewayRTL_433.cpp
@@ -43,13 +43,221 @@
 static char messageBuffer[JSON_MSG_BUFFER];
 rtl_433_ESP rtl_433;
 
+static const uint8_t RTL_433_WHITELIST_MAX = 5;
+static const uint8_t RTL_433_SEEN_MAX = 30;
+static const char* RTL_433_CONFIG_KEY = "RTL433Config";
+
+bool RTL_433WhitelistEnabled = false;
+char RTL_433Whitelist[RTL_433_WHITELIST_MAX][uniqueIdSize] = {{0}};
+
+struct RTL_433seenDevice {
+  char deviceId[uniqueIdSize];
+  char modelName[modelNameSize];
+  char type[typeSize];
+};
+
+std::vector<RTL_433seenDevice*> RTL_433seenDevices;
+
+static String htmlEscape(const char* value) {
+  String escaped = value;
+  escaped.replace("&", "&amp;");
+  escaped.replace("\"", "&quot;");
+  escaped.replace("'", "&#39;");
+  escaped.replace("<", "&lt;");
+  escaped.replace(">", "&gt;");
+  return escaped;
+}
+
+static bool RTL_433Config_isWhitelisted(const char* id) {
+  for (uint8_t i = 0; i < RTL_433_WHITELIST_MAX; i++) {
+    if (RTL_433Whitelist[i][0] && strcmp(RTL_433Whitelist[i], id) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static void RTL_433Config_storeSeenDevice(const char* id, const char* model, const char* type) {
+  if (!id || !id[0]) {
+    return;
+  }
+  for (std::vector<RTL_433seenDevice*>::iterator it = RTL_433seenDevices.begin(); it != RTL_433seenDevices.end(); ++it) {
+    if (strcmp((*it)->deviceId, id) == 0) {
+      return;
+    }
+  }
+  if (RTL_433seenDevices.size() >= RTL_433_SEEN_MAX) {
+    delete RTL_433seenDevices.front();
+    RTL_433seenDevices.erase(RTL_433seenDevices.begin());
+  }
+  RTL_433seenDevice* device = new RTL_433seenDevice();
+  strlcpy(device->deviceId, id, uniqueIdSize);
+  strlcpy(device->modelName, model ? model : "", modelNameSize);
+  strlcpy(device->type, type ? type : "", typeSize);
+  RTL_433seenDevices.push_back(device);
+}
+
+void RTL_433Config_setWhitelistEnabled(bool enabled) {
+  RTL_433WhitelistEnabled = enabled;
+}
+
+bool RTL_433Config_isWhitelistEnabled() {
+  return RTL_433WhitelistEnabled;
+}
+
+void RTL_433Config_clearWhitelist() {
+  for (uint8_t i = 0; i < RTL_433_WHITELIST_MAX; i++) {
+    RTL_433Whitelist[i][0] = '\0';
+  }
+}
+
+bool RTL_433Config_addWhitelistId(const char* id) {
+  if (!id || !id[0]) {
+    return false;
+  }
+  if (RTL_433Config_isWhitelisted(id)) {
+    return true;
+  }
+  for (uint8_t i = 0; i < RTL_433_WHITELIST_MAX; i++) {
+    if (!RTL_433Whitelist[i][0]) {
+      strlcpy(RTL_433Whitelist[i], id, uniqueIdSize);
+      return true;
+    }
+  }
+  THEENGS_LOG_WARNING(F("[rtl_433] Whitelist is full, ignoring %s" CR), id);
+  return false;
+}
+
+void RTL_433Config_addState(JsonObject& data) {
+  data["rtl433wle"] = RTL_433WhitelistEnabled;
+  for (uint8_t i = 0; i < RTL_433_WHITELIST_MAX; i++) {
+    if (!RTL_433Whitelist[i][0]) {
+      continue;
+    }
+    String key = "rtl433wl" + String(i + 1);
+    data[key] = RTL_433Whitelist[i];
+  }
+}
+
+bool RTL_433Config_fromJson(JsonObject& data) {
+  bool updated = false;
+  if (data.containsKey("rtl433wle") && data["rtl433wle"].is<bool>()) {
+    bool enabled = data["rtl433wle"].as<bool>();
+    if (RTL_433WhitelistEnabled != enabled) {
+      RTL_433WhitelistEnabled = enabled;
+      updated = true;
+    }
+  }
+  for (uint8_t i = 0; i < RTL_433_WHITELIST_MAX; i++) {
+    String key = "rtl433wl" + String(i + 1);
+    if (data.containsKey(key) && data[key].is<const char*>()) {
+      const char* newId = data[key].as<const char*>();
+      if (strncmp(RTL_433Whitelist[i], newId, uniqueIdSize) != 0) {
+        strlcpy(RTL_433Whitelist[i], newId, uniqueIdSize);
+        updated = true;
+      }
+    }
+  }
+  return updated;
+}
+
+bool RTL_433Config_save() {
+  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
+  JsonObject data = jsonBuffer.to<JsonObject>();
+  RTL_433Config_addState(data);
+  String conf = "";
+  serializeJson(jsonBuffer, conf);
+  preferences.begin(Gateway_Short_Name, false);
+  int result = preferences.putString(RTL_433_CONFIG_KEY, conf);
+  preferences.end();
+  THEENGS_LOG_NOTICE(F("[rtl_433] Config_save: %s, result: %d" CR), conf.c_str(), result);
+  return result > 0;
+}
+
+bool RTL_433Config_load() {
+  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
+  preferences.begin(Gateway_Short_Name, true);
+  if (!preferences.isKey(RTL_433_CONFIG_KEY)) {
+    preferences.end();
+    THEENGS_LOG_NOTICE(F("[rtl_433] Config not found" CR));
+    return false;
+  }
+  auto error = deserializeJson(jsonBuffer, preferences.getString(RTL_433_CONFIG_KEY, "{}"));
+  preferences.end();
+  if (error) {
+    THEENGS_LOG_ERROR(F("[rtl_433] Config deserialization failed: %s, buffer capacity: %u" CR), error.c_str(), jsonBuffer.capacity());
+    return false;
+  }
+  JsonObject data = jsonBuffer.as<JsonObject>();
+  RTL_433Config_fromJson(data);
+  THEENGS_LOG_NOTICE(F("[rtl_433] Config loaded" CR));
+  return true;
+}
+
+String RTL_433Config_webWhitelist() {
+  String html = "<p><label><input id='rwe' name='rwe' type='checkbox' ";
+  html += RTL_433WhitelistEnabled ? "checked" : "";
+  html += "> RTL_433 Whitelist enabled</label></p>";
+  html += "<input type='hidden' name='rwlsave' value='1'>";
+  html += "<p><b>RTL_433 Whitelist devices</b></p>";
+  if (RTL_433seenDevices.empty()) {
+    html += "<p>No RTL_433 devices seen yet</p>";
+  }
+  uint8_t index = 0;
+  for (std::vector<RTL_433seenDevice*>::iterator it = RTL_433seenDevices.begin(); it != RTL_433seenDevices.end() && index < RTL_433_SEEN_MAX; ++it) {
+    RTL_433seenDevice* device = *it;
+    String escapedId = htmlEscape(device->deviceId);
+    html += "<p><label><input type='checkbox' name='rwl";
+    html += String(index);
+    html += "' value='";
+    html += escapedId;
+    html += "' ";
+    html += RTL_433Config_isWhitelisted(device->deviceId) ? "checked" : "";
+    html += "> ";
+    html += escapedId;
+    if (device->modelName[0]) {
+      html += " (";
+      html += htmlEscape(device->modelName);
+      html += ")";
+    }
+    html += "</label></p>";
+    index++;
+  }
+  for (uint8_t i = 0; i < RTL_433_WHITELIST_MAX; i++) {
+    if (!RTL_433Whitelist[i][0]) {
+      continue;
+    }
+    bool alreadyListed = false;
+    for (std::vector<RTL_433seenDevice*>::iterator it = RTL_433seenDevices.begin(); it != RTL_433seenDevices.end(); ++it) {
+      if (strcmp((*it)->deviceId, RTL_433Whitelist[i]) == 0) {
+        alreadyListed = true;
+        break;
+      }
+    }
+    if (alreadyListed) {
+      continue;
+    }
+    String escapedId = htmlEscape(RTL_433Whitelist[i]);
+    html += "<p><label><input type='checkbox' name='rwlm";
+    html += String(i);
+    html += "' value='";
+    html += escapedId;
+    html += "' checked> ";
+    html += escapedId;
+    html += " (not seen in this session)</label></p>";
+  }
+  return html;
+}
+
 #  ifdef ZmqttDiscovery
 SemaphoreHandle_t semaphorecreateOrUpdateDeviceRTL_433;
 std::vector<RTL_433device*> RTL_433devices;
 int newRTL_433Devices = 0;
 
 static RTL_433device NO_RTL_433_DEVICE_FOUND = {{0},
-                                                0,
+                                                {0},
+                                                {0},
+                                                {0},
                                                 false};
 
 RTL_433device* getDeviceById(const char* id); // Declared here to avoid pre-compilation issue (misplaced auto declaration by pio)
@@ -68,13 +276,14 @@ void dumpRTL_433Devices() {
   for (std::vector<RTL_433device*>::iterator it = RTL_433devices.begin(); it != RTL_433devices.end(); ++it) {
     RTL_433device* p = *it;
     DISCOVERY_TRACE_LOG(F("uniqueId %s" CR), p->uniqueId);
+    DISCOVERY_TRACE_LOG(F("deviceId %s" CR), p->deviceId);
     DISCOVERY_TRACE_LOG(F("modelName %s" CR), p->modelName);
     DISCOVERY_TRACE_LOG(F("type %s" CR), p->type);
     DISCOVERY_TRACE_LOG(F("isDisc %d" CR), p->isDisc);
   }
 }
 
-void createOrUpdateDeviceRTL_433(const char* id, const char* model, const char* type, uint8_t flags) {
+void createOrUpdateDeviceRTL_433(const char* id, const char* deviceId, const char* model, const char* type, uint8_t flags) {
   if (xSemaphoreTake(semaphorecreateOrUpdateDeviceRTL_433, pdMS_TO_TICKS(30000)) == pdFALSE) {
     THEENGS_LOG_ERROR(F("[rtl_433] semaphorecreateOrUpdateDeviceRTL_433 Semaphore NOT taken" CR));
     return;
@@ -87,6 +296,9 @@ void createOrUpdateDeviceRTL_433(const char* id, const char* model, const char* 
     device = new RTL_433device();
     if (strlcpy(device->uniqueId, id, uniqueIdSize) > uniqueIdSize) {
       THEENGS_LOG_WARNING(F("[rtl_433] Device id %s exceeds available space" CR), id); // Remove from production release ?
+    };
+    if (strlcpy(device->deviceId, deviceId, uniqueIdSize) > uniqueIdSize) {
+      THEENGS_LOG_WARNING(F("[rtl_433] Device base id %s exceeds available space" CR), deviceId); // Remove from production release ?
     };
     if (strlcpy(device->modelName, model, modelNameSize) > modelNameSize) {
       THEENGS_LOG_WARNING(F("[rtl_433] Device model %s exceeds available space" CR), model); // Remove from production release ?
@@ -124,6 +336,10 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
   for (std::vector<RTL_433device*>::iterator it = localDevices.begin(); it != localDevices.end(); ++it) {
     RTL_433device* pdevice = *it;
     DISCOVERY_TRACE_LOG(F("Device id %s" CR), pdevice->uniqueId);
+    if (RTL_433WhitelistEnabled && !RTL_433Config_isWhitelisted(pdevice->deviceId)) {
+      DISCOVERY_TRACE_LOG(F("Device skipped by whitelist %s" CR), pdevice->deviceId);
+      continue;
+    }
     // Do not launch discovery for the RTL_433devices already discovered (unless we have overrideDiscovery) or that are not unique by their MAC Address (Ibeacon, GAEN and Microsoft Cdp)
     if (overrideDiscovery || !isDiscovered(pdevice)) {
       size_t numRows = sizeof(parameters) / sizeof(parameters[0]);
@@ -244,7 +460,7 @@ void launchRTL_433Discovery(bool overrideDiscovery) {
   }
 }
 
-void storeRTL_433Discovery(JsonObject& RFrtl_433_ESPdata, const char* model, const char* type, const char* uniqueid) {
+void storeRTL_433Discovery(JsonObject& RFrtl_433_ESPdata, const char* model, const char* type, const char* uniqueid, const char* rawDeviceId) {
   //Sanitize model name
   String modelSanitized = model;
   modelSanitized.replace(" ", "_");
@@ -258,7 +474,7 @@ void storeRTL_433Discovery(JsonObject& RFrtl_433_ESPdata, const char* model, con
   for (int i = 0; i < numRows; i++) {
     if (RFrtl_433_ESPdata.containsKey(parameters[i][0])) {
       String key_id = String(uniqueid) + "-" + String(parameters[i][0]);
-      createOrUpdateDeviceRTL_433((char*)key_id.c_str(), (char*)modelSanitized.c_str(), (char*)type, device_flags_init);
+      createOrUpdateDeviceRTL_433((char*)key_id.c_str(), rawDeviceId, (char*)modelSanitized.c_str(), (char*)type, device_flags_init);
     }
   }
 }
@@ -295,13 +511,19 @@ void rtl_433_Callback(char* message) {
   topic = topic + "/" + uniqueid;
 #  endif
 
+  String rawDeviceId = uniqueid;
   uniqueid.replace("/", "-");
 
   DISCOVERY_TRACE_LOG(F("uniqueid: %s" CR), uniqueid.c_str());
+  RTL_433Config_storeSeenDevice(rawDeviceId.c_str(), model.c_str(), type.c_str());
+  if (RTL_433WhitelistEnabled && !RTL_433Config_isWhitelisted(rawDeviceId.c_str())) {
+    THEENGS_LOG_TRACE(F("[rtl_433] Message skipped by whitelist: %s" CR), rawDeviceId.c_str());
+    return;
+  }
   if (!isAduplicateSignal(MQTTvalue)) {
 #  ifdef ZmqttDiscovery
     if (SYSConfig.discovery)
-      storeRTL_433Discovery(RFrtl_433_ESPdata, (char*)model.c_str(), (char*)type.c_str(), (char*)uniqueid.c_str());
+      storeRTL_433Discovery(RFrtl_433_ESPdata, (char*)model.c_str(), (char*)type.c_str(), (char*)uniqueid.c_str(), (char*)rawDeviceId.c_str());
 #  endif
     RFrtl_433_ESPdata["origin"] = (char*)topic.c_str();
     enqueueJsonObject(RFrtl_433_ESPdata);
@@ -313,6 +535,7 @@ void rtl_433_Callback(char* message) {
 }
 
 void setupRTL_433() {
+  RTL_433Config_load();
   rtl_433.setCallback(rtl_433_Callback, messageBuffer, JSON_MSG_BUFFER);
 #  ifdef ZmqttDiscovery
   semaphorecreateOrUpdateDeviceRTL_433 = xSemaphoreCreateBinary();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -366,6 +366,7 @@ void handle_autodiscovery() {
 #  ifdef ZgatewayRTL_433
     launchRTL_433Discovery(true);
 #  endif
+    stateMeasures();
   }
 
   connectedOnce = true;
@@ -2817,6 +2818,10 @@ String stateMeasures() {
 #ifdef ZmqttDiscovery
   SYSdata["disc"] = SYSConfig.discovery;
 #endif
+#ifdef ZgatewayRTL_433
+  JsonObject SYSobject = SYSdata.as<JsonObject>();
+  RTL_433Config_addState(SYSobject);
+#endif
   SYSdata["env"] = ENV_NAME;
   uint32_t freeMem;
   uint32_t minFreeMem;
@@ -3648,8 +3653,16 @@ void XtoSYS(const char* topicOri, JsonObject& SYSdata) { // json object decoding
       }
       THEENGS_LOG_NOTICE(F("Discovery state: %T" CR), SYSConfig.discovery);
     }
+#ifdef ZgatewayRTL_433
+    if (RTL_433Config_fromJson(SYSdata)) {
+      publishState = true;
+    }
+#endif
     if (SYSdata.containsKey("save") && SYSdata["save"].as<bool>()) {
       SYSConfig_save();
+#ifdef ZgatewayRTL_433
+      RTL_433Config_save();
+#endif
     }
     if (publishState) {
       stateMeasures();

--- a/main/mqttDiscovery.cpp
+++ b/main/mqttDiscovery.cpp
@@ -727,6 +727,9 @@ void pubMqttDiscovery() {
 #  endif
       // Switch with state_on/state_off
       {HASS_TYPE_SWITCH, "SYS: Auto discovery", "disc", "", "{{ value_json.disc }}", "{\"disc\":true,\"save\":true}", "{\"disc\":false,\"save\":true}", "", stateClassNone, "false", "true", nullptr, subjectMQTTtoSYSset},
+#  ifdef ZgatewayRTL_433
+      {HASS_TYPE_SWITCH, "RTL_433: Whitelist", "rtl433wle", "", "{{ value_json.rtl433wle }}", "{\"rtl433wle\":true,\"save\":true}", "{\"rtl433wle\":false,\"save\":true}", "", stateClassNone, "false", "true", nullptr, subjectMQTTtoSYSset},
+#  endif
       // Buttons
       {HASS_TYPE_BUTTON, "SYS: Restart gateway", "restart", HASS_CLASS_RESTART, "", "{\"cmd\":\"restart\"}", "", "", stateClassNone, nullptr, nullptr, will_Topic, subjectMQTTtoSYSset},
       {HASS_TYPE_BUTTON, "SYS: Erase credentials", "erase", "", "", "{\"cmd\":\"erase\"}", "", "", stateClassNone, nullptr, nullptr, will_Topic, subjectMQTTtoSYSset},

--- a/main/webUI.cpp
+++ b/main/webUI.cpp
@@ -1310,6 +1310,7 @@ void handleLA() {
 #  elif defined(ZgatewayRTL_433) || defined(ZgatewayPilight) || defined(ZgatewayRF) || defined(ZgatewayRF2) || defined(ZactuatorSomfy)
 #    include <map>
 
+#    include "config_RF.h"
 #    include "rf/RFConfiguration.h"
 std::map<int, String> activeReceiverOptions = {
     {0, "Inactive"},
@@ -1401,6 +1402,20 @@ void handleRF() {
         WEBtoRF["rssithreshold"] = iRFConfig.getRssiThreshold();
         update = true;
       }
+#    ifdef ZgatewayRTL_433
+      if (server.hasArg("rwlsave")) {
+        RTL_433Config_setWhitelistEnabled(server.hasArg("rwe"));
+        RTL_433Config_clearWhitelist();
+        for (uint8_t i = 0; i < server.args(); i++) {
+          if (server.argName(i).startsWith("rwl") && server.argName(i) != "rwlsave") {
+            RTL_433Config_addWhitelistId(server.arg(i).c_str());
+          }
+        }
+        RTL_433Config_save();
+        stateMeasures();
+        update = true;
+      }
+#    endif
       if (update) {
         THEENGS_LOG_NOTICE(F("[WebUI] Save data" CR));
         WEBtoRF["save"] = true;
@@ -1412,6 +1427,10 @@ void handleRF() {
   }
 
   String activeReceiverHtml = generateActiveReceiverOptions(iRFConfig.getActiveReceiver());
+  String rtl433WhitelistHtml = "";
+#    ifdef ZgatewayRTL_433
+  rtl433WhitelistHtml = RTL_433Config_webWhitelist();
+#    endif
 
   char jsonChar[100];
   serializeJson(modules, jsonChar, measureJson(modules) + 1);
@@ -1419,7 +1438,7 @@ void handleRF() {
   sendHeaderChunk((String(gateway_name) + " - Configure RF").c_str());
   server.sendContent(script);
   server.sendContent(style);
-  sendBodyChunk(config_rf_body, jsonChar, gateway_name, iRFConfig.getFrequency(), activeReceiverHtml.c_str());
+  sendBodyChunk(config_rf_body, jsonChar, gateway_name, iRFConfig.getFrequency(), activeReceiverHtml.c_str(), rtl433WhitelistHtml.c_str());
   sendFooterChunk();
 }
 #  endif


### PR DESCRIPTION
## Summary

This PR adds an optional whitelist for the RTL_433 gateway.

When enabled, only RTL_433 devices whose generated device identifier is present in the whitelist are published to MQTT. Non-whitelisted RTL_433 messages are ignored. The whitelist is persisted in preferences and can be managed from the WebUI RF configuration page or through MQTT SYS commands.

The Home Assistant MQTT discovery payload also exposes a gateway switch to enable or disable the RTL_433 whitelist.

## Details

- Adds persistent RTL_433 whitelist configuration
- Uses the RTL_433 device identifier format: `type/model/subtype/channel/id`
- Tracks seen RTL_433 devices during runtime so they can be selected from the WebUI
- Filters MQTT publishing and RTL_433 discovery when the whitelist is enabled
- Adds `RTL_433: Whitelist` switch to Home Assistant discovery
- Publishes whitelist state in the SYS state topic

## Testing

Built successfully with PlatformIO:

- `esp32dev-rtl_433`
- `lilygo-rtl_433`

Also tested on an ESP32 + CC1101 setup receiving 433 MHz weather sensor data.
