### PR TITLE
[DOCS] Remove dead compatible.openmqttgateway.com links (#2205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Support open-source development through sponsorship and gain exclusive access to
 ### Theengs Plug, Bluetooth gateway (BLE) gateway and Smart Plug
 
 [Theengs plug](https://shop.theengs.io/products/theengs-plug-smart-plug-ble-gateway-and-energy-consumption) brings the following features:
-* BLE to MQTT gateway, tens of [Bluetooth devices](https://compatible.openmqttgateway.com/index.php/devices/ble-devices/) supported thanks to Theengs Decoder library. The plug uses an ESP32 acting as a BLE to Wifi gateway to scan, decode and forward the data of the nearby sensors,
+* BLE to MQTT gateway, tens of [Bluetooth devices](https://decoder.theengs.io/devices/devices.html) supported thanks to Theengs Decoder library. The plug uses an ESP32 acting as a BLE to Wifi gateway to scan, decode and forward the data of the nearby sensors,
 * Smart plug that can be controlled remotely,
 * Energy consumption monitoring,
 * Device tracker,
@@ -47,14 +47,14 @@ Support the project by purchasing the [Theengs bridge](https://shop.theengs.io/p
 
 ## Compatible items
 
-* [List of supported devices](https://compatible.openmqttgateway.com/index.php/devices/), door/window sensors, PIR sensors, smoke detectors, weather stations...
+* [List of supported devices](https://docs.openmqttgateway.com/prerequisites/devices.html), door/window sensors, PIR sensors, smoke detectors, weather stations...
 
-* [List of compatible boards (Off the shelf or DIY) is available](https://compatible.openmqttgateway.com/index.php/boards/), RF Bridge, IR, BLE gateways...
+* [List of compatible boards (Off the shelf or DIY) is available](https://docs.openmqttgateway.com/prerequisites/board.html), RF Bridge, IR, BLE gateways...
 
 *Running on a computer*
 If you want to use the BLE decoding capabilities of OpenMQTTGateway with a Raspberry Pi, Windows or Unix PC you can now leverage [Theengs Gateway](https://theengs.github.io/gateway/).
 
-* [List of compatible components to build your gateway](https://compatible.openmqttgateway.com/index.php/parts/), DHT, RF, IR emitters and receivers...
+* [List of compatible components to build your gateway](https://docs.openmqttgateway.com/prerequisites/parts.html), DHT, RF, IR emitters and receivers...
 
 ## Compatible controllers, saas or software
 
@@ -79,7 +79,7 @@ For Questions or Support please don't open an issue, first go to the [docs](http
 If you like the project and/or used it please consider supporting it! It can be done in different ways:
 * Helping other users in the [community](https://community.openmqttgateway.com)
 * [Contribute](development) to the [code](https://github.com/1technophile/OpenMQTTGateway) or the [documentation](https://docs.openmqttgateway.com)
-* Buy devices, boards or parts from the [compatible web site](https://compatible.openmqttgateway.com), the devices and parts linked use affiliated links.
+* Buy a [Theengs plug](https://shop.theengs.io/products/theengs-plug-smart-plug-ble-gateway-and-energy-consumption) or a [Theengs bridge](https://shop.theengs.io/products/theengs-bridge-esp32-ble-mqtt-gateway-with-ethernet-and-external-antenna)
 * Donate or sponsor the project [developers](https://github.com/1technophile/OpenMQTTGateway/graphs/contributors)
 * Make a video or a blog article about what you have done with [OpenMQTTGateway](https://docs.openmqttgateway.com) and share it to the [community](https://community.openmqttgateway.com)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,9 +39,9 @@ In essence, an MQTT gateway ensures smooth communication between devices and MQT
 OpenMQTTGateway integrates with established technologies, such as 433mhz/315mhz protocols and infrared (IR), allowing you to upgrade and repurpose older devices. Additionally, OMG is compatible with modern technologies like Bluetooth Low Energy (BLE) and LoRa.
 
 To have an overview of the supported PIR, door, water, temperature, smoke sensors, sirens, rings, beacons, switches & weather stations you can take a look to the 
-[compatible devices list](https://compatible.openmqttgateway.com/index.php/devices)
+[compatible devices list](prerequisites/devices.md)
 
-You can run OpenMQTTGateway on a wide variety of [boards](https://compatible.openmqttgateway.com/index.php/boards/), ESP32, ESP8266, ESP32S3, ESP32C3.
+You can run OpenMQTTGateway on a wide variety of [boards](prerequisites/board.md), ESP32, ESP8266, ESP32S3, ESP32C3.
 BLE to MQTT gateway can also run on Raspberry Pi, Windows or Unix computers thanks to [Theengs Gateway](https://theengs.github.io/gateway/).
 
 Using MQTT, you can seamlessly integrate with home automation platforms such as OpenHAB, Home Assistant, and others, or with IoT software like Node-Red.
@@ -98,7 +98,7 @@ Support open-source development through sponsorship and gain exclusive access to
 ### Theengs Plug, BLE gateway and Smart Plug
 
 [Theengs plug](https://shop.theengs.io/products/theengs-plug-smart-plug-ble-gateway-and-energy-consumption) brings the following features:
-* BLE to MQTT gateway, tens of [Bluetooth devices](https://compatible.openmqttgateway.com/index.php/devices/ble-devices/) supported thanks to Theengs Decoder library. The plug uses an ESP32 acting as a BLE to Wifi gateway to scan, decode and forward the data of the nearby sensors,
+* BLE to MQTT gateway, tens of [Bluetooth devices](https://decoder.theengs.io/devices/devices.html) supported thanks to Theengs Decoder library. The plug uses an ESP32 acting as a BLE to Wifi gateway to scan, decode and forward the data of the nearby sensors,
 * Smart plug that can be controlled remotely,
 * Energy consumption monitoring,
 * Device tracker,

--- a/docs/participate/support.md
+++ b/docs/participate/support.md
@@ -12,7 +12,6 @@ If you like the project, you can help in different ways. Choose what fits you be
 
 ## Financial support
 - Purchase the [Theengs mobile application](https://app.theengs.io) or the [Theengs plug](https://shop.theengs.io).
-- Buy devices or parts via the [compatible web site](https://compatible.openmqttgateway.com) (affiliate links help the project).
 - Sponsor the project [developers](https://github.com/1technophile/OpenMQTTGateway/graphs/contributors).
 - Make a video or blog article about what you built with [OpenMQTTGateway](https://docs.openmqttgateway.com) and share it.
 

--- a/docs/prerequisites/board.md
+++ b/docs/prerequisites/board.md
@@ -6,8 +6,6 @@ aside: false
 
 OpenMQTTGateway is not closed to one board or type of board, by using the power of the Arduino framework and libraries that are cross compatibles it let you many choice of hardware, from an ESP8266 to an ESP32.
 
-You can take a look to the [OpenMQTTGateway compatible website](https://compatible.openmqttgateway.com) to have a view of the [supported boards](https://compatible.openmqttgateway.com/index.php/boards/).
-
 Moreover the gateways capacities can be extended with sensors; DHT, HC SR501, ADC, I2C bus, INA226, MQ2, TEMT6000, TSL2561, BME280/BMP280, HTU21D, AHTx0, DS1820
 or actuators; LED, relays, PWM.
 
@@ -45,7 +43,6 @@ Support the project by purchasing the [Theengs bridge](https://shop.theengs.io/p
 The plug is available in North America only, other regions are planned.
 
 Choosing your board depends heavily on the technologies you want to use with it.
-To have a good overview of the compatibilities per board you can refer to the compatible modules attributes of each [board](https://compatible.openmqttgateway.com/index.php/boards/).
 
 The choice between these boards will depend on your knowledge and your requirements in terms of reliability, situation, modules wanted and devices you already have. Use the table below to explore the latest environments.
 

--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -1,8 +1,6 @@
 # Devices
 
-You can take a look to the [OpenMQTTGateway compatible website](https://compatible.openmqttgateway.com) to have a view of the [supported devices](https://compatible.openmqttgateway.com/index.php/devices/).
-
-Added to that is an overview of devices supported by OpenMQTTGateway:
+Here is an overview of devices supported by OpenMQTTGateway:
 
 ## For radio frequency devices 
 OpenMQTTGateway can support a wide range of 433mhz/315mhz devices, all the ones with SC5262 / SC5272, HX2262 / HX2272, PT2262 / PT2272, EV1527, RT1527, FP1527, HS1527 chipsets are supported by the RF gateway. Added to that RF2 support Kaku and Pilight an [huge list](https://wiki.pilight.org/devices). 

--- a/docs/prerequisites/parts.md
+++ b/docs/prerequisites/parts.md
@@ -1,8 +1,6 @@
 # Parts
 Depending on the gateway you would like to setup and your board, you may need extra parts/module to add.
 
-You can take a look to the [OpenMQTTGateway compatible website](https://compatible.openmqttgateway.com) to have a view of the [supported parts](https://compatible.openmqttgateway.com/index.php/parts/).
-
 Here is below the main parts reference.
 
 ## Main parts 
@@ -15,5 +13,5 @@ Here is below the main parts reference.
 |A6/A7|-|-|-|-|X|
 
 ::: tip
-There is a wide range of parts available that may be compatible with OpenMQTTGateway, the ones [listed](https://compatible.openmqttgateway.com/index.php/parts/) are the ones tested and for which you can ask for support. Indeed for other parts we may not have it so as to reproduce the issue, or in the worst case they may not be compatible.
+There is a wide range of parts available that may be compatible with OpenMQTTGateway, the ones listed above are the ones tested and for which you can ask for support. Indeed for other parts we may not have it so as to reproduce the issue, or in the worst case they may not be compatible.
 :::

--- a/docs/setitup/actuators.md
+++ b/docs/setitup/actuators.md
@@ -2,10 +2,10 @@
 ## Compatible parts 
 |Module|Purpose|Where to Buy|
 |-|-|-|
-|LED|Basic led|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|FASTLED|RGB Leds management|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|BUZZER|-|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|RELAY|Switch power circuit|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|LED|Basic led|-|
+|FASTLED|RGB Leds management|-|
+|BUZZER|-|-|
+|RELAY|Switch power circuit|-|
 
 ## Pinout
 |Module| Boards|

--- a/docs/setitup/gsm.md
+++ b/docs/setitup/gsm.md
@@ -3,8 +3,8 @@
 
 |Module|Purpose|Where to Buy|
 |-|-|-|
-|A6|GSM GPRS module|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|A7|GSM GPRS module with GPS|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|A6|GSM GPRS module|-|
+|A7|GSM GPRS module with GPS|-|
 
 ## Hardware setup
 

--- a/docs/setitup/ir.md
+++ b/docs/setitup/ir.md
@@ -2,11 +2,11 @@
 ## Compatible parts
 |Module|Purpose|Where to Buy|
 |-|-|-|
-|IR diode|Emitting|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|IR receiver|Receiving|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|IR diode|Emitting|-|
+|IR receiver|Receiving|-|
 |transistor 2N2222|Amplify uC signal for the IR diode|-|
-|330 ohms resistor|-|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|220 ohms resistor|limit current to LED|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|330 ohms resistor|-|-|
+|220 ohms resistor|limit current to LED|-|
 
 The IR setup can work with bc547 and a 4x3 LED-Matrix.
 

--- a/docs/setitup/lora.md
+++ b/docs/setitup/lora.md
@@ -1,6 +1,6 @@
 # LoRa gateway
 ## Compatible parts
 An ESP32 board with a LoRa module.
-Ideally a TTGO board with LoRa module included see [compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)
+Ideally a TTGO board with LoRa module included.
 
 With this kind of board there is no hardware modification needed.

--- a/docs/setitup/rf.md
+++ b/docs/setitup/rf.md
@@ -23,11 +23,11 @@ Heltec LORA V3 is not compatible with RTL_433 library as it is based on an SX126
 ## Assembly/soldering required parts
 |Module|Purpose|Compatible modules|Receiver Switching|Where to Buy|
 |-|-|-|-|-|
-|SRX882 or SRX882S (recommended)|433Mhz Receiver|RF(RCSwitch), RF2(KaKu), Pilight|Supported|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|STX882 (recommended)|433Mhz Transmitter|RF(RCSwitch), RF2(KaKu), Pilight|Supported|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|CC1101|433Mhz Transceiver|[RTL_433](../use/rf#supported-decoders), RF(RCSwitch), RF2(KaKu), Pilight|Supported|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|SX1276/SX1278|433Mhz Transceiver|[RTL_433](../use/rf#supported-decoders)|Not Supported|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|LilyGo/Heltec|433Mhz Transceiver|[RTL_433](../use/rf#supported-decoders)|Not Supported|[compatible parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|SRX882 or SRX882S (recommended)|433Mhz Receiver|RF(RCSwitch), RF2(KaKu), Pilight|Supported|-|
+|STX882 (recommended)|433Mhz Transmitter|RF(RCSwitch), RF2(KaKu), Pilight|Supported|-|
+|CC1101|433Mhz Transceiver|[RTL_433](../use/rf#supported-decoders), RF(RCSwitch), RF2(KaKu), Pilight|Supported|-|
+|SX1276/SX1278|433Mhz Transceiver|[RTL_433](../use/rf#supported-decoders)|Not Supported|-|
+|LilyGo/Heltec|433Mhz Transceiver|[RTL_433](../use/rf#supported-decoders)|Not Supported|-|
 
 ### SRX STX Pinout
 |Board| Receiver Pin| Emitter Pin|

--- a/docs/setitup/sensors.md
+++ b/docs/setitup/sensors.md
@@ -2,20 +2,20 @@
 ## Compatible sensors
 |Module|Purpose|Where to Buy|
 |-|-|-|
-|DHT11|Temperature, Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|DHT22|Temperature, Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|HCSR501|PIR|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|BH1750|Digital light|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|BME280|Temperature, Humidity, Pressure|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|BMP280|Temperature, Pressure|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|C-37, YL-83, HM-RD|Leak, Water|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|HTU21|Temperature, Humidity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|DHT11|Temperature, Humidity|-|
+|DHT22|Temperature, Humidity|-|
+|HCSR501|PIR|-|
+|BH1750|Digital light|-|
+|BME280|Temperature, Humidity, Pressure|-|
+|BMP280|Temperature, Pressure|-|
+|C-37, YL-83, HM-RD|Leak, Water|-|
+|HTU21|Temperature, Humidity|-|
 |GPIO Input|Inputs|-|
-|GPIO KeyCode|Keycode|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|INA226|Current, Voltage|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|MQ2|Gas (flammable)|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|TEMT6000|Luminosity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
-|TSL2561|Luminosity|[parts list](https://compatible.openmqttgateway.com/index.php/parts)|
+|GPIO KeyCode|Keycode|-|
+|INA226|Current, Voltage|-|
+|MQ2|Gas (flammable)|-|
+|TEMT6000|Luminosity|-|
+|TSL2561|Luminosity|-|
 
 ## Pinout
 |Module|Arduino Pin| ESP8266 Pin|ESP32 Pin|

--- a/docs/use/ble.md
+++ b/docs/use/ble.md
@@ -4,7 +4,7 @@ description: Versatile Bluetooth gateway that scans and decodes data from variou
 ---
 # Bluetooth gateway
 
-The manufacturer agnostic Bluetooth Low Energy (BLE) gateway acts as a powerful BLE scanner and decoder of [Bluetooth devices](https://compatible.openmqttgateway.com/index.php/devices/ble-devices/), allowing you to visualize and analyze information from a wide range of sensors. 
+The manufacturer agnostic Bluetooth Low Energy (BLE) gateway acts as a powerful BLE scanner and decoder of [Bluetooth devices](https://decoder.theengs.io/devices/devices.html), allowing you to visualize and analyze information from a wide range of sensors. 
 It can also act as a device tracker and presence detection gateway by receiving nearby BLE devices and trackers.
 
 Data are transmitted to an MQTT broker, where it can be used to trigger events and rules, as well as displayed, stored and processed in your favorite controller (Home Assistant, OpenHAB, Jeedom, Domoticz, ioBroker or any MQTT compatible software).
@@ -30,7 +30,7 @@ With the ability to monitor and analyze data such as temperature, humidity, mois
 ### Theengs Plug, BLE gateway and Smart Plug
 
 [Theengs plug](https://shop.theengs.io/products/theengs-plug-smart-plug-ble-gateway-and-energy-consumption) brings the following features:
-* BLE to MQTT gateway, tens of [Bluetooth devices](https://compatible.openmqttgateway.com/index.php/devices/ble-devices/) supported thanks to Theengs Decoder library. The plug uses an ESP32 acting as a BLE to Wifi gateway to scan, decode and forward the data of the nearby sensors,
+* BLE to MQTT gateway, tens of [Bluetooth devices](https://decoder.theengs.io/devices/devices.html) supported thanks to Theengs Decoder library. The plug uses an ESP32 acting as a BLE to Wifi gateway to scan, decode and forward the data of the nearby sensors,
 * Smart plug that can be controlled remotely,
 * Energy consumption monitoring,
 * Device tracker,
@@ -72,7 +72,7 @@ Once the data has been transmitted to the MQTT broker, it can be easily integrat
 
 ![Home Assistant chart](../img/OpenMQTTGateway-home-assistant-chart.png)
 
-Examples of compatible sensors among [our list](https://decoder.theengs.io/devices/devices_by_brand.html: Mi Flora, Mi jia, LYWDS02, LYWSD03MMC, ClearGrass, Mi scale, iBBQ, TPMS
+Examples of compatible sensors among [our list](https://decoder.theengs.io/devices/devices_by_brand.html): Mi Flora, Mi jia, LYWDS02, LYWSD03MMC, ClearGrass, Mi scale, iBBQ, TPMS
 
 ## Receiving signals from BLE devices for Device Tracker detection
 The gateway will detect BLE trackers from Tile, Nut, TagIt, iTAG, Gigaset G-Tag, TicWatch GTH (Pro), Teltonika FMT100 vehicle tracker and Bosch Nyon eBike computers, as well as other devices with additional properties decoding like Mi Band, Amazfit, RuuviTag and others indicated as Device Trackers in the [compatible BLE devices list](https://decoder.theengs.io/devices/devices.html), and automatically create a device tracker entity following the Home Assistant discovery convention (if auto discovery is activated).


### PR DESCRIPTION
## Description:
The compatible.openmqttgateway.com site is offline (TLS connection reset), leaving 38 dead links across the docs and README. Repoint BLE device lists to the canonical Theengs Decoder devices page already used by the navbar, point boards/devices/parts references to the corresponding docs pages, and drop the affiliate-site mentions and 'Where to Buy' links that have no live equivalent. Also fix a malformed markdown link in docs/use/ble.md.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
