### PR TITLE
[FIX] ESP32 Ethernet: make NetworkAdvancedSetup usable, and skip WiFiManager when Ethernet is up

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1451,9 +1451,13 @@ void setup() {
     checkSerial();
 #  endif
 
-    THEENGS_LOG_NOTICE(F("No config in flash, launching wifi manager" CR));
-    // In failSafeMode we don't want to setup wifi manager as it has already been done before
-    if (!failSafeMode) setupWiFiManager();
+    // In failSafeMode we don't want to setup wifi manager as it has already been done before,
+    // and with Ethernet already connected we don't need it at all: bringing up the WiFi radio
+    // would only add 2.4GHz contention with BLE.
+    if (!failSafeMode && !ethConnected) {
+      THEENGS_LOG_NOTICE(F("No config in flash, launching wifi manager" CR));
+      setupWiFiManager();
+    }
   }
 
 #endif
@@ -2447,18 +2451,23 @@ void setup_ethernet_esp32() {
   bool ethBeginSuccess = false;
   WiFi.onEvent(WiFiEvent);
 #    ifdef NetworkAdvancedSetup
-  IPAddress ip_adress;
-  IPAddress gateway_adress;
-  IPAddress subnet_adress;
-  IPAddress dns_adress;
-  ip.fromString(NET_IP);
-  gateway.fromString(NET_GW);
-  subnet.fromString(NET_MASK);
-  Dns.fromString(NET_DNS);
-
   THEENGS_LOG_TRACE(F("Adv eth cfg" CR));
-  ETH.config(ip, gateway, subnet, Dns);
+  // ETH.config() has to be called after ETH.begin(): the underlying netif is
+  // created by begin(), before that the call returns false and is a no-op.
   ethBeginSuccess = ETH.begin();
+  if (ethBeginSuccess) {
+    IPAddress ip_adress;
+    IPAddress gateway_adress;
+    IPAddress subnet_adress;
+    IPAddress dns_adress;
+    ip_adress.fromString(NET_IP);
+    gateway_adress.fromString(NET_GW);
+    subnet_adress.fromString(NET_MASK);
+    dns_adress.fromString(NET_DNS);
+    if (!ETH.config(ip_adress, gateway_adress, subnet_adress, dns_adress)) {
+      THEENGS_LOG_ERROR(F("Adv eth cfg failed" CR));
+    }
+  }
 #    else
   THEENGS_LOG_NOTICE(F("Spl eth cfg" CR));
   ethBeginSuccess = ETH.begin();


### PR DESCRIPTION
Static IP over Ethernet on ESP32 is currently unusable, and a factory-fresh
board with a working Ethernet link still brings up the WiFi radio. Three
related fixes, all in `setup()` / `setup_ethernet_esp32()`.

### 1. `NetworkAdvancedSetup` + `ESP32_ETHERNET` does not compile

`setup_ethernet_esp32()` declared `ip_adress` / `gateway_adress` /
`subnet_adress` / `dns_adress`, then called `fromString()` on `ip`, `gateway`,
`subnet` and `Dns` — identifiers that are declared nowhere in the tree. Any
environment combining the two flags fails to build.

The WiFi path in `setupwifi()` does the same thing correctly, so this looks
like an incomplete copy of it. This change follows that naming.

### 2. Even once it compiles, the static IP was silently ignored

`ETH.config()` was called **before** `ETH.begin()`. In arduino-esp32,
`NetworkInterface::config()` starts with:

```cpp
if (_esp_netif == NULL) {
  return false;
}
```

and `_esp_netif` is only created inside `ETH.begin()` (`esp_netif_new()`). So
the call returned `false` and did nothing: the board went on to request DHCP,
and on a network without a DHCP server it timed out and fell through to the
WiFi manager — the exact scenario the setting exists to avoid.

Swapping the order is safe. The client branch of `config()` stops the running
DHCP client itself (`esp_netif_dhcpc_stop`), applies the static address and
sets `ESP_NETIF_HAS_STATIC_IP_BIT`. The return value is now checked and logged
instead of discarded, so a bad configuration is visible rather than silent.

### 3. WiFi manager started even with Ethernet already connected

In `setup()`, the "config loaded from flash" branch guards correctly:

```cpp
if (!failSafeMode && !ethConnected) setupWiFiManager();
```

but the "no config in flash" branch a few lines below checked only
`!failSafeMode`. A factory-fresh board whose Ethernet link is already up would
therefore start the WiFi manager anyway.

Besides being unnecessary, it powers up the 2.4 GHz radio and competes with
BLE on gateways running `ZgatewayBT` over Ethernet, which costs advertisements.
This aligns the two branches rather than introducing a new rule; the log line
moved inside the guard so it is not printed when the manager is skipped.

`ethConnected` is declared unconditionally at the top of `main.cpp`, so the
added check compiles on boards built without `ESP32_ETHERNET`.

## Verification

Tested on three Olimex ESP32-POE-ISO boards. With `NetworkAdvancedSetup` and
`NET_IP` set, each board now takes its address immediately with no DHCP wait,
does not fall back to the WiFi manager, and connects to the broker:

```
N: Ethernet Connected
N: OpenMQTTGateway Ethernet IP: 192.168.0.62
N: OpenMQTTGateway Ethernet link speed: 100 Mbps
N: Connected to broker
N: Scan begin
```

Builds checked on three environments to cover the paths this touches:

| Environment | Path covered |
|---|---|
| `esp32-olimex-gtw-ble-poe-iso` | Ethernet without `NetworkAdvancedSetup` |
| `esp32dev-ble` | ESP32 without `ESP32_ETHERNET` |
| `nodemcuv2-2g` | ESP8266 toolchain |

Formatting checked with `clang-format` against the repository's
`.clang-format`: no differences in the file.

Happy to split the third fix into its own PR if you would rather keep the
behaviour change separate from the two build/no-op bugs.
