### PR TITLE
[BT] Default BLE AES key empty, skip decryption without a key

### DIFF
--- a/main/User_config.h
+++ b/main/User_config.h
@@ -695,7 +695,8 @@ void storeSignalValue(uint64_t);
 #      define JSON_BLE_AES_CUSTOM_KEYS 256 // 42 byte BLE Custom Key * 6 rounded up to 256.
 #    endif
 #    ifndef BLE_AES
-#      define BLE_AES "00112233445566778899001122334455"
+#      define BLE_AES "" // Runtime default for ble_aes[]. Empty = no default; override
+                        // at build time with -DBLE_AES='"<32-hex-key>"' to ship one.
 #    endif
 #  endif
 #endif

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -694,9 +694,10 @@ void storeSignalValue(uint64_t);
 #    ifndef JSON_BLE_AES_CUSTOM_KEYS
 #      define JSON_BLE_AES_CUSTOM_KEYS 256 // 42 byte BLE Custom Key * 6 rounded up to 256.
 #    endif
+// Runtime default for ble_aes[]. Empty = no default; override at build time
+// with -DBLE_AES='"<32-hex-key>"' to ship a stock key.
 #    ifndef BLE_AES
-#      define BLE_AES "" // Runtime default for ble_aes[]. Empty = no default; override
-                        // at build time with -DBLE_AES='"<32-hex-key>"' to ship one.
+#      define BLE_AES ""
 #    endif
 #  endif
 #endif

--- a/main/config_WebContent.h
+++ b/main/config_WebContent.h
@@ -294,8 +294,7 @@ const char config_ble_body_decoder[] =
 const char config_ble_body_encrypt[] =
     "<hr><p><b>Encryption</b></p>"
     "<p><b>BLE AES Default Key (32 char hex)</b></p>"
-    "<input id='bk' name='bk' minlength='32' maxlength='32' placeholder=" BLE_AES
-    " value='%s'>"
+    "<input id='bk' name='bk' minlength='32' maxlength='32' placeholder='00112233445566778899001122334455' value='%s'>"
     "<hr><p><b>BLE Key Pairs</b></p>"
     "<p>MacAddress:AESKey with space separator</p>"
     "<p><textarea id='kp' name='kp' placeholder='A4C138012345:00112233445566778899001122334455' rows='3' cols='46'>%s</textarea></p>";

--- a/main/gatewayBT.cpp
+++ b/main/gatewayBT.cpp
@@ -1275,9 +1275,14 @@ void process_bledata(JsonObject& BLEdata) {
     if (ble_aes_keys.containsKey(macWOdots)) {
       THEENGS_LOG_TRACE(F("[BLEDecryptor] Custom AES key %s" CR), ble_aes_keys[macWOdots].as<const char*>());
       bleaeskeylength = hexToBytes(ble_aes_keys[macWOdots], bleaeskey, 16);
-    } else {
+    } else if (strlen(ble_aes) >= 32) {
       THEENGS_LOG_TRACE(F("[BLEDecryptor] Default AES key" CR));
       bleaeskeylength = hexToBytes(ble_aes, bleaeskey, 16);
+    } else {
+      // No per-MAC key configured and no default set: skip silently rather
+      // than attempting decryption with a placeholder key.
+      THEENGS_LOG_DEBUG(F("[BLEDecryptor] No AES key configured for %s, skipping" CR), macWOdots.c_str());
+      return;
     }
     // Check AES Key
     if (bleaeskeylength != 16) {

--- a/main/gatewayBT.cpp
+++ b/main/gatewayBT.cpp
@@ -1281,7 +1281,7 @@ void process_bledata(JsonObject& BLEdata) {
     } else {
       // No per-MAC key configured and no default set: skip silently rather
       // than attempting decryption with a placeholder key.
-      THEENGS_LOG_DEBUG(F("[BLEDecryptor] No AES key configured for %s, skipping" CR), macWOdots.c_str());
+      THEENGS_LOG_TRACE(F("[BLEDecryptor] No AES key configured for %s, skipping" CR), macWOdots.c_str());
       return;
     }
     // Check AES Key

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -96,6 +96,10 @@ char gateway_name[parameters_size + 1] = Gateway_Name;
 unsigned long lastDiscovery = 0;
 
 #if BLEDecryptor
+// BLE_AES defaults to "" (see User_config.h) so encrypted PVVX/BTHome/Victron
+// frames are only decrypted when a per-MAC key is configured (ble_aes_keys) or
+// the user enters a default. Sites shipping a stock default key can still set
+// it at build time via -DBLE_AES='"<32-hex-key>"'.
 char ble_aes[parameters_size] = BLE_AES;
 StaticJsonDocument<JSON_BLE_AES_CUSTOM_KEYS> ble_aes_keys;
 #endif


### PR DESCRIPTION
## Description:
Shipping a non-empty default key caused fresh installs to attempt decryption of every encrypted PVVX/BTHome v2/Victron advertisement with the placeholder string from User_config.h. Frames that didn't happen to share that key were silently dropped at the CCM auth step, masking otherwise-decodable devices (notably Victron MPPT) until users found and entered a per-MAC key.

Initialise ble_aes[] to "" and treat an empty default as "no default configured" in the decryption path - mirroring Theengs Gateway, which has no default and skips frames whose MAC has no bindkey. Per-MAC keys in ble_aes_keys still take precedence; the BLE_AES macro remains as the WebUI placeholder hint.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
