### PR TITLE
[SYS] Keep WiFiManager portal available when saved WiFi credentials are lost

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2317,7 +2317,11 @@ void setupWiFiManager() {
     // Check if the config file exists and prevent the portal from showing if yes
     // Showing the portal if the config file exist would enable access to the configuration data and to the ESP update page
     // This is a security risk if an attacker has access to the gateway password
-    if (SPIFFS.exists("/config.json")) {
+    // Only suppress the portal when we still have saved WiFi credentials. If the
+    // credentials were lost (e.g. NVS erased) while config.json remains, keeping
+    // the portal disabled makes the gateway impossible to re-onboard and it
+    // reboot-loops (autoConnect fails immediately -> ESPRestart, forever).
+    if (SPIFFS.exists("/config.json") && WiFi.SSID().length() > 0) {
       wifiManager.setEnableConfigPortal(false);
     }
   }


### PR DESCRIPTION
## Description:
setupWiFiManager() disables the config portal whenever /config.json exists (a security measure to avoid exposing the config data + OTA page). But if the saved WiFi credentials are lost while config.json remains -- e.g. the NVS partition is erased ({"cmd":"erase"}, or corruption) -- the gateway can no longer connect AND the portal is suppressed: autoConnect() fails immediately and the failure path calls ESPRestart(3). The device then reboot-loops forever, un-onboardable, its SoftAP flickering up ~1s per cycle.

Only suppress the portal when config.json exists AND saved STA credentials are still present (WiFi.SSID() non-empty). With no credentials the portal stays enabled, so the gateway raises a stable onboarding AP and can be re-provisioned instead of reboot-looping. The original security intent is preserved for provisioned gateways (which always have saved credentials).

Reproduced + verified on a Theengs Plug (esp32dev, min_spiffs): with NVS erased and config.json present, the SoftAP is now stable and accepts provisioning via the captive portal, rejoining the broker normally.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
