### PR TITLE
[SYS] esp32-arduino-libs: bump 0.1.7 -> 0.1.8 (restores RISC-V -march)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -181,7 +181,7 @@ extra_scripts = pre:scripts/add_mlongcalls.py
 [com]
 esp8266_platform = espressif8266@4.2.1
 esp32_platform =  https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
-esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.7/esp32-arduino-libs.tar.gz
+esp32_platform_packages = framework-arduinoespressif32-libs @ https://github.com/theengs/esp32-arduino-lib-builder/releases/download/0.1.8/esp32-arduino-libs.tar.gz
 esp32_solo_platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 atmelavr_platform = atmelavr@3.3.0
 


### PR DESCRIPTION
## Description:
0.1.7 shipped esp32c3 flags with no -march at all, so every ESP32-C2/C3 build fell back to the compiler default (rv32imafdc) and emitted atomic and hardware-FP instructions the core does not implement. The firmware panicked with "Illegal instruction" during C++ static init — on the first std::shared_ptr refcount, inside the Arduino core's global SPIFFS constructor — so the board boot-looped before printing a single line of OMG output. That is issue #2336: esp32c3-dev-c2-ble dev builds boot-loop while 1.8.1 (built on arduino-esp32 2.x, which passed -march=rv32imc explicitly) is fine.

The flag was lost in packaging, not in the compiler: ESP-IDF >= 5.5.2 moved the toolchain base flags into @response files and the lib-builder's flag extraction silently dropped them. The precompiled libs were always correct RV32IMC code. 0.1.8 restores -march across c_flags/cpp_flags/S_flags/ld_flags and pioarduino-build.py, and fails the lib build if a target's ISA flag ever goes missing again (theengs/esp32-arduino-lib-builder#9).

Xtensa targets were never affected — each core has its own GCC driver whose default multilib already matches — but they are rebuilt from the same bundle, so esp32/esp32s3 want a smoke test alongside the C3.

Bench-verified on an ESP32-C3 rev v0.4: boot-loops on 0.1.7 (30 panics in 20 s, MTVAL 0x06f7202f), boots and decodes BLE on 0.1.8 with no project-level flags.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
