### PR TITLE
[SYS] Migrate M5 boards to M5Unified + M5GFX (modern platform)

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -649,7 +649,8 @@ custom_hardware = OLIMEX ESP32 Gateway
 custom_img = img/boards/olimex-esp32-gateway.jpg
 
 [env:esp32-m5stick-ble]
-platform = espressif32@6.1.0
+platform = ${com.esp32_platform}
+platform_packages = ${com.esp32_platform_packages}
 board = m5stack-core-esp32
 board_build.partitions = partitions/no_coredump.csv
 lib_deps =
@@ -673,12 +674,13 @@ custom_hardware = M5Stick Grey
 custom_img = img/boards/m5stick.webp
 
 [env:esp32-m5stack-ble]
-platform = espressif32@6.1.0
+platform = ${com.esp32_platform}
+platform_packages = ${com.esp32_platform_packages}
 board = m5stack-core-esp32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
-  ${libraries.m5stack}
+  ${libraries.m5unified}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -698,12 +700,13 @@ custom_hardware = M5Stack Core
 custom_img = img/boards/m5stack-core.webp
 
 [env:esp32-m5tough-ble]
-platform = espressif32@6.1.0
+platform = ${com.esp32_platform}
+platform_packages = ${com.esp32_platform_packages}
 board = m5stack-core-esp32
 board_build.partitions = min_spiffs.csv
 lib_deps =
   ${com-esp32.lib_deps}
-  ${libraries.m5tough}
+  ${libraries.m5unified}
   ${libraries.ble}
   ${libraries.decoder}
 build_flags =
@@ -717,14 +720,23 @@ custom_hardware = M5Tough rugged
 custom_img = img/boards/m5tough.webp
 
 [env:esp32-m5stick-c-ble]
-platform = espressif32@6.1.0
-board = m5stick-c
-board_build.partitions = min_spiffs.csv
+platform = ${com.esp32_platform}
+platform_packages = ${com.esp32_platform_packages}
+; The modern framework dropped the "m5stick_c" board variant (no
+; pins_arduino.h), so target the identical ESP32-PICO-D4 "pico32" variant
+; instead — the same silicon the M5StickC-Plus env already uses. M5Unified
+; detects the real StickC at runtime, and OMG defines every StickC GPIO
+; explicitly below, so the variant's pin defaults are irrelevant.
+board = pico32
+; M5Unified is much larger than the old M5StickC lib and overflows min_spiffs'
+; 0x1E0000 app slot (~1.9 MB) once IR is also enabled; use the 0x1F0000 layout
+; the M5StickC-Plus env already uses.
+board_build.partitions = partitions/no_coredump.csv
 lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.ble}
   ${libraries.decoder}
-  ${libraries.m5stickc}
+  ${libraries.m5unified}
   ${libraries.irremoteesp}
 build_flags =
   ${com-esp32.build_flags}
@@ -748,14 +760,15 @@ custom_hardware = M5Stick C
 custom_img = img/boards/m5stick-c.webp
 
 [env:esp32-m5stick-cp-ble]
-platform = espressif32@6.1.0
+platform = ${com.esp32_platform}
+platform_packages = ${com.esp32_platform_packages}
 board = pico32
 board_build.partitions = partitions/no_coredump.csv
 lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.ble}
   ${libraries.decoder}
-  ${libraries.m5stickcp}
+  ${libraries.m5unified}
   ${libraries.irremoteesp}
 build_flags =
   ${com-esp32.build_flags}

--- a/main/boardM5.cpp
+++ b/main/boardM5.cpp
@@ -30,19 +30,7 @@
 
 #if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
 #  include "TheengsCommon.h"
-#  include "config_M5.h"
-#  ifdef ZboardM5STICKC
-#    include <M5StickC.h>
-#  endif
-#  ifdef ZboardM5STICKCP
-#    include <M5StickCPlus.h>
-#  endif
-#  ifdef ZboardM5STACK
-#    include <M5Stack.h>
-#  endif
-#  ifdef ZboardM5TOUGH
-#    include <M5Tough.h>
-#  endif
+#  include "config_M5.h" // pulls in <M5Unified.h> for every M5 board
 
 void wakeScreen(int brightness);
 void displayIntro(int i, int X, int Y);
@@ -55,22 +43,22 @@ void logToLCD(bool display) {
 }
 
 void setBrightness(int brightness) {
-#  if defined(ZboardM5STACK)
-  M5.Lcd.setBrightness(brightness * 2);
-#  endif
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5TOUGH)
-  (!brightness) ? M5.Axp.ScreenBreath(0) : M5.Axp.ScreenBreath(7 + (int)brightness * 0.08);
-#  endif
+  // M5Unified drives the backlight uniformly across Core (direct control) and
+  // the AXP-powered boards (Stick C/CP, Tough), replacing the old per-board
+  // M5.Lcd.setBrightness / M5.Axp.ScreenBreath split. Map the 0..100 OMG scale
+  // onto the panel's 0..255 range (100 -> 200, sleep 2 -> 4).
+  M5.Display.setBrightness(brightness * 2);
 }
 
 void setupM5() {
   THEENGS_LOG_NOTICE(F("Setup M5" CR));
+  M5.begin(); // auto-detects the board, initialises the display and power
   pinMode(SLEEP_BUTTON, INPUT);
   // M5 stack 320*240
   // M5StickC 160*80
   // M5Stick LCD not supported
   wakeScreen(NORMAL_LCD_BRIGHTNESS);
-  M5.Lcd.fillScreen(WHITE);
+  M5.Lcd.fillScreen(TFT_WHITE);
   displayIntro(M5.Lcd.width() * 0.25, (M5.Lcd.width() / 2) + M5.Lcd.width() * 0.12, (M5.Lcd.height() / 2) + M5.Lcd.height() * 0.2);
 #  if LOG_TO_LCD
   Log.begin(LOG_LEVEL_LCD, &M5.Lcd); // Log on LCD following LOG_LEVEL_LCD
@@ -81,18 +69,15 @@ void setupM5() {
 
 void sleepScreen() {
   THEENGS_LOG_TRACE(F("Screen going to sleep" CR));
-#  if defined(ZboardM5STACK)
-  M5.begin(false, false, false); // M5.lcd.sleep() provokes a reset of the ESP
-#  endif
-#  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5TOUGH)
-  M5.Axp.ScreenBreath(0);
-  M5.Axp.SetLDO2(false);
-#  endif
+  // Backlight off + panel sleep. M5Unified routes this to the AXP LDO on
+  // Stick/Tough and to the Core's backlight control, so the old M5.begin()
+  // re-init workaround and the M5.Axp calls are no longer needed.
+  M5.Display.sleep();
 }
 
 void wakeScreen(int brightness) {
   THEENGS_LOG_TRACE(F("Screen wake up" CR));
-  M5.begin();
+  M5.Display.wakeup(); // undo sleepScreen(); harmless if already awake
   M5.Lcd.setCursor(0, 0, (M5.Lcd.height() > 200) ? 4 : 2);
   M5.Lcd.setTextSize(1);
   M5.Lcd.setRotation(1);
@@ -167,38 +152,38 @@ void drawLogo(int logoSize, int circle1X, int circle1Y, bool circle1, bool circl
   int circle2Y = circle1Y - (logoSize * 0.8);
 
   if (line1) {
-    M5.Lcd.drawLine(circle1X - 2, circle1Y, circle2X - 2, circle2Y, BLUE);
-    M5.Lcd.drawLine(circle1X - 1, circle1Y, circle2X - 1, circle2Y, BLUE);
-    M5.Lcd.drawLine(circle1X, circle1Y, circle2X, circle2Y, BLUE);
-    M5.Lcd.drawLine(circle1X + 1, circle1Y, circle2X + 1, circle2Y, BLUE);
-    M5.Lcd.drawLine(circle1X + 2, circle1Y, circle2X + 2, circle2Y, BLUE);
-    M5.Lcd.fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T * 2, WHITE);
+    M5.Lcd.drawLine(circle1X - 2, circle1Y, circle2X - 2, circle2Y, TFT_BLUE);
+    M5.Lcd.drawLine(circle1X - 1, circle1Y, circle2X - 1, circle2Y, TFT_BLUE);
+    M5.Lcd.drawLine(circle1X, circle1Y, circle2X, circle2Y, TFT_BLUE);
+    M5.Lcd.drawLine(circle1X + 1, circle1Y, circle2X + 1, circle2Y, TFT_BLUE);
+    M5.Lcd.drawLine(circle1X + 2, circle1Y, circle2X + 2, circle2Y, TFT_BLUE);
+    M5.Lcd.fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T * 2, TFT_WHITE);
   }
   if (line2) {
-    M5.Lcd.drawLine(circle1X - 2, circle1Y, circle3X - 2, circle3Y, BLUE);
-    M5.Lcd.drawLine(circle1X - 1, circle1Y, circle3X - 1, circle3Y, BLUE);
-    M5.Lcd.drawLine(circle1X, circle1Y, circle3X, circle3Y, BLUE);
-    M5.Lcd.drawLine(circle1X + 1, circle1Y, circle3X + 1, circle3Y, BLUE);
-    M5.Lcd.fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T * 2, WHITE);
+    M5.Lcd.drawLine(circle1X - 2, circle1Y, circle3X - 2, circle3Y, TFT_BLUE);
+    M5.Lcd.drawLine(circle1X - 1, circle1Y, circle3X - 1, circle3Y, TFT_BLUE);
+    M5.Lcd.drawLine(circle1X, circle1Y, circle3X, circle3Y, TFT_BLUE);
+    M5.Lcd.drawLine(circle1X + 1, circle1Y, circle3X + 1, circle3Y, TFT_BLUE);
+    M5.Lcd.fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T * 2, TFT_WHITE);
   }
-  M5.Lcd.fillCircle(circle1X, circle1Y, logoSize / 2 - circle1T * 2, WHITE);
+  M5.Lcd.fillCircle(circle1X, circle1Y, logoSize / 2 - circle1T * 2, TFT_WHITE);
   if (circle1) {
-    M5.Lcd.fillCircle(circle1X, circle1Y, logoSize / 2, WHITE);
+    M5.Lcd.fillCircle(circle1X, circle1Y, logoSize / 2, TFT_WHITE);
     M5.Lcd.fillCircle(circle1X, circle1Y, logoSize / 2 - circle1T, TFT_GREEN);
-    M5.Lcd.fillCircle(circle1X, circle1Y, logoSize / 2 - circle1T * 2, WHITE);
+    M5.Lcd.fillCircle(circle1X, circle1Y, logoSize / 2 - circle1T * 2, TFT_WHITE);
   }
   if (circle2) {
-    M5.Lcd.fillCircle(circle2X, circle2Y, logoSize / 3, WHITE);
+    M5.Lcd.fillCircle(circle2X, circle2Y, logoSize / 3, TFT_WHITE);
     M5.Lcd.fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T, TFT_ORANGE);
-    M5.Lcd.fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T * 2, WHITE);
+    M5.Lcd.fillCircle(circle2X, circle2Y, logoSize / 3 - circle2T * 2, TFT_WHITE);
   }
   if (circle3) {
-    M5.Lcd.fillCircle(circle3X, circle3Y, logoSize / 4, WHITE);
+    M5.Lcd.fillCircle(circle3X, circle3Y, logoSize / 4, TFT_WHITE);
     M5.Lcd.fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T, TFT_PINK);
-    M5.Lcd.fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T * 2, WHITE);
+    M5.Lcd.fillCircle(circle3X, circle3Y, logoSize / 4 - circle3T * 2, TFT_WHITE);
   }
   if (name) {
-    M5.Lcd.setTextColor(BLUE);
+    M5.Lcd.setTextColor(TFT_BLUE);
     M5.Lcd.drawString("penMQTTGateway", circle1X + (circle1X * 0.27), circle1Y, (M5.Lcd.height() > 200) ? 4 : 2);
   }
 }
@@ -207,7 +192,7 @@ void M5Print(char* line1, char* line2, char* line3) {
   wakeScreen(NORMAL_LCD_BRIGHTNESS);
   M5.Lcd.fillScreen(TFT_WHITE);
   drawLogo(M5.Lcd.width() * 0.1875, (M5.Lcd.width() / 2) - M5.Lcd.width() * 0.24, M5.Lcd.height() * 0.5, true, true, true, true, true, true);
-  M5.Lcd.setTextColor(BLUE);
+  M5.Lcd.setTextColor(TFT_BLUE);
   M5.Lcd.drawString(line1, 5, M5.Lcd.height() * 0.7, 1);
   M5.Lcd.drawString(line2, 5, M5.Lcd.height() * 0.8, 1);
   M5.Lcd.drawString(line3, 5, M5.Lcd.height() * 0.9, 1);

--- a/main/config_M5.h
+++ b/main/config_M5.h
@@ -26,18 +26,12 @@
 #ifndef config_M5_h
 #define config_M5_h
 
-#ifdef ZboardM5STICKC
-#  include <M5StickC.h>
-#endif
-#ifdef ZboardM5STICKCP
-#  include <M5StickCPlus.h>
-#endif
-#ifdef ZboardM5STACK
-#  include <M5Stack.h>
-#endif
-#ifdef ZboardM5TOUGH
-#  include <M5Tough.h>
-#endif
+// All M5 boards (Core / Stick C / Stick C Plus / Tough) are driven through the
+// unified M5Unified + M5GFX libraries, which build on the modern Arduino core
+// and auto-detect the board at runtime. This replaces the per-board libraries
+// (M5Stack / M5StickC / M5StickC-Plus / M5Tough) that were pinned to Arduino
+// core 2.x (espressif32@6.1.0) because they don't compile on core 3.x.
+#include <M5Unified.h>
 
 extern void setupM5();
 extern void loopM5();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2933,23 +2933,20 @@ String stateMeasures() {
     SYSdata["mac"] = (char*)WiFi.macAddress().c_str();
   }
 #ifdef ZboardM5STACK
-  M5.Power.begin();
+  // Power is initialised by M5.begin() in setupM5(); no explicit begin() needed.
   SYSdata["m5battlevel"] = (int8_t)M5.Power.getBatteryLevel();
-  SYSdata["m5ischarging"] = (bool)M5.Power.isCharging();
-  SYSdata["m5ischargefull"] = (bool)M5.Power.isChargeFull();
+  SYSdata["m5ischarging"] = (bool)(M5.Power.isCharging() == m5::Power_Class::is_charging);
+  SYSdata["m5ischargefull"] = (bool)(M5.Power.getBatteryLevel() >= 100);
 #endif
 #if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5TOUGH)
-  M5.Axp.EnableCoulombcounter();
-  SYSdata["m5batvoltage"] = (float)M5.Axp.GetBatVoltage();
-  SYSdata["m5batcurrent"] = (float)M5.Axp.GetBatCurrent();
-  SYSdata["m5vinvoltage"] = (float)M5.Axp.GetVinVoltage();
-  SYSdata["m5vincurrent"] = (float)M5.Axp.GetVinCurrent();
-  SYSdata["m5vbusvoltage"] = (float)M5.Axp.GetVBusVoltage();
-  SYSdata["m5vbuscurrent"] = (float)M5.Axp.GetVBusCurrent();
-  SYSdata["m5tempaxp"] = (float)M5.Axp.GetTempInAXP192();
-  SYSdata["m5batpower"] = (float)M5.Axp.GetBatPower();
-  SYSdata["m5batchargecurrent"] = (float)M5.Axp.GetBatChargeCurrent();
-  SYSdata["m5apsvoltage"] = (float)M5.Axp.GetAPSVoltage();
+  // M5Unified exposes a portable battery API across the AXP192/AXP2101 PMICs.
+  // getBatteryVoltage() is in mV; convert to volts to preserve the previous
+  // field semantics. The AXP192-only Vin/VBus/internal-temperature/power
+  // readings have no portable M5Unified equivalent, so those fields are dropped.
+  SYSdata["m5batvoltage"] = (float)M5.Power.getBatteryVoltage() / 1000.0f;
+  SYSdata["m5batcurrent"] = (float)M5.Power.getBatteryCurrent();
+  SYSdata["m5battlevel"] = (int8_t)M5.Power.getBatteryLevel();
+  SYSdata["m5ischarging"] = (bool)(M5.Power.isCharging() == m5::Power_Class::is_charging);
 #endif
   SYSdata["modules"] = modules;
 

--- a/main/mqttDiscovery.cpp
+++ b/main/mqttDiscovery.cpp
@@ -787,10 +787,12 @@ void pubMqttDiscovery() {
   const char* esp32Sensors[][13] = {
       {HASS_TYPE_SENSOR, "SYS: Internal temperature", "tempc", HASS_CLASS_TEMPERATURE, "{{ value_json.tempc  | round(1)}}", "", "", HASS_UNIT_CELSIUS, stateClassMeasurement, nullptr, nullptr, nullptr, nullptr},
 #    if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5TOUGH)
+      // Portable M5Unified battery telemetry. The AXP192-only Vin sensors were
+      // dropped in the M5Unified migration (no portable equivalent).
       {HASS_TYPE_SENSOR, "SYS: Bat voltage", "m5batvoltage", HASS_CLASS_VOLTAGE, "{{ value_json.m5batvoltage }}", "", "", HASS_UNIT_VOLT, stateClassNone, nullptr, nullptr, nullptr, nullptr},
       {HASS_TYPE_SENSOR, "SYS: Bat current", "m5batcurrent", HASS_CLASS_CURRENT, "{{ value_json.m5batcurrent }}", "", "", HASS_UNIT_AMP, stateClassNone, nullptr, nullptr, nullptr, nullptr},
-      {HASS_TYPE_SENSOR, "SYS: Vin voltage", "m5vinvoltage", HASS_CLASS_VOLTAGE, "{{ value_json.m5vinvoltage }}", "", "", HASS_UNIT_VOLT, stateClassNone, nullptr, nullptr, nullptr, nullptr},
-      {HASS_TYPE_SENSOR, "SYS: Vin current", "m5vincurrent", HASS_CLASS_CURRENT, "{{ value_json.m5vincurrent }}", "", "", HASS_UNIT_AMP, stateClassNone, nullptr, nullptr, nullptr, nullptr},
+      {HASS_TYPE_SENSOR, "SYS: Batt level", "m5battlevel", HASS_CLASS_BATTERY, "{{ value_json.m5battlevel }}", "", "", HASS_UNIT_PERCENT, stateClassNone, nullptr, nullptr, nullptr, nullptr},
+      {HASS_TYPE_BINARY_SENSOR, "SYS: Is Charging", "m5ischarging", "", "{{ value_json.m5ischarging }}", "", "", "", stateClassNone, nullptr, nullptr, nullptr, nullptr},
 #    endif
 #    ifdef ZboardM5STACK
       {HASS_TYPE_SENSOR, "SYS: Batt level", "m5battlevel", HASS_CLASS_BATTERY, "{{ value_json.m5battlevel }}", "", "", HASS_UNIT_PERCENT, stateClassNone, nullptr, nullptr, nullptr, nullptr},

--- a/platformio.ini
+++ b/platformio.ini
@@ -148,10 +148,10 @@ fastled = fastled/FastLED@3.9.15
 adafruit_neopixel = adafruit/Adafruit NeoPixel@^1.11.0
 onewire = https://github.com/h2zero/OneWire/archive/GPIO-fix.zip
 dallastemperature = DallasTemperature
-m5stickc = M5StickC@0.2.5
-m5stickcp = https://github.com/m5stack/M5StickC-Plus/archive/0.1.1.zip
-m5stack = M5Stack@0.4.6
-m5tough = https://github.com/m5stack/M5Tough/archive/ccf49e1.zip
+; M5Unified + M5GFX drive all M5 boards (Core / Stick C / Stick C Plus / Tough);
+; they build on the modern Arduino core and auto-detect the board at runtime,
+; replacing the per-board M5Stack/M5StickC/M5StickC-Plus/M5Tough libraries.
+m5unified = m5stack/M5Unified@^0.2.5
 smartrc-cc1101-driver-lib = https://github.com/LSatan/SmartRC-CC1101-Driver-Lib/archive/v3.0.2.zip
 stl = https://github.com/mike-matera/ArduinoSTL/archive/7411816.zip
 shtc3 = https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library/archive/671ef7e.zip


### PR DESCRIPTION
## Description:
The per-board libs (M5Stack/M5StickC/M5StickC-Plus/M5Tough) don't build on Arduino core 3.x, which kept the five M5 BLE envs pinned to espressif32@6.1.0. Port board support to M5Unified + M5GFX so they run ${com.esp32_platform} like the rest of the tree.

- environments.ini: 5 M5 envs -> modern platform + m5unified. m5stick-c uses the pico32 variant (m5stick_c variant absent upstream) and no_coredump partitions (M5Unified overflows min_spiffs).
- boardM5.cpp / config_M5.h: single <M5Unified.h>; M5.Lcd aliases M5.Display; unified brightness/sleep/wake.
- main.cpp / mqttDiscovery.cpp: battery telemetry via M5.Power; AXP192-only Vin/VBus/temp fields dropped (no portable equivalent).

All five M5 envs build; M5Stack Core hardware-verified.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
