### PR TITLE
Fix esp32dev-multi_receiver build on ESP32-C3 (missing soc/sens_reg.h)

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -1236,7 +1236,7 @@ custom_hardware = ESP32 LILYGO LoRa32 V2.1
 
 [env:esp32dev-multi_receiver]
 platform = espressif32@6.1.0
-board = esp32dev
+board = esp32-c3-devkitm-1
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
@@ -1258,6 +1258,7 @@ build_flags =
   '-DRF_MODULE_GDO0=12'   ; CC1101 pin GDO0
   '-DRF_MODULE_GDO2=27'   ; CC1101 pin GDO2
 ;  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
+  '-DNO_INT_TEMP_READING'  ; soc/sens_reg.h not available on ESP32-C3
 custom_description = Multi RF library with the possibility to switch between RTL_433_ESP, NewRemoteSwitch and RCSwitch, need CC1101
 
 [env:esp32dev-multi_receiver-pilight]


### PR DESCRIPTION
## Description:

`soc/sens_reg.h` is not present in the ESP32-C3 SDK (only available on ESP32, ESP32-S2, and ESP32-S3). The `esp32dev-multi_receiver` environment targets `esp32-c3-devkitm-1`, so the internal temperature reading code that includes this header fails to compile.

Adding `-DNO_INT_TEMP_READING` to the environment's `build_flags` skips that code path and restores a successful build.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).