### PR TITLE
[BT] Reset BTProcessLock when immediateBTAction can't take the device…

### DIFF
--- a/main/gatewayBT.cpp
+++ b/main/gatewayBT.cpp
@@ -1692,6 +1692,10 @@ void immediateBTAction(void* pvParameters) {
         xSemaphoreGive(semaphoreCreateOrUpdateDevice);
       } else {
         THEENGS_LOG_ERROR(F("CreateOrUpdate Semaphore NOT taken" CR));
+        // Release the process lock we took above; otherwise a transient
+        // semaphore-contention failure here leaves BTProcessLock=true and
+        // wedges the BLE scanner/connect subsystem until a restart.
+        BTProcessLock = false;
       }
 
       // If we stopped the scheduled connect for this action, do the scheduled now


### PR DESCRIPTION
## Description:
immediateBTAction() sets BTProcessLock=true and stops the scan before an outbound BLE action, and resets it on the success path and the "BLE busy" path — but the branch where semaphoreCreateOrUpdateDevice can't be taken left it true. Under scan contention that wedges the BLE scanner/connect subsystem until a restart (same BTProcessLock-mishandling family as the long-uptime NimBLE scanner hang). Reset it on that branch too.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
