### PR TITLE
[Ethernet] Optional AP-SSID-as-IP broadcast for easy device discovery

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2514,11 +2514,15 @@ void WiFiEvent(WiFiEvent_t event) {
       THEENGS_LOG_NOTICE(F("OpenMQTTGateway Ethernet MAC: %s" CR), ETH.macAddress().c_str());
       THEENGS_LOG_NOTICE(F("OpenMQTTGateway Ethernet IP: %s" CR), ETH.localIP().toString().c_str());
       THEENGS_LOG_NOTICE(F("OpenMQTTGateway Ethernet link speed: %d Mbps" CR), ETH.linkSpeed());
-#if defined(IP_DISCOVERY_AP)
-      setupIPDiscoveryAP();
-#endif
       gatewayState = GatewayState::NTWK_CONNECTED;
       ethConnected = true;
+#if defined(IP_DISCOVERY_AP)
+      // Must run after ethConnected = true, not before: setup_ethernet_esp32()'s caller polls
+      // ethConnected with a short (~2.5s) timeout budget before deciding whether to launch
+      // WiFiManager's portal, and starting the WiFi radio in AP mode here can easily eat into
+      // that budget on its own.
+      setupIPDiscoveryAP();
+#endif
       break;
     case ARDUINO_EVENT_ETH_DISCONNECTED:
       THEENGS_LOG_WARNING(F("Ethernet Disconnected" CR));

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -265,6 +265,9 @@ void updateAndHandleLEDsTask();
 bool loadConfigFromFlash();
 void setupWiFiManager();
 void setOTA();
+#if defined(ESP32_ETHERNET) && defined(IP_DISCOVERY_AP)
+void setupIPDiscoveryAP();
+#endif
 void setupCommonRF();
 void sleep();
 bool checkForUpdates();
@@ -2476,6 +2479,28 @@ void setup_ethernet_esp32() {
   }
 }
 
+#if defined(ESP32_ETHERNET) && defined(IP_DISCOVERY_AP)
+// Broadcasts a WiFi AP whose SSID *is* the gateway's current IP address, so it can be found
+// with nothing more than a phone's normal WiFi network list -- no app, no mDNS/network-path
+// dependency. Aimed at Ethernet-only boards (no onboard display, no serial access without a
+// USB-TTL adapter) where finding the DHCP-assigned IP otherwise means a scanner app or a
+// router login. Password reuses ota_pass (already a per-device secret derived from the MAC
+// unless overridden) so the AP itself isn't open to anyone nearby -- the SSID/IP is still
+// readable in a WiFi network list without joining, same as any other visible network.
+void setupIPDiscoveryAP() {
+  static IPAddress lastAdvertisedIp;
+  const IPAddress ip = ETH.localIP();
+  if (ip == lastAdvertisedIp) {
+    return; // already advertising this address, nothing to do
+  }
+  lastAdvertisedIp = ip;
+
+  WiFi.mode((WiFiMode_t)(WiFi.getMode() | WIFI_MODE_AP));
+  WiFi.softAP(ip.toString().c_str(), ota_pass);
+  THEENGS_LOG_NOTICE(F("IP discovery AP started, SSID: %s" CR), ip.toString().c_str());
+}
+#endif
+
 void WiFiEvent(WiFiEvent_t event) {
   switch (event) {
     case ARDUINO_EVENT_ETH_START:
@@ -2489,6 +2514,9 @@ void WiFiEvent(WiFiEvent_t event) {
       THEENGS_LOG_NOTICE(F("OpenMQTTGateway Ethernet MAC: %s" CR), ETH.macAddress().c_str());
       THEENGS_LOG_NOTICE(F("OpenMQTTGateway Ethernet IP: %s" CR), ETH.localIP().toString().c_str());
       THEENGS_LOG_NOTICE(F("OpenMQTTGateway Ethernet link speed: %d Mbps" CR), ETH.linkSpeed());
+#if defined(IP_DISCOVERY_AP)
+      setupIPDiscoveryAP();
+#endif
       gatewayState = GatewayState::NTWK_CONNECTED;
       ethConnected = true;
       break;


### PR DESCRIPTION
## Summary

Adds an opt-in way to find an Ethernet-mode gateway's current IP at a site where you don't otherwise have easy access to the DHCP lease list (e.g. a router you don't control, at a temporary/mobile deployment). When enabled, the gateway broadcasts a WiFi AP whose SSID *is* its current IP address — readable in any phone's normal WiFi network list, no companion app, no mDNS/network-path dependency.

Built with Claude Code assistance, developed on this branch for review before opening the PR.

## What changed

`main/main.cpp` only, +32 lines, guarded entirely behind `#if defined(ESP32_ETHERNET) && defined(IP_DISCOVERY_AP)` — zero effect on any build that doesn't define `IP_DISCOVERY_AP`.

- `setupIPDiscoveryAP()`: `WiFi.mode(WiFi.getMode() | WIFI_MODE_AP)` (preserves whatever mode an Ethernet-only build is already in) + `WiFi.softAP(ip.toString().c_str(), ota_pass)` — SSID is the literal IP, password reuses the existing per-device `ota_pass` so the AP isn't open to join (though the SSID/IP is visible in a network list regardless of joining).
- Hooked into `WiFiEvent()`'s `ARDUINO_EVENT_ETH_GOT_IP` case, called *after* `ethConnected` is set — an ordering fix from an earlier iteration: calling it before `ethConnected` flips could eat into the ~2.5s budget `setup_ethernet_esp32()` gives before deciding whether to launch WiFiManager's own portal, and could trigger that portal even with valid config.
- A static `lastAdvertisedIp` guard skips re-advertising if the event fires again with an unchanged IP.

Measured cost: flash +~270 bytes, RAM +40 bytes vs. a build without this flag — no new library dependency (`WiFi.h`'s AP mode is already part of the Arduino core).

## Testing done — and an important gap

Compiles clean. The `ethConnected`-ordering fix above was made in response to a real hardware test that showed the device falling into WiFiManager's own portal unexpectedly. **However, this branch has not yet been re-tested on real hardware since that fix** — I can't currently confirm the AP actually appears in a phone's WiFi list, or that the `ota_pass`-derived password successfully lets you join it. Flagging this explicitly rather than claiming it's verified; happy to confirm before this merges if that's preferred, or treat this as a draft for now.

## Scope note

Deliberately scoped to Ethernet-only builds for this PR, matching where `WiFiEvent()` itself already lives (`#ifdef ESP32_ETHERNET`). Making this work for WiFi-STA gateways too would need a second hook point (`ARDUINO_EVENT_WIFI_STA_GOT_IP`) — kept out of scope to keep this small and focused.