### PR TITLE
[SYS] Fix erase command leaving MQTT credentials in SPIFFS

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2890,7 +2890,13 @@ void eraseConfig() {
   receivingDATA(subjectMQTTtoSYSsetSecondaryModule, eraseCmdStr.c_str());
   delay(2000);
 #endif
-  THEENGS_LOG_TRACE(F("Formatting requested, result: %d" CR), SPIFFS.format());
+  // SPIFFS.format() has to be called outside of the log macro, THEENGS_LOG_TRACE
+  // expands to ((void)0) below LOG_LEVEL_TRACE and discards its arguments with it
+  bool formatted = SPIFFS.format();
+  THEENGS_LOG_TRACE(F("Formatting requested, result: %d" CR), formatted);
+  if (!formatted) {
+    THEENGS_LOG_ERROR(F("SPIFFS format failed, config may be retained" CR));
+  }
 
 #if defined(ESP8266)
   WiFi.disconnect(true);


### PR DESCRIPTION
## Description:
eraseConfig() passed SPIFFS.format() as an argument to THEENGS_LOG_TRACE, which expands to ((void)0) below LOG_LEVEL_TRACE and discards its arguments along with the call. On every build using the default LOG_LEVEL_NOTICE the format therefore never ran, so {"cmd":"erase"} only performed nvs_flash_erase(): the WiFi credentials were cleared but /config.json survived and restored the MQTT server, port, user, password, broker and client certificates, connection index, topic, gateway name, OTA password and BLE AES keys on the next boot.

Call SPIFFS.format() on its own statement and report a failed format at ERROR level, so the failure is visible at the default log level.

This was introduced in #2232, which converted the original runtime-checked Log.trace() call to the compile-time macro. It affects the SYS erase command, the WebUI erase button and the GPIO factory-reset hold alike, since all three go through eraseConfig().

Reproduced on a Theengs Plug built at the default log level: after {"cmd":"erase"} the NVS namespaces are gone ("SYS config not found", "ONOFF config not found") and the saved APs are empty, yet the same boot still logs "Config loaded from flash" and restores the OTA server cert.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
