### PR TITLE
[FIX] Restore GET route for /wi so the WiFi scan link works

### DIFF
--- a/main/webUI.cpp
+++ b/main/webUI.cpp
@@ -1820,7 +1820,8 @@ void WebUISetup() {
   server.on("/up", handleUP); // Firmware Upgrade
 #  endif
   server.on("/cn", handleCN); // Configuration
-  server.on("/wi", HTTP_POST, handleWI); // Configure Wifi
+  server.on("/wi", HTTP_GET, handleWI); // Scan for WiFi networks (GET link)
+  server.on("/wi", HTTP_POST, handleWI); // Configure Wifi (save form, POST)
   server.on("/mq", HTTP_POST, handleMQ); // Configure MQTT
 #  ifndef ESPWifiManualSetup
   server.on("/cg", handleCG); // Configure gateway


### PR DESCRIPTION
## Description:
handleWI() dispatches internally on the "scan" query arg, so the same handler serves both the scan link and the save form. #2037 narrowed the route to POST-only, which orphaned the scan hyperlink (a GET) in config_WebContent.h. Re-register /wi for HTTP_GET alongside HTTP_POST; the credential Save form stays method=post, so no secrets move to GET.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
