### PR TITLE
[SYS] Update esp32-arduino-libs to 0.1.4 (BLE-only controller)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -180,7 +180,7 @@ monitor_speed = 115200
 [com]
 esp8266_platform = espressif8266@4.2.1
 esp32_platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.33/platform-espressif32.zip
-esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.3/esp32-arduino-libs.tar.gz
+esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.4/esp32-arduino-libs.tar.gz
 esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 atmelavr_platform = atmelavr@3.3.0
 


### PR DESCRIPTION
## Description:
Bumps the precompiled framework-arduinoespressif32-libs bundle from 0.1.3 to 0.1.4, which builds the esp32 BT controller in BLE-only mode (classic BR/EDR + A2DP/SPP/HFP dropped). OMG's BT stack is NimBLE (a BLE-only host) and never uses classic Bluetooth, so it was unreachable dead weight.

Measured on a no-PSRAM Theengs Plug (esp32, NimBLE, MQTT over TLS):
- flash 89.5% -> 86.7% (-54 KB)
- runtime freemem +~10 KB: the dual-mode controller reserved heap for the classic BR/EDR baseband + 2 classic ACL connections at esp_bt_controller_init(); BLE-only skips it
- BLE scan/decode and GATT connect (BM2/BM6 battery reads, SwitchBot control) validated working

esp32-arduino-lib-builder change: theengs/esp32-arduino-lib-builder mem/esp32-ble-only-controller (in 0.1.4).

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
