### PR TITLE
[BLE] Fix esp32dev-ble-idf: bump esp-nimble-cpp 2.1.1 -> 2.5.0

### DIFF
--- a/environments.ini
+++ b/environments.ini
@@ -2157,7 +2157,7 @@ board_build.embed_txtfiles =
 lib_deps =
   ${com-esp32.lib_deps}
   ${libraries.decoder}
-  h2zero/esp-nimble-cpp@2.1.1
+  https://github.com/h2zero/esp-nimble-cpp/archive/2.5.0.zip
   h2zero/NimBLEOta@0.2.0
 build_flags =
   ${com-esp32.build_flags}


### PR DESCRIPTION
## Problem

Every build of `esp32dev-ble-idf` fails at dependency resolution, before any compilation:

```
Library Manager: Installing h2zero/esp-nimble-cpp @ 2.1.1
UnknownPackageError: Could not find the package with 'h2zero/esp-nimble-cpp @ 2.1.1' requirements
```

`esp-nimble-cpp` 2.1.1 no longer exists in either source:

- the PlatformIO registry has pruned it — it now serves only `2.3.2`, `2.3.4`, `2.4.0`, `2.5.0`;
- the upstream `2.1.1` git tag was deleted too (tags now start at `2.2.1`), so pinning that tag by URL would not help either.

This is unrelated to any particular PR — it breaks `development` and every open PR that builds this environment.

## Fix

Pin `2.5.0`, which is the same NimBLE version the Arduino ESP32 environments already use (`libraries.ble = NimBLE-Arduino/archive/2.5.0.zip`), so both frameworks stay on one NimBLE codebase.

The dependency is referenced by GitHub archive URL rather than by registry version, matching the style used for the other BLE dependency and making it immune to future registry pruning.

`NimBLEOta@0.2.0` is unaffected: still present in the registry, with no declared dependencies.

## Verification

Built locally — no source changes required. `blufi.cpp`, the only ESP-IDF-exclusive file and the one place the newer API had not previously been exercised, compiles without warnings:

```
|-- esp-nimble-cpp @ 2.5.0
|-- NimBLEOta @ 0.2.0
...
RAM:   19.5% (used 63968 bytes from 327680 bytes)
Flash: 86.6% (used 1703247 bytes from 1966080 bytes)
esp32dev-ble-idf  SUCCESS  00:04:58
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)