### PR TITLE
Fix/wifimanager portal defaults

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -82,6 +82,7 @@ export default defineConfig({
           { text: 'Builds', link: '/upload/builds' },
           { text: 'Gitpod', link: '/upload/gitpod' },
           { text: 'Portal', link: '/upload/portal' },
+          { text: 'Portal HTTP API', link: '/upload/portal-api' },
           { text: 'Advanced Configuration', link: '/upload/advanced-configuration' },
           { text: 'Troubleshoot', link: '/upload/troubleshoot' }
         ]

--- a/docs/upload/portal-api.md
+++ b/docs/upload/portal-api.md
@@ -22,7 +22,7 @@ When the portal is active (no saved credentials, or trigger pressed at boot) the
 | `server`     | MQTT host (≤ 64) | `custom_mqtt_server`            | yes, if non-empty |
 | `port`       | MQTT port        | `custom_mqtt_port`              | yes, if non-empty |
 | `user`       | MQTT username    | `custom_mqtt_user`              | yes, if non-empty |
-| `pass`       | MQTT password    | `custom_mqtt_pass`              | yes, if value differs from compile-time `MQTT_PASS` sentinel |
+| `pass`       | MQTT password    | `custom_mqtt_pass`              | yes, if non-empty *and* value differs from the compile-time `MQTT_PASS` sentinel |
 | `secure`     | `0` / `1`        | `custom_mqtt_secure`            | yes (always) |
 | `validate`   | `0` / `1`        | `custom_validate_cert`          | yes (always) |
 | `cert`       | PEM (≤ 4096 B)   | `custom_mqtt_cert`              | yes, if length > `MIN_CERT_LENGTH` |
@@ -37,7 +37,7 @@ When the portal is active (no saved credentials, or trigger pressed at boot) the
 
 Empty `server` / `port` / `user` / `topic` / `name` / `ota` values are **ignored** rather than persisted. This means a partial POST (e.g. WiFi-only) preserves any pre-flashed defaults instead of clearing them. To intentionally clear a field, this portal API does not currently support it — re-flash with new build defaults or use the WebUI.
 
-The `pass` field uses a sentinel guard instead: the firmware compares to the compile-time `MQTT_PASS` value and persists only when they differ, so an unmodified form (which echoes back the default) does not overwrite an already-stored password.
+The `pass` field combines the empty-check with a sentinel guard: the firmware persists the form value only when it is non-empty *and* differs from the compile-time `MQTT_PASS` sentinel. The sentinel branch prevents an unmodified form (which echoes back the default) from overwriting a stored password; the non-empty branch prevents a partial POST from wiping it.
 
 ## Response and AP teardown
 

--- a/docs/upload/portal-api.md
+++ b/docs/upload/portal-api.md
@@ -1,0 +1,61 @@
+# Configuration portal HTTP API
+
+This page documents the HTTP form fields accepted by the on-device WiFi configuration portal so that companion apps, provisioning scripts, and Home Assistant flows can integrate without reading firmware source.
+
+The portal is implemented on top of [h2zero's WiFiManager fork](https://github.com/h2zero/WiFiManager) and the field declarations live in `main/main.cpp` (see `setup_wifimanager`).
+
+## Endpoint
+
+```
+POST http://<portal-ip>/wifisave
+Content-Type: application/x-www-form-urlencoded
+```
+
+When the portal is active (no saved credentials, or trigger pressed at boot) the device exposes a soft-AP — see [Portal](portal.md) for SSID/password rules.
+
+## Form fields
+
+| Field        | Type             | Source declaration              | Persisted? |
+|--------------|------------------|---------------------------------|------------|
+| `s`          | SSID             | WiFiManager built-in            | yes        |
+| `p`          | WiFi PSK         | WiFiManager built-in            | yes        |
+| `server`     | MQTT host (≤ 64) | `custom_mqtt_server`            | yes, if non-empty |
+| `port`       | MQTT port        | `custom_mqtt_port`              | yes, if non-empty |
+| `user`       | MQTT username    | `custom_mqtt_user`              | yes, if non-empty |
+| `pass`       | MQTT password    | `custom_mqtt_pass`              | yes, if value differs from compile-time `MQTT_PASS` sentinel |
+| `secure`     | `0` / `1`        | `custom_mqtt_secure`            | yes (always) |
+| `validate`   | `0` / `1`        | `custom_validate_cert`          | yes (always) |
+| `cert`       | PEM (≤ 4096 B)   | `custom_mqtt_cert`              | yes, if length > `MIN_CERT_LENGTH` |
+| `ota_cert`   | PEM (≤ 4096 B)   | `custom_ota_server_cert`        | yes, if length > `MIN_CERT_LENGTH` |
+| `client_cert`| PEM              | `custom_client_cert` (signed-client builds only) | yes, if length > `MIN_CERT_LENGTH` |
+| `client_key` | PEM              | `custom_client_key`  (signed-client builds only) | yes, if length > `MIN_CERT_LENGTH` |
+| `topic`      | MQTT base topic  | `custom_mqtt_topic`             | yes, if non-empty (trailing `/` added if missing) |
+| `name`       | Gateway name     | `custom_gateway_name`           | yes, if non-empty |
+| `ota`        | OTA / WebUI password | `custom_ota_pass`           | yes, if non-empty |
+
+## Empty-field semantics
+
+Empty `server` / `port` / `user` / `topic` / `name` / `ota` values are **ignored** rather than persisted. This means a partial POST (e.g. WiFi-only) preserves any pre-flashed defaults instead of clearing them. To intentionally clear a field, this portal API does not currently support it — re-flash with new build defaults or use the WebUI.
+
+The `pass` field uses a sentinel guard instead: the firmware compares to the compile-time `MQTT_PASS` value and persists only when they differ, so an unmodified form (which echoes back the default) does not overwrite an already-stored password.
+
+## Response and AP teardown
+
+After processing the POST, WiFiManager returns a small success page and then tears down the soft-AP to attempt joining the configured station network. The teardown happens quickly enough that the TCP socket may be reset before the HTTP response is fully flushed to the client. Companion apps should:
+
+- Treat a connection reset immediately after the POST as a likely-success signal, not a failure.
+- Verify provisioning by checking for the device on the target network or for its first MQTT LWT message rather than relying on the HTTP response.
+
+## Example
+
+```bash
+curl -X POST \
+  --data-urlencode 's=my-ssid' \
+  --data-urlencode 'p=my-psk' \
+  --data-urlencode 'server=192.168.1.10' \
+  --data-urlencode 'port=1883' \
+  --data-urlencode 'name=kitchen-omg' \
+  --data-urlencode 'ota=mySecret123' \
+  --data-urlencode 'topic=home/' \
+  http://192.168.4.1/wifisave
+```

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2352,17 +2352,28 @@ void setupWiFiManager() {
     cnt_index = CNT_DEFAULT_INDEX;
 #  ifndef WIFIMNG_HIDE_MQTT_CONFIG
 #    if !MQTT_BROKER_MODE
-    strcpy(cnt_parameters_array[cnt_index].mqtt_server, custom_mqtt_server.getValue());
-    strcpy(cnt_parameters_array[cnt_index].mqtt_port, custom_mqtt_port.getValue());
-    strcpy(cnt_parameters_array[cnt_index].mqtt_user, custom_mqtt_user.getValue());
+    // Only persist non-empty values so a partial form submit (for example a
+    // programmatic POST of only s/p) cannot wipe compile-time defaults.
+    // mqtt_pass keeps its existing sentinel-based guard below.
+    if (strlen(custom_mqtt_server.getValue()) > 0) {
+      strcpy(cnt_parameters_array[cnt_index].mqtt_server, custom_mqtt_server.getValue());
+    }
+    if (strlen(custom_mqtt_port.getValue()) > 0) {
+      strcpy(cnt_parameters_array[cnt_index].mqtt_port, custom_mqtt_port.getValue());
+    }
+    if (strlen(custom_mqtt_user.getValue()) > 0) {
+      strcpy(cnt_parameters_array[cnt_index].mqtt_user, custom_mqtt_user.getValue());
+    }
     // Check if the MQTT password field contains the default value
     if (strcmp(custom_mqtt_pass.getValue(), MQTT_PASS) != 0) {
       // If it's not the default password, update the MQTT password
       strcpy(cnt_parameters_array[cnt_index].mqtt_pass, custom_mqtt_pass.getValue());
     }
-    strcpy(mqtt_topic, custom_mqtt_topic.getValue());
-    if (mqtt_topic[strlen(mqtt_topic) - 1] != '/' && strlen(mqtt_topic) < parameters_size) {
-      strcat(mqtt_topic, "/");
+    if (strlen(custom_mqtt_topic.getValue()) > 0) {
+      strcpy(mqtt_topic, custom_mqtt_topic.getValue());
+      if (mqtt_topic[strlen(mqtt_topic) - 1] != '/' && strlen(mqtt_topic) < parameters_size) {
+        strcat(mqtt_topic, "/");
+      }
     }
 
     cnt_parameters_array[cnt_index].isConnectionSecure = *custom_mqtt_secure.getValue();
@@ -2382,8 +2393,12 @@ void setupWiFiManager() {
     }
 #      endif
 #    endif
-    strcpy(gateway_name, custom_gateway_name.getValue());
-    strcpy(ota_pass, custom_ota_pass.getValue());
+    if (strlen(custom_gateway_name.getValue()) > 0) {
+      strcpy(gateway_name, custom_gateway_name.getValue());
+    }
+    if (strlen(custom_ota_pass.getValue()) > 0) {
+      strcpy(ota_pass, custom_ota_pass.getValue());
+    }
 #  endif
 
 #  if !MQTT_BROKER_MODE

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2364,9 +2364,11 @@ void setupWiFiManager() {
     if (strlen(custom_mqtt_user.getValue()) > 0) {
       strcpy(cnt_parameters_array[cnt_index].mqtt_user, custom_mqtt_user.getValue());
     }
-    // Check if the MQTT password field contains the default value
-    if (strcmp(custom_mqtt_pass.getValue(), MQTT_PASS) != 0) {
-      // If it's not the default password, update the MQTT password
+    // Persist the MQTT password only when the form supplied a non-empty value
+    // that also differs from the compile-time MQTT_PASS sentinel. An empty
+    // value (partial / programmatic POST) must not wipe the stored password.
+    if (strlen(custom_mqtt_pass.getValue()) > 0 &&
+        strcmp(custom_mqtt_pass.getValue(), MQTT_PASS) != 0) {
       strcpy(cnt_parameters_array[cnt_index].mqtt_pass, custom_mqtt_pass.getValue());
     }
     if (strlen(custom_mqtt_topic.getValue()) > 0) {


### PR DESCRIPTION
## Description:
Don't clobber MQTT/portal defaults with empty /wifisave form fields
  Problem
  saveConfigCallback in main/main.cpp unconditionally strcpys every form value into the persisted config. If a provisioning client (companion app, HA flow, curl) POSTs only a subset of fields, the empty getValue() returns silently wipe the compile-time MQTT defaults: the DUT joins WiFi but never reaches the broker.
  The pre-existing mqtt_pass sentinel guard (strcmp(value, MQTT_PASS) != 0) shared the same shape of bug — an empty value differs from the sentinel, so a partial POST also wiped the stored password.

  Fix
  Add strlen(value) > 0 guards to every textual field in the shouldSaveConfig block: mqtt_server, mqtt_port, mqtt_user, mqtt_pass (combined with the existing sentinel check), mqtt_topic, gateway_name, ota_pass. Checkbox + cert fields already had non-empty guards.

  Verification
  Verified end-to-end on a HIL bench:
  - POST only s+p to /wifisave on a flashed wifimgr build
  - Pre-fix: LWT never appears within a 600 s budget
  - Post-fix: LWT-online lands within the reconnect window using the compile-time MQTT defaults

  Also in this PR
  - New docs page docs/upload/portal-api.md documenting the /wifisave form fields, the empty-field ignore semantics, and the AP-teardown response race that callers must tolerate.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
