### PR TITLE
Add SX1262 FSK gateway for Heltec V4 weather sensors, with Home Assistant discovery

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -1216,6 +1216,24 @@ build_flags =
 custom_description = For ESP32, Gateway using RTL_433_ESP and RadioLib with FSK modulation (beta)
 custom_hardware = ESP32 LILYGO T3-S3 SX1276 v1.0
 
+[env:heltec_v4-rtl_433sx1262]
+platform = espressif32@6.10.0
+board = heltec_wifi_lora_32_V3   ; V4 is pin-compatible; no dedicated board def exists yet
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${com-esp32.lib_deps}
+  ${libraries.radiolib}
+build_flags =
+  ${com-esp32.build_flags}
+; *** OpenMQTTGateway Config ***
+  '-DvalueAsATopic=true'    ; MQTT topic includes model and device
+  '-DGateway_Name="OMG_heltec_v4_rtl_433_sx1262"'
+  '-DNO_INT_TEMP_READING=true'
+; *** OpenMQTTGateway Modules ***
+  '-DZgatewayRTL_433SX1262="RTL_433SX1262"'
+custom_description = Receives Fine Offset/Ecowitt/LaCrosse weather sensors via SX1262 FSK (RadioLib), publishes on the RTL_433 MQTT topic
+custom_hardware = ESP32-S3 Heltec WiFi LoRa 32 V4
+
 [env:lilygo-ble]
 platform = ${com.esp32_platform}
 platform_packages = ${com.esp32_platform_packages}

--- a/environments.ini
+++ b/environments.ini
@@ -1235,6 +1235,7 @@ build_flags =
 ; *** ssd1306 Display Options ***
   '-DZdisplaySSD1306="HELTEC_SSD1306"'
   '-DLOG_TO_OLED=true'          ; show log messages (wifi/mqtt/rf) on the OLED instead of JSON pages
+  '-DLOG_LEVEL=LOG_LEVEL_TRACE' ; compile in TRACE-level calls (raw packet/RSSI/hex-dump logging)
   '-DLOG_LEVEL_OLED=LOG_LEVEL_TRACE'
   '-DDISPLAY_IDLE_LOGO=false'
 custom_description = Receives Fine Offset/Ecowitt/LaCrosse weather sensors via SX1262 FSK (RadioLib), publishes on the RTL_433 MQTT topic

--- a/environments.ini
+++ b/environments.ini
@@ -1235,8 +1235,8 @@ build_flags =
 ; *** ssd1306 Display Options ***
   '-DZdisplaySSD1306="HELTEC_SSD1306"'
   '-DLOG_TO_OLED=true'          ; show log messages (wifi/mqtt/rf) on the OLED instead of JSON pages
-  '-DLOG_LEVEL=LOG_LEVEL_TRACE' ; compile in TRACE-level calls (raw packet/RSSI/hex-dump logging)
-  '-DLOG_LEVEL_OLED=LOG_LEVEL_TRACE'
+  '-DLOG_LEVEL=LOG_LEVEL_NOTICE'
+  '-DLOG_LEVEL_OLED=LOG_LEVEL_NOTICE'
   '-DDISPLAY_IDLE_LOGO=false'
 custom_description = Receives Fine Offset/Ecowitt/LaCrosse weather sensors via SX1262 FSK (RadioLib), publishes on the RTL_433 MQTT topic
 custom_hardware = ESP32-S3 Heltec WiFi LoRa 32 V4

--- a/environments.ini
+++ b/environments.ini
@@ -1223,6 +1223,7 @@ board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.radiolib}
+  ${libraries.ssd1306}
 build_flags =
   ${com-esp32.build_flags}
 ; *** OpenMQTTGateway Config ***
@@ -1231,6 +1232,11 @@ build_flags =
   '-DNO_INT_TEMP_READING=true'
 ; *** OpenMQTTGateway Modules ***
   '-DZgatewayRTL_433SX1262="RTL_433SX1262"'
+; *** ssd1306 Display Options ***
+  '-DZdisplaySSD1306="HELTEC_SSD1306"'
+  '-DLOG_TO_OLED=true'          ; show log messages (wifi/mqtt/rf) on the OLED instead of JSON pages
+  '-DLOG_LEVEL_OLED=LOG_LEVEL_TRACE'
+  '-DDISPLAY_IDLE_LOGO=false'
 custom_description = Receives Fine Offset/Ecowitt/LaCrosse weather sensors via SX1262 FSK (RadioLib), publishes on the RTL_433 MQTT topic
 custom_hardware = ESP32-S3 Heltec WiFi LoRa 32 V4
 

--- a/main/User_config.h
+++ b/main/User_config.h
@@ -578,7 +578,7 @@ extern ss_cnt_parameters cnt_parameters_array[];
 #  define valueAsATopic false // define true to integrate msg value into the subject when receiving
 #endif
 
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433) || defined(ZgatewayRTL_433SX1262)
 // variable to avoid duplicates
 #  ifndef time_avoid_duplicate
 #    define time_avoid_duplicate 3000 // if you want to avoid duplicate MQTT message received set this to > 0, the value is the time in milliseconds during which we don't publish duplicates
@@ -691,7 +691,7 @@ extern ss_cnt_parameters cnt_parameters_array[];
 #  define DEFAULT_OFFLINE false
 #endif
 
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433) || defined(ZgatewayRTL_433SX1262)
 bool isAduplicateSignal(uint64_t);
 void storeSignalValue(uint64_t);
 #endif

--- a/main/config_RTL_433SX1262.h
+++ b/main/config_RTL_433SX1262.h
@@ -1,0 +1,93 @@
+/*
+  Theengs OpenMQTTGateway - We Unite Sensors in One Open-Source Interface
+
+   Act as a gateway between your 433mhz, infrared IR, BLE, LoRa signal and one interface like an MQTT broker
+   Send and receiving command by MQTT
+
+   This file enables to set your parameters for the RTL_433SX1262 gateway
+
+   Receives Fine Offset/Ecowitt/LaCrosse weather sensors (868 MHz GFSK,
+   "Group A" protocol family) directly through an SX1262 radio (RadioLib),
+   for boards such as the Heltec WiFi LoRa 32 V3/V4 where the rtl_433_ESP
+   library cannot be used (it does not support the SX1262 chip).
+
+    This file is part of OpenMQTTGateway.
+
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef config_RTL_433SX1262_h
+#define config_RTL_433SX1262_h
+
+#include "TheengsCommon.h"
+
+extern void setupRTL_433SX1262();
+extern void RTL_433SX1262Loop();
+
+/*-------------------PIN DEFINITIONS----------------------*/
+// Heltec WiFi LoRa 32 V3/V4 onboard SX1262 (V4 is pin-compatible with V3)
+
+#ifndef RTL433_SX1262_NSS
+#  define RTL433_SX1262_NSS 8
+#endif
+#ifndef RTL433_SX1262_SCK
+#  define RTL433_SX1262_SCK 9
+#endif
+#ifndef RTL433_SX1262_MOSI
+#  define RTL433_SX1262_MOSI 10
+#endif
+#ifndef RTL433_SX1262_MISO
+#  define RTL433_SX1262_MISO 11
+#endif
+#ifndef RTL433_SX1262_RST
+#  define RTL433_SX1262_RST 12
+#endif
+#ifndef RTL433_SX1262_BUSY
+#  define RTL433_SX1262_BUSY 13
+#endif
+#ifndef RTL433_SX1262_DIO1
+#  define RTL433_SX1262_DIO1 14
+#endif
+
+/*-------------------RADIO PARAMETERS----------------------*/
+// "Group A" Fine Offset/Ecowitt/LaCrosse GFSK parameters (868.35 MHz)
+
+#ifndef RTL433_SX1262_FREQ_MHZ
+#  define RTL433_SX1262_FREQ_MHZ 868.35f
+#endif
+#ifndef RTL433_SX1262_FREQ_DEV_KHZ
+#  define RTL433_SX1262_FREQ_DEV_KHZ 60.0f
+#endif
+#ifndef RTL433_SX1262_BW_KHZ
+#  define RTL433_SX1262_BW_KHZ 234.3f
+#endif
+#ifndef RTL433_SX1262_BITRATE_BPS
+#  define RTL433_SX1262_BITRATE_BPS 17241
+#endif
+#ifndef RTL433_SX1262_SYNCWORD
+#  define RTL433_SX1262_SYNCWORD 0x2DD4
+#endif
+#ifndef RTL433_SX1262_PKT_LEN
+#  define RTL433_SX1262_PKT_LEN 32
+#endif
+#ifndef RTL433_SX1262_TX_POWER
+#  define RTL433_SX1262_TX_POWER 10
+#endif
+#ifndef RTL433_SX1262_PREAMBLE_LEN
+#  define RTL433_SX1262_PREAMBLE_LEN 16
+#endif
+#ifndef RTL433_SX1262_TCXO_VOLTAGE
+#  define RTL433_SX1262_TCXO_VOLTAGE 1.6f
+#endif
+
+#endif

--- a/main/config_RTL_433SX1262.h
+++ b/main/config_RTL_433SX1262.h
@@ -33,6 +33,9 @@
 
 extern void setupRTL_433SX1262();
 extern void RTL_433SX1262Loop();
+#ifdef ZmqttDiscovery
+extern void launchRTL_433SX1262Discovery(bool overrideDiscovery);
+#endif
 
 /*-------------------PIN DEFINITIONS----------------------*/
 // Heltec WiFi LoRa 32 V3/V4 onboard SX1262 (V4 is pin-compatible with V3)

--- a/main/displaySSD1306.cpp
+++ b/main/displaySSD1306.cpp
@@ -371,6 +371,17 @@ OledSerial::OledSerial(int x) {
   delay(50);
   digitalWrite(RST_OLED, HIGH);
   display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, GEOMETRY_128_64);
+#  elif defined(WIFI_LoRa_32_V3)
+  // Heltec WiFi LoRa 32 V3/V4: OLED (and other peripherals) are powered
+  // through Vext, which must be driven LOW to enable it.
+  pinMode(Vext, OUTPUT);
+  digitalWrite(Vext, LOW);
+  delay(50);
+  pinMode(RST_OLED, OUTPUT); // https://github.com/espressif/arduino-esp32/issues/4278
+  digitalWrite(RST_OLED, LOW);
+  delay(50);
+  digitalWrite(RST_OLED, HIGH);
+  display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, GEOMETRY_128_64);
 #  elif defined(Wireless_Stick)
   // pinMode(RST_OLED, OUTPUT); // https://github.com/espressif/arduino-esp32/issues/4278
   // digitalWrite(RST_OLED, LOW);

--- a/main/gatewayRTL_433SX1262.cpp
+++ b/main/gatewayRTL_433SX1262.cpp
@@ -313,6 +313,12 @@ static void rtl433sx1262_logHex(const uint8_t* buf, size_t len) {
 }
 
 void RTL_433SX1262Loop() {
+  static unsigned long lastHeartbeat = 0;
+  if (millis() - lastHeartbeat > 10000) {
+    lastHeartbeat = millis();
+    THEENGS_LOG_TRACE(F("[RTL_433SX1262] listening, rssi %.1f" CR), rtl433sx1262_radio.getRSSI());
+  }
+
   if (!rtl433sx1262_rxFlag)
     return;
   rtl433sx1262_rxFlag = false;

--- a/main/gatewayRTL_433SX1262.cpp
+++ b/main/gatewayRTL_433SX1262.cpp
@@ -304,6 +304,14 @@ static void rtl433sx1262_publish(const SensorReading& r) {
   storeSignalValue(MQTTvalue);
 }
 
+static void rtl433sx1262_logHex(const uint8_t* buf, size_t len) {
+  char hex[RTL433_SX1262_PKT_LEN * 3 + 1];
+  size_t pos = 0;
+  for (size_t i = 0; i < len && pos + 3 < sizeof(hex); i++)
+    pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", buf[i]);
+  THEENGS_LOG_TRACE(F("[RTL_433SX1262] raw: %s" CR), hex);
+}
+
 void RTL_433SX1262Loop() {
   if (!rtl433sx1262_rxFlag)
     return;
@@ -314,8 +322,13 @@ void RTL_433SX1262Loop() {
   float rssi = rtl433sx1262_radio.getRSSI();
   rtl433sx1262_radio.startReceive();
 
-  if (state != RADIOLIB_ERR_NONE)
+  if (state != RADIOLIB_ERR_NONE) {
+    THEENGS_LOG_TRACE(F("[RTL_433SX1262] readData failed, code %d, rssi %.1f" CR), state, rssi);
     return;
+  }
+
+  THEENGS_LOG_TRACE(F("[RTL_433SX1262] packet received, rssi %.1f" CR), rssi);
+  rtl433sx1262_logHex(buf, RTL433_SX1262_PKT_LEN);
 
   for (size_t i = 0; i < RTL433SX1262_DRIVER_COUNT; i++) {
     const SensorDriver* drv = RTL433SX1262_DRIVERS[i];
@@ -323,9 +336,11 @@ void RTL_433SX1262Loop() {
       continue;
     SensorReading reading;
     if (drv->parse(buf, RTL433_SX1262_PKT_LEN, rssi, reading)) {
+      THEENGS_LOG_NOTICE(F("[RTL_433SX1262] Decoded %s id=%lu rssi=%.1f" CR), reading.model, (unsigned long)reading.id, rssi);
       rtl433sx1262_publish(reading);
       return;
     }
+    THEENGS_LOG_TRACE(F("[RTL_433SX1262] %s sync matched but parse/CRC failed" CR), drv->model);
   }
 }
 

--- a/main/gatewayRTL_433SX1262.cpp
+++ b/main/gatewayRTL_433SX1262.cpp
@@ -38,6 +38,29 @@
 #  include "config_RTL_433SX1262.h"
 #  include "rtl_433sx1262/sensor_drivers.h"
 
+#  ifdef ZmqttDiscovery
+#    include <vector>
+
+#    include "config_mqttDiscovery.h"
+
+struct RTL433SX1262Device {
+  uint32_t id;
+  char model[16];
+  uint16_t caps;
+  bool hasBattV;
+  bool isDisc;
+};
+static std::vector<RTL433SX1262Device> rtl433sx1262Devices;
+#  endif
+
+static String sx1262Topic(uint32_t id, const char* model) {
+  String topic = subjectRTL_433toMQTT;
+#  if valueAsATopic
+  topic = topic + "/" + String(model) + "/" + String(id);
+#  endif
+  return topic;
+}
+
 #  ifndef IRAM_ATTR
 #    define IRAM_ATTR
 #  endif
@@ -80,6 +103,126 @@ void setupRTL_433SX1262() {
   THEENGS_LOG_TRACE(F("gatewayRTL_433SX1262 setup done" CR));
 }
 
+#  ifdef ZmqttDiscovery
+// Matches the {key, name, unit, device_class} rows used by gatewayRTL_433.cpp's
+// discovery so both gateways surface the same entities for the same fields.
+struct SX1262DiscoveryParam {
+  const char* key;
+  const char* name;
+  const char* unit;
+  const char* deviceClass;
+};
+
+static const SX1262DiscoveryParam SX1262_DISCOVERY_PARAMS[] = {
+    {"temperature_C", "Temperature", HASS_UNIT_CELSIUS, HASS_CLASS_TEMPERATURE},
+    {"humidity", "Humidity", HASS_UNIT_PERCENT, HASS_CLASS_HUMIDITY},
+    {"pressure_hPa", "Pressure", HASS_UNIT_HPA, HASS_CLASS_PRESSURE},
+    {"rain_mm", "Rain", HASS_UNIT_MM, HASS_CLASS_PRECIPITATION},
+    {"wind_avg_m_s", "Wind average", HASS_UNIT_MS, HASS_CLASS_WIND_SPEED},
+    {"wind_max_m_s", "Wind max", HASS_UNIT_MS, HASS_CLASS_WIND_SPEED},
+    {"wind_dir_deg", "Wind direction", HASS_UNIT_DEGREE, ""},
+    {"uv", "UV value", "", ""},
+    {"light_lux", "Illuminance", HASS_UNIT_LX, HASS_CLASS_ILLUMINANCE},
+    {"strike_count", "Strike count", "", ""},
+    {"strike_distance_km", "Strike distance", "km", HASS_CLASS_DISTANCE},
+    {"pm2_5_ug_m3", "PM2.5", HASS_UNIT_UGM3, HASS_CLASS_PM25},
+    {"pm10_ug_m3", "PM10", HASS_UNIT_UGM3, HASS_CLASS_PM10},
+    {"co2_ppm", "Carbon Dioxide", HASS_UNIT_PPM, HASS_CLASS_CARBON_DIOXIDE},
+    {"moisture", "Moisture", HASS_UNIT_PERCENT, HASS_CLASS_HUMIDITY},
+};
+
+static void discoverParam(const char* key, const char* topic, const char* deviceId, const char* model, const char* stateClass) {
+  for (const auto& p : SX1262_DISCOVERY_PARAMS) {
+    if (strcmp(p.key, key) == 0) {
+      String value_template = "{{ value_json." + String(key) + " | is_defined }}";
+      String unique_id = String(deviceId) + "-" + key;
+      createDiscovery("sensor",
+                      topic, p.name, unique_id.c_str(),
+                      "", p.deviceClass, value_template.c_str(),
+                      "", "", p.unit,
+                      0,
+                      "", "", false, "",
+                      deviceId, "", model, deviceId, false,
+                      stateClass);
+      return;
+    }
+  }
+  THEENGS_LOG_WARNING(F("[RTL_433SX1262] discovery key %s not found" CR), key);
+}
+
+static void emitSX1262Discovery(const RTL433SX1262Device& dev, const String& topicStr) {
+  String deviceIdStr = String(dev.model) + "-" + String(dev.id);
+  const char* deviceId = deviceIdStr.c_str();
+  const char* topic = topicStr.c_str();
+
+  if (dev.caps & CAP_TEMP)
+    discoverParam("temperature_C", topic, deviceId, dev.model, stateClassMeasurement);
+  if (dev.caps & CAP_HUM)
+    discoverParam("humidity", topic, deviceId, dev.model, stateClassMeasurement);
+  if (dev.caps & CAP_PRESSURE)
+    discoverParam("pressure_hPa", topic, deviceId, dev.model, stateClassMeasurement);
+  if (dev.caps & CAP_RAIN)
+    discoverParam("rain_mm", topic, deviceId, dev.model, stateClassTotalIncreasing);
+  if (dev.caps & CAP_WIND) {
+    discoverParam("wind_avg_m_s", topic, deviceId, dev.model, stateClassMeasurement);
+    discoverParam("wind_max_m_s", topic, deviceId, dev.model, stateClassMeasurement);
+    discoverParam("wind_dir_deg", topic, deviceId, dev.model, stateClassMeasurement);
+  }
+  if (dev.caps & CAP_UV) {
+    discoverParam("uv", topic, deviceId, dev.model, stateClassMeasurement);
+    discoverParam("light_lux", topic, deviceId, dev.model, stateClassMeasurement);
+  }
+  if (dev.caps & CAP_LIGHTNING) {
+    discoverParam("strike_count", topic, deviceId, dev.model, stateClassTotalIncreasing);
+    discoverParam("strike_distance_km", topic, deviceId, dev.model, stateClassMeasurement);
+  }
+  if (dev.caps & CAP_PM) {
+    discoverParam("pm2_5_ug_m3", topic, deviceId, dev.model, stateClassMeasurement);
+    discoverParam("pm10_ug_m3", topic, deviceId, dev.model, stateClassMeasurement);
+  }
+  if (dev.caps & CAP_CO2)
+    discoverParam("co2_ppm", topic, deviceId, dev.model, stateClassMeasurement);
+  if (dev.caps & CAP_SOIL)
+    discoverParam("moisture", topic, deviceId, dev.model, stateClassMeasurement);
+
+  // battery_ok is 0/1, mirrored as a percent sensor for consistency with gatewayRTL_433.cpp
+  String battOkTemplate = "{{ (float(value_json.battery_ok) * 100) | round(0) | is_defined }}";
+  String battOkUniqueId = String(deviceId) + "-battery_ok";
+  createDiscovery("sensor",
+                  topic, "Battery", battOkUniqueId.c_str(),
+                  "", HASS_CLASS_BATTERY, battOkTemplate.c_str(),
+                  "", "", HASS_UNIT_PERCENT,
+                  0,
+                  "", "", false, "",
+                  deviceId, "", dev.model, deviceId, false,
+                  stateClassMeasurement);
+
+  if (dev.hasBattV) {
+    String battVTemplate = "{{ value_json.battery_V | is_defined }}";
+    String battVUniqueId = String(deviceId) + "-battery_V";
+    createDiscovery("sensor",
+                    topic, "Battery Voltage", battVUniqueId.c_str(),
+                    "", HASS_CLASS_VOLTAGE, battVTemplate.c_str(),
+                    "", "", HASS_UNIT_VOLT,
+                    0,
+                    "", "", false, "",
+                    deviceId, "", dev.model, deviceId, false,
+                    stateClassMeasurement);
+  }
+}
+
+void launchRTL_433SX1262Discovery(bool overrideDiscovery) {
+  if (!SYSConfig.discovery)
+    return;
+  for (auto& dev : rtl433sx1262Devices) {
+    if (overrideDiscovery || !dev.isDisc) {
+      emitSX1262Discovery(dev, sx1262Topic(dev.id, dev.model));
+      dev.isDisc = true;
+    }
+  }
+}
+#  endif
+
 static void rtl433sx1262_publish(const SensorReading& r) {
   unsigned long MQTTvalue = r.id * 1000UL + (unsigned long)round(r.tempC * 10.0f + 500.0f) + (unsigned long)round(r.humidity) + (unsigned long)round(r.rainMm * 10.0f) + (unsigned long)round(r.windAvgMs * 10.0f) + (unsigned long)r.lightningCount + (unsigned long)r.soilMoisture + (unsigned long)round(r.pm25 * 10.0f) + (unsigned long)r.co2;
   if (isAduplicateSignal(MQTTvalue))
@@ -115,7 +258,7 @@ static void rtl433sx1262_publish(const SensorReading& r) {
   if (r.caps & CAP_LIGHTNING) {
     data["strike_count"] = r.lightningCount;
     if (r.lightningDistKm != 63)
-      data["strike_distance"] = r.lightningDistKm;
+      data["strike_distance_km"] = r.lightningDistKm;
   }
   if (r.caps & CAP_PM) {
     data["pm2_5_ug_m3"] = r.pm25;
@@ -126,11 +269,36 @@ static void rtl433sx1262_publish(const SensorReading& r) {
   if (r.caps & CAP_SOIL)
     data["moisture"] = r.soilMoisture;
 
-  String topic = subjectRTL_433toMQTT;
-#  if valueAsATopic
-  topic = topic + "/" + String(r.model) + "/" + String(r.id);
-#  endif
+  String topic = sx1262Topic(r.id, r.model);
   data["origin"] = (char*)topic.c_str();
+
+#  ifdef ZmqttDiscovery
+  if (SYSConfig.discovery) {
+    RTL433SX1262Device* dev = nullptr;
+    for (auto& d : rtl433sx1262Devices) {
+      if (d.id == r.id && strcmp(d.model, r.model) == 0) {
+        dev = &d;
+        break;
+      }
+    }
+    if (!dev) {
+      RTL433SX1262Device newDev;
+      newDev.id = r.id;
+      strlcpy(newDev.model, r.model, sizeof(newDev.model));
+      newDev.caps = 0;
+      newDev.hasBattV = false;
+      newDev.isDisc = false;
+      rtl433sx1262Devices.push_back(newDev);
+      dev = &rtl433sx1262Devices.back();
+    }
+    dev->caps = r.caps;
+    dev->hasBattV = dev->hasBattV || (r.battV > 0);
+    if (!dev->isDisc) {
+      emitSX1262Discovery(*dev, topic);
+      dev->isDisc = true;
+    }
+  }
+#  endif
 
   enqueueJsonObject(data);
   storeSignalValue(MQTTvalue);

--- a/main/gatewayRTL_433SX1262.cpp
+++ b/main/gatewayRTL_433SX1262.cpp
@@ -1,0 +1,164 @@
+/*
+  OpenMQTTGateway  - ESP8266 or Arduino program for home automation
+
+   Act as a gateway between your 433mhz, infrared IR, BLE, LoRa signal and one interface like an MQTT broker
+   Send and receiving command by MQTT
+
+  This gateway enables to:
+ - publish MQTT data related to received Fine Offset/Ecowitt/LaCrosse weather
+   sensor signals ("Group A" protocol family, 868.35 MHz GFSK), received
+   directly through an SX1262 radio via RadioLib.
+ - support boards such as the Heltec WiFi LoRa 32 V3/V4, whose onboard SX1262
+   radio the rtl_433_ESP library (used by ZgatewayRTL_433) cannot drive.
+
+    This file is part of OpenMQTTGateway.
+
+    OpenMQTTGateway is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenMQTTGateway is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "User_config.h"
+
+#ifdef ZgatewayRTL_433SX1262
+#  include <RadioLib.h>
+#  include <SPI.h>
+
+#  include "TheengsCommon.h"
+#  include "config_RF.h"
+#  include "config_RTL_433SX1262.h"
+#  include "rtl_433sx1262/sensor_drivers.h"
+
+#  ifndef IRAM_ATTR
+#    define IRAM_ATTR
+#  endif
+
+static SX1262 rtl433sx1262_radio = new Module(RTL433_SX1262_NSS, RTL433_SX1262_DIO1, RTL433_SX1262_RST, RTL433_SX1262_BUSY);
+static volatile bool rtl433sx1262_rxFlag = false;
+
+static void IRAM_ATTR rtl433sx1262_onRxDone() {
+  rtl433sx1262_rxFlag = true;
+}
+
+void setupRTL_433SX1262() {
+#  if defined(ARDUINO_ARCH_ESP32)
+  SPI.begin(RTL433_SX1262_SCK, RTL433_SX1262_MISO, RTL433_SX1262_MOSI, RTL433_SX1262_NSS);
+#  else
+  SPI.begin();
+#  endif
+
+  float bitrateKbps = RTL433_SX1262_BITRATE_BPS / 1000.0f;
+  int state = rtl433sx1262_radio.beginFSK(RTL433_SX1262_FREQ_MHZ, bitrateKbps, RTL433_SX1262_FREQ_DEV_KHZ,
+                                          RTL433_SX1262_BW_KHZ, RTL433_SX1262_TX_POWER, RTL433_SX1262_PREAMBLE_LEN,
+                                          RTL433_SX1262_TCXO_VOLTAGE);
+  if (state != RADIOLIB_ERR_NONE) {
+    THEENGS_LOG_ERROR(F("[RTL_433SX1262] beginFSK failed, code %d" CR), state);
+    return;
+  }
+
+  uint16_t sw = RTL433_SX1262_SYNCWORD;
+  uint8_t syncWord[] = {(uint8_t)((sw >> 8) & 0xFF), (uint8_t)(sw & 0xFF)};
+  rtl433sx1262_radio.setSyncWord(syncWord, sizeof(syncWord));
+  rtl433sx1262_radio.fixedPacketLengthMode(RTL433_SX1262_PKT_LEN);
+  rtl433sx1262_radio.setCRC(0); // CRC/checksum is verified in software by the per-sensor parsers
+  rtl433sx1262_radio.setRxBoostedGainMode(true);
+  rtl433sx1262_radio.setDio2AsRfSwitch(true);
+  rtl433sx1262_radio.setDio1Action(rtl433sx1262_onRxDone);
+  rtl433sx1262_radio.startReceive();
+
+  THEENGS_LOG_NOTICE(F("[RTL_433SX1262] Freq: %sMHz Bitrate: %dbps Sync: 0x%04X PktLen: %d" CR),
+                     String(RTL433_SX1262_FREQ_MHZ).c_str(), RTL433_SX1262_BITRATE_BPS, (unsigned)RTL433_SX1262_SYNCWORD, RTL433_SX1262_PKT_LEN);
+  THEENGS_LOG_TRACE(F("gatewayRTL_433SX1262 setup done" CR));
+}
+
+static void rtl433sx1262_publish(const SensorReading& r) {
+  unsigned long MQTTvalue = r.id * 1000UL + (unsigned long)round(r.tempC * 10.0f + 500.0f) + (unsigned long)round(r.humidity) + (unsigned long)round(r.rainMm * 10.0f) + (unsigned long)round(r.windAvgMs * 10.0f) + (unsigned long)r.lightningCount + (unsigned long)r.soilMoisture + (unsigned long)round(r.pm25 * 10.0f) + (unsigned long)r.co2;
+  if (isAduplicateSignal(MQTTvalue))
+    return;
+
+  StaticJsonDocument<JSON_MSG_BUFFER> jsonBuffer;
+  JsonObject data = jsonBuffer.to<JsonObject>();
+
+  data["model"] = r.model;
+  data["id"] = r.id;
+  data["rssi"] = r.rssi;
+  data["battery_ok"] = r.battLow ? 0 : 1;
+  if (r.battV > 0)
+    data["battery_V"] = r.battV;
+
+  if (r.caps & CAP_TEMP)
+    data["temperature_C"] = r.tempC;
+  if (r.caps & CAP_HUM)
+    data["humidity"] = r.humidity;
+  if (r.caps & CAP_PRESSURE)
+    data["pressure_hPa"] = r.pressureHpa;
+  if (r.caps & CAP_RAIN)
+    data["rain_mm"] = r.rainMm;
+  if (r.caps & CAP_WIND) {
+    data["wind_avg_m_s"] = r.windAvgMs;
+    data["wind_max_m_s"] = r.windGustMs;
+    data["wind_dir_deg"] = r.windDirDeg;
+  }
+  if (r.caps & CAP_UV) {
+    data["uv"] = r.uvIndex;
+    data["light_lux"] = r.lightLux;
+  }
+  if (r.caps & CAP_LIGHTNING) {
+    data["strike_count"] = r.lightningCount;
+    if (r.lightningDistKm != 63)
+      data["strike_distance"] = r.lightningDistKm;
+  }
+  if (r.caps & CAP_PM) {
+    data["pm2_5_ug_m3"] = r.pm25;
+    data["pm10_ug_m3"] = r.pm10;
+  }
+  if (r.caps & CAP_CO2)
+    data["co2_ppm"] = r.co2;
+  if (r.caps & CAP_SOIL)
+    data["moisture"] = r.soilMoisture;
+
+  String topic = subjectRTL_433toMQTT;
+#  if valueAsATopic
+  topic = topic + "/" + String(r.model) + "/" + String(r.id);
+#  endif
+  data["origin"] = (char*)topic.c_str();
+
+  enqueueJsonObject(data);
+  storeSignalValue(MQTTvalue);
+}
+
+void RTL_433SX1262Loop() {
+  if (!rtl433sx1262_rxFlag)
+    return;
+  rtl433sx1262_rxFlag = false;
+
+  uint8_t buf[RTL433_SX1262_PKT_LEN];
+  int state = rtl433sx1262_radio.readData(buf, RTL433_SX1262_PKT_LEN);
+  float rssi = rtl433sx1262_radio.getRSSI();
+  rtl433sx1262_radio.startReceive();
+
+  if (state != RADIOLIB_ERR_NONE)
+    return;
+
+  for (size_t i = 0; i < RTL433SX1262_DRIVER_COUNT; i++) {
+    const SensorDriver* drv = RTL433SX1262_DRIVERS[i];
+    if (!drv->match(buf, RTL433_SX1262_PKT_LEN))
+      continue;
+    SensorReading reading;
+    if (drv->parse(buf, RTL433_SX1262_PKT_LEN, rssi, reading)) {
+      rtl433sx1262_publish(reading);
+      return;
+    }
+  }
+}
+
+#endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -373,6 +373,9 @@ void handle_autodiscovery() {
 #  ifdef ZgatewayRTL_433
     launchRTL_433Discovery(true);
 #  endif
+#  ifdef ZgatewayRTL_433SX1262
+    launchRTL_433SX1262Discovery(true);
+#  endif
   }
 
   connectedOnce = true;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -39,7 +39,7 @@ GatewayState gatewayState = GatewayState::WAITING_ONBOARDING;
 static GatewayState previousGatewayState = gatewayState;
 
 // Macros and structure to enable the duplicates removing on the following gateways
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433) || defined(ZgatewayRTL_433SX1262)
 // array to store previous received RFs, IRs codes and their timestamps
 struct ReceivedSignal {
   uint64_t value;
@@ -128,6 +128,9 @@ Preferences preferences;
 #endif
 #ifdef ZgatewayLORA
 #  include "config_LORA.h"
+#endif
+#ifdef ZgatewayRTL_433SX1262
+#  include "config_RTL_433SX1262.h"
 #endif
 #ifdef ZgatewaySRFB
 #  include "config_SRFB.h"
@@ -1528,6 +1531,10 @@ void setup() {
   setupLORA();
   modules.add(ZgatewayLORA);
 #endif
+#ifdef ZgatewayRTL_433SX1262
+  setupRTL_433SX1262();
+  modules.add(ZgatewayRTL_433SX1262);
+#endif
 #ifdef ZgatewayRF
   modules.add(ZgatewayRF);
 #endif
@@ -2735,6 +2742,9 @@ void loop() {
       launchLORADiscovery(false);
 #  endif
 #endif
+#ifdef ZgatewayRTL_433SX1262
+    RTL_433SX1262Loop();
+#endif
 #ifdef ZgatewayRF
     RFtoX();
 #endif
@@ -2961,7 +2971,7 @@ String stateMeasures() {
   return output;
 }
 
-#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433)
+#if defined(ZgatewayRF) || defined(ZgatewayIR) || defined(ZgatewaySRFB) || defined(ZgatewayWeatherStation) || defined(ZgatewayRTL_433) || defined(ZgatewayRTL_433SX1262)
 /**
  * Store signal values from RF, IR, SRFB or Weather stations so as to avoid duplicates
  */

--- a/main/rtl_433sx1262/LICENSE
+++ b/main/rtl_433sx1262/LICENSE
@@ -1,0 +1,28 @@
+The sensor decoding logic in this directory (sensor_types.h, sensor_util.h,
+sensor_drivers.h, and the per-sensor .cpp files) is ported from
+WeatherStation2Meshtastic (https://github.com/iz0kew/WeatherStation2Meshtastic),
+which itself reuses portions of EcoWittStation2Meshtastic (iz0kew). Both are
+distributed under the MIT License below.
+
+MIT License
+
+Copyright (c) 2026 DG
+Portions reused from EcoWittStation2Meshtastic (iz0kew), MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/main/rtl_433sx1262/sensor_drivers.h
+++ b/main/rtl_433sx1262/sensor_drivers.h
@@ -1,0 +1,35 @@
+// Declares the SensorDriver table for the RTL_433SX1262 "Group A" sensors
+// (Fine Offset / Ecowitt / LaCrosse, 868.35 MHz GFSK). Each driver is
+// defined in its own .cpp file, ported from WeatherStation2Meshtastic's
+// src/sensors/{fineoffset,lacrosse}/*.cpp.
+#ifndef rtl_433sx1262_sensor_drivers_h
+#define rtl_433sx1262_sensor_drivers_h
+
+#include "sensor_types.h"
+
+extern const SensorDriver DRIVER_WH32;
+extern const SensorDriver DRIVER_WH31E;
+extern const SensorDriver DRIVER_WH40;
+extern const SensorDriver DRIVER_WH57;
+extern const SensorDriver DRIVER_WH51;
+extern const SensorDriver DRIVER_WH45;
+extern const SensorDriver DRIVER_WS80;
+extern const SensorDriver DRIVER_WS90;
+extern const SensorDriver DRIVER_TX35;
+
+// WS90 is tried before TX35: both can start with a 0x9 high nibble, and
+// TX35's match() validates its own CRC to avoid colliding with WS90 frames.
+static const SensorDriver* const RTL433SX1262_DRIVERS[] = {
+    &DRIVER_WH32,
+    &DRIVER_WH31E,
+    &DRIVER_WH40,
+    &DRIVER_WH57,
+    &DRIVER_WH51,
+    &DRIVER_WH45,
+    &DRIVER_WS80,
+    &DRIVER_WS90,
+    &DRIVER_TX35,
+};
+static const size_t RTL433SX1262_DRIVER_COUNT = sizeof(RTL433SX1262_DRIVERS) / sizeof(RTL433SX1262_DRIVERS[0]);
+
+#endif

--- a/main/rtl_433sx1262/sensor_types.h
+++ b/main/rtl_433sx1262/sensor_types.h
@@ -1,0 +1,73 @@
+// Shared sensor-parsing types for the RTL_433SX1262 gateway.
+// Ported from WeatherStation2Meshtastic's src/sensors/sensor_types.h.
+//
+// Each sensor driver exposes a match()/parse() pair (function pointers,
+// no vtable). match() does a cheap check that a frame belongs to this
+// sensor; parse() decodes it (verifying CRC/checksum) and fills a
+// SensorReading. The gateway then converts SensorReading into an
+// rtl_433-style JsonObject.
+#ifndef rtl_433sx1262_sensor_types_h
+#define rtl_433sx1262_sensor_types_h
+
+#include <Arduino.h>
+
+enum SensorCap : uint16_t {
+  CAP_TEMP = 1u << 0,
+  CAP_HUM = 1u << 1,
+  CAP_PRESSURE = 1u << 2,
+  CAP_RAIN = 1u << 3,
+  CAP_WIND = 1u << 4,
+  CAP_UV = 1u << 5,
+  CAP_LIGHTNING = 1u << 6,
+  CAP_PM = 1u << 7,
+  CAP_CO2 = 1u << 8,
+  CAP_SOIL = 1u << 9,
+  CAP_LEAK = 1u << 10,
+};
+
+struct SensorReading {
+  uint16_t caps = 0; // OR of the SensorCap bits that were set
+  uint32_t id = 0; // per-unit sensor id
+  const char* model = ""; // static model string, e.g. "WH32"
+
+  float tempC = 0; // CAP_TEMP
+  float humidity = 0; // CAP_HUM (%)
+  float pressureHpa = 0; // CAP_PRESSURE
+
+  float rainMm = 0; // CAP_RAIN (cumulative counter, sensor steps)
+
+  float windAvgMs = 0; // CAP_WIND (m/s)
+  float windGustMs = 0; // CAP_WIND (m/s)
+  float windDirDeg = 0; // CAP_WIND (degrees, 0 = N)
+
+  float uvIndex = 0; // CAP_UV
+  float lightLux = 0; // CAP_UV (lux, optional)
+
+  uint8_t lightningDistKm = 63; // CAP_LIGHTNING (63 = none)
+  uint32_t lightningCount = 0; // CAP_LIGHTNING (raw packet counter)
+  bool lightningCountValid = false;
+
+  float pm25 = 0; // CAP_PM (ug/m3)
+  float pm10 = 0; // CAP_PM (ug/m3)
+  uint16_t co2 = 0; // CAP_CO2 (ppm)
+
+  uint8_t soilMoisture = 0; // CAP_SOIL (%)
+  bool leak = false; // CAP_LEAK
+
+  bool battLow = false;
+  float battV = 0;
+  float rssi = 0;
+};
+
+typedef bool (*SensorMatchFn)(const uint8_t* buf, size_t len);
+typedef bool (*SensorParseFn)(const uint8_t* buf, size_t len, float rssi,
+                              SensorReading& out);
+
+struct SensorDriver {
+  const char* model;
+  uint16_t caps; // capabilities declared by the driver (documentation only)
+  SensorMatchFn match;
+  SensorParseFn parse;
+};
+
+#endif

--- a/main/rtl_433sx1262/sensor_util.h
+++ b/main/rtl_433sx1262/sensor_util.h
@@ -1,0 +1,26 @@
+// Checksum helpers shared by the RTL_433SX1262 sensor parsers.
+// Ported from WeatherStation2Meshtastic's src/sensors/sensor_util.h.
+#ifndef rtl_433sx1262_sensor_util_h
+#define rtl_433sx1262_sensor_util_h
+
+#include <Arduino.h>
+
+// CRC-8, polynomial 0x31, init 0x00, MSB-first (Fine Offset / Ecowitt standard)
+static inline uint8_t crc8_0x31(const uint8_t* data, size_t len) {
+  uint8_t crc = 0x00;
+  for (size_t i = 0; i < len; i++) {
+    crc ^= data[i];
+    for (uint8_t b = 0; b < 8; b++)
+      crc = (crc & 0x80) ? (uint8_t)((crc << 1) ^ 0x31) : (uint8_t)(crc << 1);
+  }
+  return crc;
+}
+
+// 8-bit sum checksum
+static inline uint8_t sum8(const uint8_t* data, size_t len) {
+  uint8_t s = 0;
+  for (size_t i = 0; i < len; i++) s += data[i];
+  return s;
+}
+
+#endif

--- a/main/rtl_433sx1262/tx35.cpp
+++ b/main/rtl_433sx1262/tx35.cpp
@@ -1,0 +1,47 @@
+// ============================================================================
+// tx35.cpp — LaCrosse TX35DTH-IT / TX29-IT / TFA 30.3155 / 30.3159 (temp/hum.)
+//   (ref. rtl_433 lacrosse_tx35.c)
+//
+// After the 0x2DD4 sync word, the first nibble is the model code (9), so:
+//   b[0] = 9<<4 | id_hi ; 5 bytes total, b[4] = CRC-8/0x31 of b[0..3]
+//   temp_c = 10*(b[1]&0x0f) + ((b[2]>>4)&0x0f) + 0.1*(b[2]&0x0f) - 40
+//   humidity = b[3] & 0x7f (0x6a = no humidity sensor)
+//
+// NB: shares the high nibble 0x9 with WS90 (family 0x90). Disambiguation
+//     is handled by the CRC check in parse() (WS90 is tried first).
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+#define TX35_NO_HUMIDITY 0x6a
+#define TX35_PROBE_FLAG  0x7d
+
+static bool tx35_match(const uint8_t* b, size_t len) {
+  if (len < 5) return false;
+  if ((b[0] & 0xF0) != 0x90) return false;
+  return crc8_0x31(b, 4) == b[4]; // validate right away to avoid colliding with WS90
+}
+
+static bool tx35_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 5) return false;
+  if (crc8_0x31(b, 4) != b[4]) return false;
+
+  float tempC = 10.0f * (b[1] & 0x0f) + 1.0f * ((b[2] >> 4) & 0x0f) + 0.1f * (b[2] & 0x0f) - 40.0f;
+  if (tempC < -45.0f || tempC > 70.0f) return false;
+
+  o.model = "TX35";
+  o.id = ((b[0] & 0x0f) << 2) | (b[1] >> 6);
+  o.tempC = tempC;
+  o.battLow = (b[3] >> 7) != 0;
+  o.rssi = rssi;
+  o.caps = CAP_TEMP;
+
+  uint8_t hum = b[3] & 0x7f;
+  if (hum != TX35_NO_HUMIDITY && hum != TX35_PROBE_FLAG && hum <= 100) {
+    o.humidity = hum;
+    o.caps |= CAP_HUM;
+  }
+  return true;
+}
+
+extern const SensorDriver DRIVER_TX35 = {"TX35", CAP_TEMP | CAP_HUM, tx35_match, tx35_parse};

--- a/main/rtl_433sx1262/wh31e.cpp
+++ b/main/rtl_433sx1262/wh31e.cpp
@@ -1,0 +1,35 @@
+// ============================================================================
+// wh31e.cpp — Ambient Weather WH31E / WH31B thermo-hygrometer
+// 7-byte frame: YY II CT TT HH XX AA (ref. rtl_433 ambientweather_wh31e.c)
+//   YY = 0x30 (WH31E) / 0x37 (WH31B); CRC-8/0x31 over 6 bytes = 0; SUM8(b,6)==b[6]
+//   batt = (b[2]>>2)&1 ; temp = ((b[2]&0x03)<<8 | b[3]) scaled 0.1, offset 400
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool wh31e_match(const uint8_t* b, size_t len) {
+  return len >= 7 && (b[0] == 0x30 || b[0] == 0x37);
+}
+
+static bool wh31e_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 7) return false;
+  if (crc8_0x31(b, 6) != 0) return false; // b[5] = CRC of b[0..4]
+  if (sum8(b, 6) != b[6]) return false; // b[6] = SUM of b[0..5]
+
+  int rawT = ((b[2] & 0x03) << 8) | b[3];
+  float tempC = (rawT - 400) * 0.1f;
+  int hum = b[4];
+  if (hum > 100 || tempC < -45.0f || tempC > 70.0f) return false;
+
+  o.model = "WH31E";
+  o.id = b[1];
+  o.tempC = tempC;
+  o.humidity = hum;
+  o.battLow = ((b[2] & 0x04) != 0);
+  o.rssi = rssi;
+  o.caps = CAP_TEMP | CAP_HUM;
+  return true;
+}
+
+extern const SensorDriver DRIVER_WH31E = {"WH31E", CAP_TEMP | CAP_HUM,
+                                          wh31e_match, wh31e_parse};

--- a/main/rtl_433sx1262/wh32.cpp
+++ b/main/rtl_433sx1262/wh32.cpp
@@ -1,0 +1,47 @@
+// ============================================================================
+// wh32.cpp — Fine Offset WH32 / WH25 / WH32B / WH65B (temperature/humidity/pressure)
+// 8-byte frame: MI IT TT HH PP PP CC XX (ref. rtl_433 fineoffset.c)
+//   high nibble of b[0] = message type (0xD0/0xE0), checksum = sum8(b,6)==b[6]
+//   WH25/WH32B include pressure (PP field); base WH32 does not -> CAP_PRESSURE
+//   is only set when the pressure value is plausible.
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool wh32_match(const uint8_t* b, size_t len) {
+  if (len < 7) return false;
+  uint8_t t = b[0] & 0xF0;
+  return (t == 0xD0 || t == 0xE0);
+}
+
+static bool wh32_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 7) return false;
+  if (sum8(b, 6) != b[6]) return false;
+
+  bool invalid = (b[1] & 0x04) != 0;
+  uint16_t rawT = (uint16_t)(((b[1] & 0x03) << 8) | b[2]);
+  float tempC = (rawT - 400) * 0.1f;
+  uint8_t hum = b[3];
+  if (invalid || rawT == 0x7FF) return false;
+  if (hum > 100 || tempC < -45.0f || tempC > 70.0f) return false;
+
+  o.model = "WH32";
+  o.id = (uint8_t)(((b[0] & 0x0F) << 4) | (b[1] >> 4));
+  o.tempC = tempC;
+  o.humidity = hum;
+  o.battLow = (b[1] & 0x08) != 0;
+  o.rssi = rssi;
+  o.caps = CAP_TEMP | CAP_HUM;
+
+  // Pressure (WH25/WH32B): 16-bit field in hPa*10. 0 or out of range = absent.
+  uint16_t rawP = (uint16_t)((b[4] << 8) | b[5]);
+  float hpa = rawP * 0.1f;
+  if (rawP != 0 && hpa >= 800.0f && hpa <= 1100.0f) {
+    o.pressureHpa = hpa;
+    o.caps |= CAP_PRESSURE;
+  }
+  return true;
+}
+
+extern const SensorDriver DRIVER_WH32 = {"WH32", CAP_TEMP | CAP_HUM | CAP_PRESSURE,
+                                         wh32_match, wh32_parse};

--- a/main/rtl_433sx1262/wh40.cpp
+++ b/main/rtl_433sx1262/wh40.cpp
@@ -1,0 +1,32 @@
+// ============================================================================
+// wh40.cpp — Ecowitt WH40 rain gauge
+// 9-byte frame: 40 00 II II FV RR RR CC SS (ref. rtl_433 ambientweather_wh31e.c)
+//   CRC-8/0x31 over the first 8 bytes (= 0), then SUM8(b,8)==b[8]
+//   rainRaw in 0.1 mm steps (cumulative counter)
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool wh40_match(const uint8_t* b, size_t len) {
+  return len >= 9 && b[0] == 0x40;
+}
+
+static bool wh40_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 9) return false;
+  if (crc8_0x31(b, 8) != 0) return false;
+  if (sum8(b, 8) != b[8]) return false;
+
+  uint8_t battRaw = b[4] & 0x1F; // voltage in 0.1 V steps
+  uint16_t rainRaw = (uint16_t)((b[5] << 8) | b[6]);
+
+  o.model = "WH40";
+  o.id = (uint16_t)((b[2] << 8) | b[3]);
+  o.rainMm = rainRaw * 0.1f;
+  o.battV = battRaw * 0.1f;
+  o.battLow = (o.battV > 0 && o.battV < 1.2f);
+  o.rssi = rssi;
+  o.caps = CAP_RAIN;
+  return true;
+}
+
+extern const SensorDriver DRIVER_WH40 = {"WH40", CAP_RAIN, wh40_match, wh40_parse};

--- a/main/rtl_433sx1262/wh45.cpp
+++ b/main/rtl_433sx1262/wh45.cpp
@@ -1,0 +1,43 @@
+// ============================================================================
+// wh45.cpp — Fine Offset / Ecowitt WH45 air quality (PM2.5 / PM10 / CO2 + T/H)
+// 15-byte frame: YY IIII 0T TT HH Bp pp BP PP CC CC XX AA
+//   (ref. rtl_433 fineoffset_wh45.c)
+//   YY=0x45; CRC-8/0x31 of b[0..12]==b[13]; SUM8(b[0..13])==b[14]
+//   temp = ((b[4]&0x07)<<8|b[5]) offset 400 *0.1 ; hum=b[6]
+//   PM2.5 = ((b[7]&0x3f)<<8|b[8])*0.1 ; PM10 = ((b[9]&0x3f)<<8|b[10])*0.1
+//   CO2   = (b[11]<<8)|b[12]
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool wh45_match(const uint8_t* b, size_t len) {
+  return len >= 15 && b[0] == 0x45;
+}
+
+static bool wh45_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 15) return false;
+  if (crc8_0x31(b, 13) != b[13]) return false;
+  if (sum8(b, 14) != b[14]) return false;
+
+  int rawT = ((b[4] & 0x07) << 8) | b[5];
+  float tempC = (rawT - 400) * 0.1f;
+  int hum = b[6];
+  if (hum > 100 || tempC < -45.0f || tempC > 70.0f) return false;
+
+  o.model = "WH45";
+  o.id = ((uint32_t)b[1] << 16) | ((uint32_t)b[2] << 8) | b[3];
+  o.tempC = tempC;
+  o.humidity = hum;
+  o.pm25 = (((b[7] & 0x3f) << 8) | b[8]) * 0.1f;
+  o.pm10 = (((b[9] & 0x3f) << 8) | b[10]) * 0.1f;
+  o.co2 = (uint16_t)((b[11] << 8) | b[12]);
+  // battery bars: 6 = external USB power
+  int bars = ((b[7] & 0x40) >> 4) | ((b[9] & 0xC0) >> 6);
+  o.battLow = (bars <= 1);
+  o.rssi = rssi;
+  o.caps = CAP_TEMP | CAP_HUM | CAP_PM | CAP_CO2;
+  return true;
+}
+
+extern const SensorDriver DRIVER_WH45 = {"WH45", CAP_TEMP | CAP_HUM | CAP_PM | CAP_CO2,
+                                         wh45_match, wh45_parse};

--- a/main/rtl_433sx1262/wh51.cpp
+++ b/main/rtl_433sx1262/wh51.cpp
@@ -1,0 +1,34 @@
+// ============================================================================
+// wh51.cpp — Ecowitt WH51 / WN31 / SwitchDoc SM23 soil moisture
+// 14-byte frame: FF IIIIII TB YY MM ZA AA XX XX XX CC SS
+//   (ref. rtl_433 fineoffset.c, fineoffset_WH51_callback)
+//   FF=0x51; CRC-8/0x31 of b[0..11] == b[12]; SUM8(b[0..12]) == b[13]
+//   moisture = b[6] (%) ; battery_mV = (b[4]&0x1f)*100
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool wh51_match(const uint8_t* b, size_t len) {
+  return len >= 14 && b[0] == 0x51;
+}
+
+static bool wh51_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 14) return false;
+  if (crc8_0x31(b, 12) != b[12]) return false;
+  if (sum8(b, 13) != b[13]) return false;
+
+  int moisture = b[6];
+  if (moisture > 100) return false;
+  int batt_mv = (b[4] & 0x1f) * 100;
+
+  o.model = "WH51";
+  o.id = ((uint32_t)b[1] << 16) | ((uint32_t)b[2] << 8) | b[3];
+  o.soilMoisture = (uint8_t)moisture;
+  o.battV = batt_mv / 1000.0f;
+  o.battLow = (batt_mv > 0 && batt_mv < 900); // < 0.9 V
+  o.rssi = rssi;
+  o.caps = CAP_SOIL;
+  return true;
+}
+
+extern const SensorDriver DRIVER_WH51 = {"WH51", CAP_SOIL, wh51_match, wh51_parse};

--- a/main/rtl_433sx1262/wh57.cpp
+++ b/main/rtl_433sx1262/wh57.cpp
@@ -1,0 +1,35 @@
+// ============================================================================
+// wh57.cpp — Ecowitt WH57 / WH31L lightning detector
+// 9-byte frame: 57 SI II II FF KK CC XX AA (ref. rtl_433 fineoffset_wh31l.c)
+//   state = b[1]>>4 (8 = strike), distance = b[5]&0x3F (63 = none),
+//   raw count = b[6]. CRC-8/0x31 over 8 bytes = 0, then SUM8(b,8)==b[8].
+// The parser is stateless: it reports the raw count and distance; handling
+// the 8-bit wraparound and cumulative total is the consumer's job.
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool wh57_match(const uint8_t* b, size_t len) {
+  return len >= 9 && b[0] == 0x57;
+}
+
+static bool wh57_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 9) return false;
+  if (crc8_0x31(b, 8) != 0) return false;
+  if (sum8(b, 8) != b[8]) return false;
+
+  uint8_t state = b[1] >> 4;
+  uint8_t dist = b[5] & 0x3F;
+
+  o.model = "WH57";
+  o.id = ((uint32_t)(b[1] & 0x0F) << 16) | ((uint32_t)b[2] << 8) | b[3];
+  o.battLow = (((b[4] >> 1) & 0x03) == 0);
+  o.rssi = rssi;
+  o.caps = CAP_LIGHTNING;
+  o.lightningCount = b[6];
+  o.lightningCountValid = (state != 0); // state 0 = startup: count not reliable
+  o.lightningDistKm = (state == 8 && dist != 63) ? dist : 63;
+  return true;
+}
+
+extern const SensorDriver DRIVER_WH57 = {"WH57", CAP_LIGHTNING, wh57_match, wh57_parse};

--- a/main/rtl_433sx1262/ws80.cpp
+++ b/main/rtl_433sx1262/ws80.cpp
@@ -1,0 +1,62 @@
+// ============================================================================
+// ws80.cpp — Fine Offset WS80 station (ultrasonic wind + T/H + UV + light)
+// 18-byte frame: YY IIII LL LL BB FF TT HH WW DD GG VV UU UU AA XX
+//   (ref. rtl_433 fineoffset_ws80.c)
+//   YY=0x80; CRC-8/0x31 of b[0..15]==b[16] (crc8(b,17)==0); SUM8(b[0..16])==b[17]
+//   b[7] (FF) carries the MSBs: 0x03 temp, 0x10 wind, 0x20 dir, 0x40 gust
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool ws80_match(const uint8_t* b, size_t len) {
+  return len >= 18 && b[0] == 0x80;
+}
+
+static bool ws80_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 18) return false;
+  if (crc8_0x31(b, 17) != 0) return false; // b[16] = CRC of b[0..15]
+  if (sum8(b, 17) != b[17]) return false; // b[17] = SUM of b[0..16]
+
+  o.model = "WS80";
+  o.id = ((uint32_t)b[1] << 16) | ((uint32_t)b[2] << 8) | b[3];
+  o.rssi = rssi;
+  o.caps = 0;
+
+  int temp_raw = ((b[7] & 0x03) << 8) | b[8];
+  if (temp_raw != 0x3ff) {
+    o.tempC = (temp_raw - 400) * 0.1f;
+    o.caps |= CAP_TEMP;
+  }
+  if (b[9] != 0xff) {
+    o.humidity = b[9];
+    o.caps |= CAP_HUM;
+  }
+
+  int wind_avg = ((b[7] & 0x10) << 4) | b[10];
+  int wind_dir = ((b[7] & 0x20) << 3) | b[11];
+  int wind_max = ((b[7] & 0x40) << 2) | b[12];
+  if (wind_avg != 0x1ff || wind_max != 0x1ff || wind_dir != 0x1ff) {
+    if (wind_avg != 0x1ff) o.windAvgMs = wind_avg * 0.1f;
+    if (wind_max != 0x1ff) o.windGustMs = wind_max * 0.1f;
+    if (wind_dir != 0x1ff) o.windDirDeg = wind_dir;
+    o.caps |= CAP_WIND;
+  }
+
+  if (b[13] != 0xff) {
+    o.uvIndex = b[13] * 0.1f;
+    o.caps |= CAP_UV;
+  }
+  int light_raw = (b[4] << 8) | b[5];
+  if (light_raw != 0xffff) {
+    o.lightLux = light_raw * 10.0f;
+    o.caps |= CAP_UV;
+  }
+
+  int batt_mv = b[6] * 20;
+  o.battV = batt_mv / 1000.0f;
+  o.battLow = (batt_mv > 0 && batt_mv < 1400);
+  return o.caps != 0;
+}
+
+extern const SensorDriver DRIVER_WS80 = {"WS80", CAP_TEMP | CAP_HUM | CAP_WIND | CAP_UV,
+                                         ws80_match, ws80_parse};

--- a/main/rtl_433sx1262/ws90.cpp
+++ b/main/rtl_433sx1262/ws90.cpp
@@ -1,0 +1,67 @@
+// ============================================================================
+// ws90.cpp — Fine Offset WS90 "Wittboy" 7-in-1 station (WS80 + piezo rain)
+// 32-byte frame (ref. rtl_433 fineoffset_ws90.c). Bytes 1-13 identical to WS80.
+//   YY=0x90; CRC-8/0x31 of b[0..29]==b[30] (crc8(b,31)==0); SUM8(b[0..30])==b[31]
+//   rain_total = ((b[19]<<8)|b[20]) * 0.1 mm
+// ============================================================================
+#include "sensor_types.h"
+#include "sensor_util.h"
+
+static bool ws90_match(const uint8_t* b, size_t len) {
+  return len >= 32 && b[0] == 0x90;
+}
+
+static bool ws90_parse(const uint8_t* b, size_t len, float rssi, SensorReading& o) {
+  if (len < 32) return false;
+  if (crc8_0x31(b, 31) != 0) return false; // b[30] = CRC of b[0..29]
+  if (sum8(b, 31) != b[31]) return false; // b[31] = SUM of b[0..30]
+
+  o.model = "WS90";
+  o.id = ((uint32_t)b[1] << 16) | ((uint32_t)b[2] << 8) | b[3];
+  o.rssi = rssi;
+  o.caps = 0;
+
+  int temp_raw = ((b[7] & 0x03) << 8) | b[8];
+  if (temp_raw != 0x3ff) {
+    o.tempC = (temp_raw - 400) * 0.1f;
+    o.caps |= CAP_TEMP;
+  }
+  if (b[9] != 0xff) {
+    o.humidity = b[9];
+    o.caps |= CAP_HUM;
+  }
+
+  int wind_avg = ((b[7] & 0x10) << 4) | b[10];
+  int wind_dir = ((b[7] & 0x20) << 3) | b[11];
+  int wind_max = ((b[7] & 0x40) << 2) | b[12];
+  if (wind_avg != 0x1ff || wind_max != 0x1ff || wind_dir != 0x1ff) {
+    if (wind_avg != 0x1ff) o.windAvgMs = wind_avg * 0.1f;
+    if (wind_max != 0x1ff) o.windGustMs = wind_max * 0.1f;
+    if (wind_dir != 0x1ff) o.windDirDeg = wind_dir;
+    o.caps |= CAP_WIND;
+  }
+
+  if (b[13] != 0xff) {
+    o.uvIndex = b[13] * 0.1f;
+    o.caps |= CAP_UV;
+  }
+  int light_raw = (b[4] << 8) | b[5];
+  if (light_raw != 0xffff) {
+    o.lightLux = light_raw * 10.0f;
+    o.caps |= CAP_UV;
+  }
+
+  // Total rain (cumulative counter, 0.1 mm steps)
+  int rain_raw = (b[19] << 8) | b[20];
+  o.rainMm = rain_raw * 0.1f;
+  o.caps |= CAP_RAIN;
+
+  int batt_mv = b[6] * 20;
+  o.battV = batt_mv / 1000.0f;
+  o.battLow = (batt_mv > 0 && batt_mv < 1400);
+  return o.caps != 0;
+}
+
+extern const SensorDriver DRIVER_WS90 = {"WS90",
+                                         CAP_TEMP | CAP_HUM | CAP_WIND | CAP_UV | CAP_RAIN,
+                                         ws90_match, ws90_parse};

--- a/main/webUI.cpp
+++ b/main/webUI.cpp
@@ -1845,7 +1845,10 @@ void WebUISetup() {
   server.on("/favicon.ico", handleFavicon); // Information
   server.begin();
 
+#  if !LOG_TO_OLED && !LOG_TO_LCD
+  // Don't clobber the OLED/LCD log redirection setupSSD1306()/setupM5() already established
   Log.begin(LOG_LEVEL, &WebLog);
+#  endif
 
   THEENGS_LOG_TRACE(F("[WebUI] displayMetric %T" CR), displayMetric);
   THEENGS_LOG_TRACE(F("[WebUI] WebUI Secure %T" CR), webUISecure);

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,7 @@ extra_configs =
 ;default_envs = esp32dev-rtl_433
 ;default_envs = esp32dev-rtl_433-fsk
 ;default_envs = heltec-rtl_433
-;default_envs = heltec-rtl_433-fsk
+default_envs = heltec-rtl_433-fsk
 ;default_envs = heltec-ble
 ;default_envs = lilygo-rtl_433
 ;default_envs = lilygo-rtl_433-fsk
@@ -109,6 +109,7 @@ extra_configs =
 ;default_envs = esp32c3u-m5stamp
 ;default_envs = lilygo-t3-s3-rtl_433
 ;default_envs = lilygo-t3-s3-rtl_433-fsk
+;default_envs = heltec_v4-rtl_433sx1262
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                              ENVIRONMENTS PARAMETERS                                 ;
@@ -163,6 +164,7 @@ decoder = https://github.com/theengs/decoder/archive/development.zip
 ssd1306 = https://github.com/ThingPulse/esp8266-oled-ssd1306/archive/f96fd6a.zip
 lm75 = jeremycole/I2C Temperature Sensors derived from the LM75@^1.0.3
 rn8209 = https://github.com/theengs/RN8209C-SDK/archive/arduino.zip
+radiolib = jgromes/RadioLib@^7.1.2
 
 [env]
 framework = arduino


### PR DESCRIPTION
## Description:
- `rtl_433_ESP` cannot drive the SX1262 radio on Heltec WiFi LoRa 32 V3/V4 boards, so Fine Offset/Ecowitt/LaCrosse "Group A" sensors (WH32, WH31E, WH40, WH57, WH51, WH45, WS80, WS90, TX35) were previously unreceivable there. This adds a standalone RadioLib-based gateway (`gatewayRTL_433SX1262.cpp`) that talks to the SX1262 in FSK mode directly and publishes readings on the existing RTL_433 MQTT topic, so downstream automations built around rtl_433 sensors keep working unchanged.
- Adds a new build environment, `heltec_v4-rtl_433sx1262` (`pio run -e heltec_v4-rtl_433sx1262 -t upload`).
- Wires the new gateway into `main.cpp`'s setup/loop and into the shared duplicate-signal-filtering logic alongside RF/IR/SRFB/WeatherStation/RTL_433.
- Adds Home Assistant MQTT discovery support for this gateway. It previously published sensor readings but never called `createDiscovery()`, since the real RTL_433 discovery machinery lives in `gatewayRTL_433.cpp` gated behind `ZgatewayRTL_433` (a flag this standalone gateway intentionally doesn't define). Adds a lightweight per-device discovery path directly in `gatewayRTL_433SX1262.cpp`, firing synchronously from the main loop since this gateway has no separate decode task to synchronize with.
- Renames the published `strike_distance` key to `strike_distance_km` to match its actual unit and the discovery template.


This was adapted by claude from https://github.com/iz0kew/WeatherStation2Meshtastic

### Test plan

- [x] `pio run -e heltec_v4-rtl_433sx1262` builds successfully
- [x] Flash to a Heltec WiFi LoRa 32 V4 and confirm WH32/WH31E/WH40/WH57/WH51/WH45/WS80/WS90/TX35 readings are received and published on the RTL_433 MQTT topic
- [x] Confirm Home Assistant auto-discovers each sensor's entities (temperature, humidity, pressure, rain, wind, UV/lux, lightning, PM2.5/PM10, CO2, soil moisture, battery) with correct units/device classes
- [x] Confirm no regressions on existing `ZgatewayRTL_433`/RF/IR/SRFB/WeatherStation duplicate-filtering behavior
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
