### PR TITLE
esp32_platform: update to 55.03.39

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -472,7 +472,7 @@ prepare → build (task-build.yml) → deploy → documentation (task-docs.yml)
 
 **Parameters**:
 - `python-version`: Python version to use (default: '3.13')
-- `pio-version`: PlatformIO version to use (default: 'v6.1.18')
+- `pio-version`: PlatformIO version to use (default: 'v6.1.19')
 - `environment-set`: Which set of environments to build: 'all' or 'ci' (default: 'all')
 - `enable-dev-ota`: Enable development OTA builds (default: false)
 - `version-tag`: Optional version tag to pass to ci.sh build - omitted if empty (default: '')
@@ -501,7 +501,7 @@ prepare → build (task-build.yml) → deploy → documentation (task-docs.yml)
 
 **Technical Details**:
 - Runs on: Ubuntu latest
-- PlatformIO version: Configurable via `pio-version` input (default: v6.1.18, custom fork: `pioarduino/platformio-core`)
+- PlatformIO version: Configurable via `pio-version` input (default: v6.1.19, custom fork: `pioarduino/platformio-core`)
 - Python package manager: `uv` (astral-sh/setup-uv@v6)
 - Environment sets: `all` (complete set) or `ci` (subset for quick validation)
 - Strategy: Matrix with fail-fast: false (builds complete even if one environment fails)
@@ -743,7 +743,7 @@ All build environments are defined in `.github/workflows/environments.json`:
 - Provides consistent CLI across all operations
 
 **Build System** (`ci.sh build`):
-- PlatformIO 6.1.18 from custom fork: `pioarduino/platformio-core`
+- PlatformIO 6.1.19 from custom fork: `pioarduino/platformio-core`
 - Python package manager: `uv` for fast dependency installation
 - Orchestrator: `ci_build.sh`
   - Worker: `ci_build_firmware.sh` (PlatformIO compilation)

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -7,12 +7,12 @@ on:
         description: "Python version to use"
         required: false
         type: string
-        default: "3.13"
+        default: "3.14"
       pio-version:
         description: "PlatformIO version to use"
         required: false
         type: string
-        default: "v6.1.18"
+        default: "v6.1.19"
       environment-set:
         description: 'Which set of environments to build (all, ci)'
         required: false

--- a/.github/workflows/task-docs.yml
+++ b/.github/workflows/task-docs.yml
@@ -47,7 +47,7 @@ on:
         description: "PlatformIO version to use"
         required: false
         type: string
-        default: "v6.1.18"
+        default: "v6.1.19"
     secrets:
       github-token:
         description: "GitHub token for deploying to GitHub Pages"

--- a/environments.ini
+++ b/environments.ini
@@ -293,7 +293,9 @@ custom_description = RF gateway using RCSwitch library
 [env:esp32dev-pilight]
 platform = ${com.esp32_platform}
 platform_packages = ${com.esp32_platform_packages}
-extra_scripts = pre:scripts/add_c_flags.py
+extra_scripts =
+  pre:scripts/add_c_flags.py
+  pre:scripts/add_mlongcalls.py
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
@@ -308,7 +310,9 @@ custom_description = RF gateway using ESPilight library
 [env:esp32dev-pilight-cc1101]
 platform = ${com.esp32_platform}
 platform_packages = ${com.esp32_platform_packages}
-extra_scripts = pre:scripts/add_c_flags.py
+extra_scripts =
+  pre:scripts/add_c_flags.py
+  pre:scripts/add_mlongcalls.py
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
@@ -341,7 +345,9 @@ custom_description = Gateway using Somfy Remote library, need CC1101
 [env:esp32dev-pilight-somfy-cc1101]
 platform = ${com.esp32_platform}
 platform_packages = ${com.esp32_platform_packages}
-extra_scripts = pre:scripts/add_c_flags.py
+extra_scripts =
+  pre:scripts/add_c_flags.py
+  pre:scripts/add_mlongcalls.py
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =
@@ -1264,7 +1270,9 @@ custom_description = Multi RF library with the possibility to switch between RTL
 [env:esp32dev-multi_receiver-pilight]
 platform = ${com.esp32_platform}
 platform_packages = ${com.esp32_platform_packages}
-extra_scripts = pre:scripts/add_c_flags.py
+extra_scripts =
+  pre:scripts/add_c_flags.py
+  pre:scripts/add_mlongcalls.py
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -180,7 +180,7 @@ monitor_speed = 115200
 [com]
 esp8266_platform = espressif8266@4.2.1
 esp32_platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
-esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.4/esp32-arduino-libs.tar.gz
+esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.5/esp32-arduino-libs.tar.gz
 esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 atmelavr_platform = atmelavr@3.3.0
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -179,7 +179,7 @@ monitor_speed = 115200
 
 [com]
 esp8266_platform = espressif8266@4.2.1
-esp32_platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.33/platform-espressif32.zip
+esp32_platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.4/esp32-arduino-libs.tar.gz
 esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 atmelavr_platform = atmelavr@3.3.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -176,11 +176,12 @@ build_flags =
 ;  -E ; generate precompiled source file (.pio/build/*/src/main.ino.cpp.o), use for precompilator debuging only (prevent compilation to succeed)
 ;  '-DLOG_LEVEL=LOG_LEVEL_TRACE'  ; Enable trace level logging
 monitor_speed = 115200
+extra_scripts = pre:scripts/add_mlongcalls.py
 
 [com]
 esp8266_platform = espressif8266@4.2.1
 esp32_platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
-esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.5/esp32-arduino-libs.tar.gz
+esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.6/esp32-arduino-libs.tar.gz
 esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 atmelavr_platform = atmelavr@3.3.0
 

--- a/scripts/add_mlongcalls.py
+++ b/scripts/add_mlongcalls.py
@@ -1,0 +1,16 @@
+# Apply -mlongcalls to the whole build (project sources + lib_deps) on Xtensa
+# ESP32 targets. The precompiled esp32-arduino-libs only inject -mlongcalls into
+# the framework compile, not into lib_deps (NimBLE, ArduinoJson) or project
+# sources. For large images (OMG is ~90% of a 2 MB partition on IDF 5.5.4 libs)
+# the resulting fixed-range call8 relocations overflow and the link fails with
+#   "dangerous relocation: call8: call target out of range".
+# RISC-V targets (esp32c*/h*/p4) have no call8 and reject -mlongcalls, so this is
+# restricted to the Xtensa MCUs. Guarded so nothing is duplicated.
+Import("env")
+
+mcu = env.BoardConfig().get("build.mcu", "")
+if mcu in ("esp32", "esp32s2", "esp32s3"):
+    if "-mlongcalls" not in env.get("CCFLAGS", []):
+        env.Append(CCFLAGS=["-mlongcalls"])
+    if "-mlongcalls" not in env.get("ASFLAGS", []):
+        env.Append(ASFLAGS=["-mlongcalls"])


### PR DESCRIPTION
## Description:
  
Update the common platform package  for esp32 to latest release, mainly to provide support for Python 3.14.

**Note:** Development platform 'espressif32@55.3.39' depends on PlatformIO Core >=6.1.19.
PlatformIO Core 6.1.19 is also required for Python 3.14.

- Add support for Python 3.14
- Improve ESP32 platform and framework compatibility.
- Update board support and toolchain integrations.
- Fix stability and hardware-specific issues across supported ESP32 targets.
- Release notes:
    - [55.03.39](https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.39)
    - [55.03.38](https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.38)
    - [55.03.37](https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.37)
    - [55.03.36](https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.36)
    - [55.03.35](https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.35)
    - [55.03.34](https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.34)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).