### PR TITLE
SERIAL gateway: make frame format (parity/stop bits) configurable

### DIFF
--- a/main/config_SERIAL.h
+++ b/main/config_SERIAL.h
@@ -81,6 +81,10 @@ extern bool XtoSERIAL(const char* topicOri, JsonObject& SERIALdata);
 #  define SERIALBaud 9600 // The serial connection Baud
 #endif
 
+#ifndef SERIAL_CONFIG
+#  define SERIAL_CONFIG SERIAL_8N1 // The serial frame format (data/parity/stop bits), e.g. SERIAL_8E1 for 8 data bits/even parity/1 stop bit
+#endif
+
 /*-------------------PIN DEFINITIONS----------------------*/
 #ifndef SERIAL_UART
 // set hardware serial UART to be used for device communication or

--- a/main/gatewaySERIAL.cpp
+++ b/main/gatewaySERIAL.cpp
@@ -78,9 +78,9 @@ void setupSERIAL() {
 #    if SERIAL_UART == 0 // init UART0
   Serial.end(); // stop if already initialized
 #      ifdef ESP32
-  Serial.begin(SERIALBaud, SERIAL_8N1, SERIAL_RX_GPIO, SERIAL_TX_GPIO);
+  Serial.begin(SERIALBaud, SERIAL_CONFIG, SERIAL_RX_GPIO, SERIAL_TX_GPIO);
 #      else
-  Serial.begin(SERIALBaud, SERIAL_8N1);
+  Serial.begin(SERIALBaud, SERIAL_CONFIG);
 #      endif
 #      if defined(ESP8266) && defined(SERIAL_UART0_SWAP)
   Serial.swap(); // swap UART0 ports from (GPIO1,GPIO3) to (GPIO15,GPIO13)
@@ -91,9 +91,9 @@ void setupSERIAL() {
 #    elif SERIAL_UART == 1 // init UART1
   Serial1.end(); // stop if already initialized
 #      ifdef ESP32
-  Serial1.begin(SERIALBaud, SERIAL_8N1, SERIAL_RX_GPIO, SERIAL_TX_GPIO);
+  Serial1.begin(SERIALBaud, SERIAL_CONFIG, SERIAL_RX_GPIO, SERIAL_TX_GPIO);
 #      else
-  Serial1.begin(SERIALBaud, SERIAL_8N1);
+  Serial1.begin(SERIALBaud, SERIAL_CONFIG);
 #      endif
   SERIALStream = &Serial1;
   THEENGS_LOG_NOTICE(F("SERIAL HW UART1" CR));
@@ -101,16 +101,16 @@ void setupSERIAL() {
 #    elif SERIAL_UART == 2 // init UART2
   Serial2.end(); // stop if already initialized
 #      ifdef ESP32
-  Serial2.begin(SERIALBaud, SERIAL_8N1, SERIAL_RX_GPIO, SERIAL_TX_GPIO);
+  Serial2.begin(SERIALBaud, SERIAL_CONFIG, SERIAL_RX_GPIO, SERIAL_TX_GPIO);
 #      else
-  Serial2.begin(SERIALBaud, SERIAL_8N1);
+  Serial2.begin(SERIALBaud, SERIAL_CONFIG);
 #      endif
   SERIALStream = &Serial2;
   THEENGS_LOG_NOTICE(F("SERIAL HW UART2" CR));
 
 #    elif SERIAL_UART == 3 // init UART3
   Serial3.end(); // stop if already initialized
-  Serial3.begin(SERIALBaud, SERIAL_8N1);
+  Serial3.begin(SERIALBaud, SERIAL_CONFIG);
   SERIALStream = &Serial3;
   THEENGS_LOG_NOTICE(F("SERIAL HW UART3" CR));
 #    endif


### PR DESCRIPTION
## Problem

`ZgatewaySERIAL`'s `setupSERIAL()` hardcodes `SERIAL_8N1` in every `Serial*.begin()` call (UART0/1/2/3), with no way to override it via a build flag — unlike `SERIALBaud`, which already follows the standard `#ifndef`/`#define` override pattern used elsewhere in this codebase.

Devices that use a different frame format (e.g. even-parity RS232 output, which is what led me here) currently can't be read at all — a parity mismatch misaligns the byte frame, it doesn't just add occasional noise.

## Fix

Adds `SERIAL_CONFIG`, following the exact override pattern already used for `SERIALBaud`/`SERIAL_RX_GPIO`/etc. in `config_SERIAL.h`, defaulting to `SERIAL_8N1` so existing environments are unaffected. All four `Serial*.begin()` calls in `gatewaySERIAL.cpp` now use it instead of the hardcoded literal.

```ini
build_flags =
  '-DSERIAL_CONFIG=SERIAL_8E1'
```

## Testing

Built successfully on ESP32 (`hillclimb-wt32-eth01-serial`, a WT32-ETH01 + `ZgatewaySERIAL` + `ESP32_ETHERNET` environment) both with the default (`SERIAL_8N1`, byte-identical behavior to before) and with `SERIAL_CONFIG=SERIAL_8E1` overridden. Didn't touch ESP8266 codepaths beyond the same mechanical substitution — `HardwareSerial::begin`'s config parameter is part of the standard Arduino API on both platforms.

Small and mechanical by design — happy to adjust naming/scope if you'd prefer a different approach.