### PR TITLE
[RF] Deselect a secondary CC1101 chip-select on shared-SPI boards

### DIFF
--- a/main/commonRF.cpp
+++ b/main/commonRF.cpp
@@ -76,6 +76,15 @@ void initCC1101() {
   int delayMaxMS = 500;
   bool connected = false;
 
+#    ifdef RF_MODULE_SECONDARY_CS
+  // Boards carrying two radios on one SPI bus must hold the unused radio's
+  // chip-select high, or it answers on MISO and corrupts every transfer to the
+  // radio we do use.
+  pinMode(RF_MODULE_SECONDARY_CS, OUTPUT);
+  digitalWrite(RF_MODULE_SECONDARY_CS, HIGH);
+  THEENGS_LOG_NOTICE(F("Deselected secondary radio CS on GPIO%d" CR), RF_MODULE_SECONDARY_CS);
+#    endif
+
 #    if defined(RF_CC1101_SCK) && defined(RF_CC1101_MISO) && \
         defined(RF_CC1101_MOSI) && defined(RF_CC1101_CS)
   THEENGS_LOG_TRACE(F("initCC1101 with custom SPI pins, SCK=%d, MISO=%d, MOSI=%d, CS=%d" CR), RF_CC1101_SCK, RF_CC1101_MISO, RF_CC1101_MOSI, RF_CC1101_CS);


### PR DESCRIPTION
## Description:
Boards that carry two radios on one SPI bus need the unused radio's CS held high, or it answers on MISO and corrupts every transfer to the radio that is actually in use. Add an optional RF_MODULE_SECONDARY_CS: when defined, drive that pin high before probing the CC1101.

Bench-proven on a dual-CC1101 ESP32 board where one radio is faulty and the other is the working one: without the deselect the shared bus is unreliable; with it, the working module probes cleanly on the first attempt and decodes live 433 MHz sensors.

No effect on single-radio boards: the whole block compiles out unless RF_MODULE_SECONDARY_CS is set.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
